### PR TITLE
perf(router): eliminate per-event allocs and lazy groupKey in dispatch

### DIFF
--- a/internal/router/retry.go
+++ b/internal/router/retry.go
@@ -169,6 +169,21 @@ func (rs *RetryScheduler) ForceRetryNow(c Consumer, groupKey string) {
 	queue[0].NextRetryAt = time.Now().Add(-time.Second)
 }
 
+// HasBlocked reports whether any consumer currently has at least one blocked
+// message group. Router.dispatch uses this as a cheap pre-check: when false,
+// the groupKey string conversion and per-consumer IsBlocked calls are skipped
+// entirely, eliminating an allocation on the hot path for the common case.
+func (rs *RetryScheduler) HasBlocked() bool {
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
+	for _, s := range rs.states {
+		if len(s.blockedGroups) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
 // IsBlocked reports whether the given (consumerID, groupKey) pair is currently
 // in the blocked state managed by this RetryScheduler. Router.dispatch calls
 // this to skip events whose message group is awaiting a retry attempt.

--- a/internal/router/retry_test.go
+++ b/internal/router/retry_test.go
@@ -108,6 +108,35 @@ func TestRetrySchedulerRetriesOnFailure(t *testing.T) {
 	}
 }
 
+// TestHasBlocked verifies the cheap pre-check method added to RetryScheduler:
+//   - Returns false on a fresh scheduler (no consumers registered).
+//   - Returns true once a blocked group is added.
+//   - Returns false again after the blocked group is cleared by a successful Tick.
+func TestHasBlocked(t *testing.T) {
+	rs := router.NewRetryScheduler()
+	if rs.HasBlocked() {
+		t.Fatal("expected HasBlocked=false on empty scheduler")
+	}
+
+	consumer := &countingConsumer{id: "hb-c1", failFor: 0}
+	entry := makeEntry(1, `{"id":1}`)
+	rs.AddBlocked(consumer, "key", &router.RetryRecord{
+		Entry:       entry,
+		Attempts:    1,
+		NextRetryAt: time.Now().Add(-time.Second),
+		ConsumerID:  "hb-c1",
+	})
+	if !rs.HasBlocked() {
+		t.Fatal("expected HasBlocked=true after AddBlocked")
+	}
+
+	// Tick with failFor=0 → consumer succeeds → group cleared.
+	rs.Tick(context.Background())
+	if rs.HasBlocked() {
+		t.Fatal("expected HasBlocked=false after successful Tick cleared the group")
+	}
+}
+
 // TestRetrySchedulerDeadLettersAfterMaxRetries verifies that after maxRetries
 // failed attempts, the entry is removed from blockedGroups (dead-lettered).
 func TestRetrySchedulerDeadLettersAfterMaxRetries(t *testing.T) {

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -107,6 +107,15 @@ type consumerState struct {
 	cursorByPartition map[uint32]uint64
 }
 
+// consumerSnap is a lightweight snapshot of a consumer's state captured at
+// the start of dispatch. It is reused across events via per-partition scratch
+// buffers to avoid per-event heap allocations.
+type consumerSnap struct {
+	consumer Consumer
+	blocked  bool
+	cursor   uint64 // this consumer's next-seq for the partition at snapshot time
+}
+
 // Router reads from the EventLog and delivers events to all registered
 // Consumers. One goroutine per partition is used; goroutines run for the
 // lifetime of the context passed to Run.
@@ -229,6 +238,10 @@ func (r *Router) Run(ctx context.Context) error {
 // it waits for a notify signal from the EventLog writer or a fallback timer
 // before retrying. The fallback timer (pollInterval) acts as a safety net for
 // missed signals; the notify path delivers sub-millisecond wakeup on write.
+//
+// Each goroutine owns its own snaps and deliveryErrs scratch slices that are
+// grown as needed and reset ([:0]) per event. This eliminates the two
+// per-event heap allocations that the previous dispatch signature caused.
 func (r *Router) runPartition(ctx context.Context, partitionID uint32) {
 	// Capture the notify channel once; nil if EventLog doesn't implement
 	// PartitionNotifier (fakes/tests fall back to pure timer polling).
@@ -249,6 +262,11 @@ func (r *Router) runPartition(ctx context.Context, partitionID uint32) {
 			return true
 		}
 	}
+
+	// Per-partition scratch buffers — owned exclusively by this goroutine.
+	// Grown on demand; reset to [:0] before each dispatch call.
+	var snaps []consumerSnap
+	var deliveryErrs []error
 
 	for {
 		select {
@@ -284,7 +302,7 @@ func (r *Router) runPartition(ctx context.Context, partitionID uint32) {
 				return
 			default:
 			}
-			r.dispatch(ctx, partitionID, entry)
+			r.dispatch(ctx, partitionID, entry, &snaps, &deliveryErrs)
 		}
 
 		// Fix E: flush once per batch for consumers that implement BatchFlusher.
@@ -339,28 +357,46 @@ func (r *Router) minCursorForPartition(partitionID uint32) uint64 {
 // partition goroutines from serialising through one synchronous network write.
 // The lock is held only for the consumer snapshot (RLock) and cursor updates
 // (Lock), both of which are fast in-memory operations.
-func (r *Router) dispatch(ctx context.Context, partitionID uint32, entry eventlog.LogEntry) {
-	groupKey := string(entry.Event.Key)
+//
+// snapsPtr and errsPtr are per-partition scratch buffers owned by the calling
+// runPartition goroutine. They are grown on demand and reset ([:0]) at the
+// start of each call, eliminating two per-event heap allocations on the hot path.
+func (r *Router) dispatch(ctx context.Context, partitionID uint32, entry eventlog.LogEntry, snapsPtr *[]consumerSnap, errsPtr *[]error) {
+	// Compute the groupKey lazily: only allocate the string if at least one
+	// consumer has a blocked message group. In the common steady-state (no
+	// failures) this avoids a string alloc and all per-consumer IsBlocked calls.
+	var groupKey string
+	hasBlocked := r.rs.HasBlocked()
+	if hasBlocked {
+		groupKey = string(entry.Event.Key)
+	}
 
 	// Phase 1: snapshot consumer list and blocked state under RLock.
 	// r.consumers only grows (no Unregister), so indices captured here
 	// remain valid for Phase 3's write lock.
 	r.mu.RLock()
-	type consumerSnap struct {
-		consumer Consumer
-		blocked  bool
-		cursor   uint64 // this consumer's next-seq for the partition at snapshot time
+	n := len(r.consumers)
+	// Grow scratch slices if needed; reuse existing capacity otherwise.
+	snaps := (*snapsPtr)[:0]
+	if cap(snaps) < n {
+		snaps = make([]consumerSnap, n)
+	} else {
+		snaps = snaps[:n]
 	}
-	snaps := make([]consumerSnap, len(r.consumers))
 	for i, cs := range r.consumers {
+		blocked := false
+		if hasBlocked {
+			// IsBlocked acquires its own mutex — safe to call under RLock.
+			blocked = r.rs.IsBlocked(cs.consumer.ID(), groupKey)
+		}
 		snaps[i] = consumerSnap{
 			consumer: cs.consumer,
-			// IsBlocked acquires its own mutex — safe to call under RLock.
-			blocked: r.rs.IsBlocked(cs.consumer.ID(), groupKey),
-			cursor:  cs.cursorByPartition[partitionID],
+			blocked:  blocked,
+			cursor:   cs.cursorByPartition[partitionID],
 		}
 	}
 	r.mu.RUnlock()
+	*snapsPtr = snaps
 
 	// Phase 2: deliver outside the lock. Concurrent partitions can deliver
 	// independently; SSE flush latency no longer serialises all goroutines.
@@ -370,7 +406,16 @@ func (r *Router) dispatch(ctx context.Context, partitionID uint32, entry eventlo
 	// a healthy consumer has already acked. Skip delivery to any consumer whose
 	// own cursor is already past entry.Seq — otherwise an unrelated slow consumer
 	// causes repeated duplicate delivery to every other consumer in the partition.
-	deliveryErrs := make([]error, len(snaps))
+	errs := (*errsPtr)[:0]
+	if cap(errs) < n {
+		errs = make([]error, n)
+	} else {
+		errs = errs[:n]
+		// Clear stale errors from previous event.
+		for i := range errs {
+			errs[i] = nil
+		}
+	}
 	for i, snap := range snaps {
 		if snap.blocked || ctx.Err() != nil {
 			continue
@@ -378,11 +423,23 @@ func (r *Router) dispatch(ctx context.Context, partitionID uint32, entry eventlo
 		if entry.Seq < snap.cursor {
 			continue // already delivered and acked by this consumer
 		}
-		deliveryErrs[i] = snap.consumer.Deliver(ctx, entry)
+		errs[i] = snap.consumer.Deliver(ctx, entry)
 	}
+	*errsPtr = errs
 
 	if ctx.Err() != nil {
 		return
+	}
+
+	// Materialise groupKey if it was skipped above but a delivery just failed —
+	// we need it for the slog warning and AddBlocked call in Phase 3.
+	if !hasBlocked {
+		for _, err := range errs {
+			if err != nil {
+				groupKey = string(entry.Event.Key)
+				break
+			}
+		}
 	}
 
 	// Phase 3: update in-memory cursors and persist them under write lock.
@@ -441,7 +498,7 @@ func (r *Router) dispatch(ctx context.Context, partitionID uint32, entry eventlo
 			continue
 		}
 
-		if err := deliveryErrs[i]; err != nil {
+		if err := errs[i]; err != nil {
 			slog.Warn("router: delivery failed, blocking message group",
 				"consumer", cs.consumer.ID(),
 				"key", groupKey,

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -451,88 +451,85 @@ func (r *Router) dispatch(ctx context.Context, partitionID uint32, entry eventlo
 			break // guard against consumers added between Phase 1 and Phase 3
 		}
 		cs := &r.consumers[i]
+		r.dispatchUpdateCursor(ctx, cs, snap, entry, partitionID, groupKey, errs, i)
+	}
+}
 
-		if snap.blocked {
-			if r.metrics != nil {
-				r.metrics.ConsumerLag.WithLabelValues(cs.consumer.ID()).Add(1)
-			}
-			// Guard: cursor has already advanced past this seq (e.g. a previous
-			// poll cycle already enqueued this entry). Skip to avoid double-queuing.
-			if entry.Seq < snap.cursor {
-				continue
-			}
-			// Enqueue the follow-on entry behind the blocked head so it is
-			// preserved in order and retried after the head succeeds (RTR-04).
-			// Without this, any event for a blocked key that arrives while the
-			// group is still blocked is silently discarded.
-			rec := &RetryRecord{
-				Entry:       entry,
-				Attempts:    0,
-				NextRetryAt: time.Now().Add(NextDelay(0)),
-				ConsumerID:  cs.consumer.ID(),
-			}
-			r.rs.AddBlocked(cs.consumer, groupKey, rec)
-			// Advance the cursor past the enqueued follow-on so the EventLog does
-			// not re-serve this seq on the next poll cycle. The retry queue now
-			// holds delivery responsibility; re-reading would cause double-queuing.
-			// Trade-off: a process restart drops in-flight follow-ons (same as the
-			// blocked head — both are in-memory only).
-			nextForFollowOn := entry.Seq + 1
-			if nextForFollowOn > cs.cursorByPartition[partitionID] {
-				cs.cursorByPartition[partitionID] = nextForFollowOn
-			}
-			if err := r.cursorStore.SaveCursor(ctx, cs.consumer.ID(), partitionID, nextForFollowOn); err != nil {
-				slog.Warn("router: failed to save cursor for blocked follow-on",
-					"consumer", cs.consumer.ID(),
-					"partition", partitionID,
-					"seq", entry.Seq,
-					"err", err,
-				)
-			}
-			continue
+// dispatchUpdateCursor handles Phase 3 per-consumer cursor logic.
+// Must be called under r.mu write lock.
+func (r *Router) dispatchUpdateCursor(
+	ctx context.Context,
+	cs *consumerState,
+	snap consumerSnap,
+	entry eventlog.LogEntry,
+	partitionID uint32,
+	groupKey string,
+	errs []error,
+	i int,
+) {
+	if snap.blocked {
+		if r.metrics != nil {
+			r.metrics.ConsumerLag.WithLabelValues(cs.consumer.ID()).Add(1)
 		}
-
-		// Skipped in Phase 2 because this consumer already acked entry.Seq.
-		// Do not touch the cursor — advancing toward entry.Seq+1 would regress it.
 		if entry.Seq < snap.cursor {
-			continue
+			return
 		}
-
-		if err := errs[i]; err != nil {
-			slog.Warn("router: delivery failed, blocking message group",
-				"consumer", cs.consumer.ID(),
-				"key", groupKey,
-				"seq", entry.Seq,
-				"err", err,
-			)
-			rec := &RetryRecord{
-				Entry:       entry,
-				Attempts:    1,
-				NextRetryAt: time.Now(),
-				ConsumerID:  cs.consumer.ID(),
-			}
-			r.rs.AddBlocked(cs.consumer, groupKey, rec)
-			continue
+		rec := &RetryRecord{
+			Entry:       entry,
+			Attempts:    0,
+			NextRetryAt: time.Now().Add(NextDelay(0)),
+			ConsumerID:  cs.consumer.ID(),
 		}
-
-		// Advance cursor to entry.Seq+1 (the next seq to read from).
-		// Cursor semantics: the value stored is the NEXT seq to read, so that
-		// minCursorForPartition can be passed directly to ReadPartition as fromSeq.
-		nextForPartition := entry.Seq + 1
-		if nextForPartition > cs.cursorByPartition[partitionID] {
-			cs.cursorByPartition[partitionID] = nextForPartition
+		r.rs.AddBlocked(cs.consumer, groupKey, rec)
+		nextForFollowOn := entry.Seq + 1
+		if nextForFollowOn > cs.cursorByPartition[partitionID] {
+			cs.cursorByPartition[partitionID] = nextForFollowOn
 		}
-		// Best-effort cursor persistence; failures are logged only.
-		if err := r.cursorStore.SaveCursor(ctx, cs.consumer.ID(), partitionID, nextForPartition); err != nil {
-			slog.Warn("router: failed to save cursor",
+		if err := r.cursorStore.SaveCursor(ctx, cs.consumer.ID(), partitionID, nextForFollowOn); err != nil {
+			slog.Warn("router: failed to save cursor for blocked follow-on",
 				"consumer", cs.consumer.ID(),
 				"partition", partitionID,
 				"seq", entry.Seq,
 				"err", err,
 			)
 		}
-		if r.metrics != nil {
-			r.metrics.ConsumerLag.WithLabelValues(cs.consumer.ID()).Set(0)
+		return
+	}
+
+	if entry.Seq < snap.cursor {
+		return
+	}
+
+	if err := errs[i]; err != nil {
+		slog.Warn("router: delivery failed, blocking message group",
+			"consumer", cs.consumer.ID(),
+			"key", groupKey,
+			"seq", entry.Seq,
+			"err", err,
+		)
+		rec := &RetryRecord{
+			Entry:       entry,
+			Attempts:    1,
+			NextRetryAt: time.Now(),
+			ConsumerID:  cs.consumer.ID(),
 		}
+		r.rs.AddBlocked(cs.consumer, groupKey, rec)
+		return
+	}
+
+	nextForPartition := entry.Seq + 1
+	if nextForPartition > cs.cursorByPartition[partitionID] {
+		cs.cursorByPartition[partitionID] = nextForPartition
+	}
+	if err := r.cursorStore.SaveCursor(ctx, cs.consumer.ID(), partitionID, nextForPartition); err != nil {
+		slog.Warn("router: failed to save cursor",
+			"consumer", cs.consumer.ID(),
+			"partition", partitionID,
+			"seq", entry.Seq,
+			"err", err,
+		)
+	}
+	if r.metrics != nil {
+		r.metrics.ConsumerLag.WithLabelValues(cs.consumer.ID()).Set(0)
 	}
 }

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -374,6 +374,50 @@ func TestWriterNeverBlocksOnFullNotifyChannel(t *testing.T) {
 	}
 }
 
+// TestHealthyConsumerNoDuplicatesUnderBlockedPeer exercises the lazy groupKey
+// optimisation: with consumer A permanently blocking on key "bad", consumer B
+// must still receive every other-key event exactly once across many poll cycles,
+// even though HasBlocked() will return true after A's first failure.
+// This validates that the lazy path correctly computes groupKey when needed and
+// that scratch-buffer reuse does not leak stale blocked/cursor values between events.
+func TestHealthyConsumerNoDuplicatesUnderBlockedPeer(t *testing.T) {
+	// Build 20 events: seq 1 is "bad" (A will fail), seqs 2-20 are "good".
+	var entries []eventlog.LogEntry
+	entries = append(entries, makeEntry(1, `"bad"`))
+	for i := uint64(2); i <= 20; i++ {
+		entries = append(entries, makeEntry(i, `"good"`))
+	}
+	el := newFakeEventLog(map[uint32][]eventlog.LogEntry{0: entries})
+
+	consumerA := &fakeConsumer{id: "blocked-peer", badKey: `"bad"`}
+	consumerB := &fakeConsumer{id: "healthy"}
+	r := router.NewRouter(el, 1, nil)
+	r.Register(consumerA)
+	r.Register(consumerB)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 400*time.Millisecond)
+	defer cancel()
+	if err := r.Run(ctx); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+
+	counts := map[uint64]int{}
+	for _, e := range consumerB.delivered() {
+		counts[e.Seq]++
+	}
+	for seq := uint64(2); seq <= 20; seq++ {
+		if counts[seq] != 1 {
+			t.Errorf("consumer B: seq=%d delivered %d times, want exactly 1", seq, counts[seq])
+		}
+	}
+	// seq=1 (bad key) should not be delivered to B (B has no bad key but A's
+	// cursor stall causes the partition to re-read seq=1 every cycle).
+	// B's own cursor gate prevents duplicate delivery of seq=1.
+	if counts[1] != 1 {
+		t.Errorf("consumer B: seq=1 delivered %d times, want exactly 1", counts[1])
+	}
+}
+
 func seqs(entries []eventlog.LogEntry) []uint64 {
 	out := make([]uint64, len(entries))
 	for i, e := range entries {


### PR DESCRIPTION
## Source fix plan

`.claude/fix-plans/router-dispatch-alloc-lock-20260531-161606.md`

## Problem

`Router.dispatch` (called once per event per partition, up to 64 goroutines × ~6k eps) had three performance costs on the hot path:

1. **Per-event heap allocations** — `snaps := make([]consumerSnap, ...)` and `deliveryErrs := make([]error, ...)` allocated two new slices for every event regardless of consumer count.
2. **Unconditional `string(entry.Event.Key)` alloc** — computed on every event even in steady-state when no message group is blocked.
3. **Per-consumer `IsBlocked` calls** — each holding `rs.mu` lock, called for every event even when `RetryScheduler` has nothing blocked.

## Implementation

- **Per-partition scratch buffers:** `runPartition` owns `snaps []consumerSnap` and `deliveryErrs []error` slices, passed by pointer into `dispatch`. Each call resets to `[:0]` and grows capacity only when needed. One goroutine owns each pair — no sharing or races.
- **`RetryScheduler.HasBlocked()`:** cheap `rs.mu`-guarded scan checking if any consumer has a non-empty blocked map. Returns false in steady-state (O(consumers), one lock). `dispatch` uses this as a gate: when false, skips both `string(entry.Event.Key)` and all `IsBlocked` calls entirely.
- **Lazy `groupKey` materialisation on error path:** if `HasBlocked()` was false but a delivery just failed, `groupKey` is computed exactly once before Phase 3's write lock for the `slog.Warn` / `AddBlocked` call.

RTR-04 per-key ordering invariant is fully preserved: scratch buffers are reset with `[:0]` at the start of each call, so no stale `blocked`/`cursor` values leak between events.

## Validation run

```
go test ./internal/router/... -race -count=1 -v
```

All 13 tests passed (including 2 new tests added by this PR):
- `TestHasBlocked` — verifies the new pre-check returns false/true/false as groups are added and cleared.
- `TestHealthyConsumerNoDuplicatesUnderBlockedPeer` — 20-event scenario where one consumer is permanently blocked; healthy consumer receives each seq exactly once with scratch-buffer reuse active.

## Residual risk / follow-up

- The write-lock reduction (batch cursor advancement replacing per-event `r.mu.Lock()` in Phase 3) described in the fix plan as the highest-impact change was intentionally deferred. It carries the highest RTR-04 risk and requires a separate, more invasive change to `cursorByPartition` and `minCursorForPartition`. Tracked in the original fix plan as a follow-up.
- `HasBlocked()` adds one extra `rs.mu` lock acquisition per event per partition on the common (unblocked) path. This is lighter than the per-consumer `IsBlocked` calls it replaces, but is still a shared lock. If the scheduler ever holds many consumer states, a bitmap or atomic counter approach could further reduce contention.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No blocking issues found.

Residual risk: `RetryScheduler.HasBlocked()` adds a full scan of all retry states on every dispatch, so its win depends on blocked groups staying rare; worth keeping an eye on under high consumer counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->