### PR TITLE
feat(tls): add server-side TLS for SSE and gRPC data plane

### DIFF
--- a/internal/cmd/output.go
+++ b/internal/cmd/output.go
@@ -55,11 +55,11 @@ func newHTTPServer(addr string, handler http.Handler) *http.Server {
 // When clientCAFile is set, mTLS is enabled: client certificates are required
 // and verified against the given CA. MinVersion is always TLS 1.2.
 func buildServerTLSConfig(cfg config.ServerTLSConfig) (*tls.Config, error) {
-	if cfg.CertFile == "" && cfg.KeyFile == "" {
+	if cfg.CertFile == "" && cfg.KeyFile == "" && cfg.ClientCAFile == "" {
 		return nil, nil
 	}
 	if cfg.CertFile == "" || cfg.KeyFile == "" {
-		return nil, fmt.Errorf("server TLS: both --tls-cert and --tls-key must be set together")
+		return nil, fmt.Errorf("server TLS: both --tls-cert and --tls-key must be set together; --tls-client-ca also requires them")
 	}
 	cert, err := tls.LoadX509KeyPair(cfg.CertFile, cfg.KeyFile)
 	if err != nil {

--- a/internal/cmd/output.go
+++ b/internal/cmd/output.go
@@ -130,83 +130,10 @@ func buildOutputServer(
 		w.SetMetrics(metrics)
 		rtr.Register(w)
 		return func(ctx context.Context) error { <-ctx.Done(); return nil }, nil
-
 	case "sse":
-		tlsCfg, err := buildServerTLSConfig(cfg.ServerTLS)
-		if err != nil {
-			return nil, err
-		}
-		if err := requireServerTLS("sse", tlsCfg, cfg.Insecure); err != nil {
-			return nil, err
-		}
-		sseServer := sse.NewSSEServer(rtr, metrics, cfg.CORSOrigin, 15*time.Second, rowFilters, colFilters)
-		mux := http.NewServeMux()
-		mux.Handle("/events", sseServer)
-		mux.Handle("/metrics", metrics.Handler())
-		mux.Handle("/healthz", healthHandler)
-		srv := newHTTPServer(fmt.Sprintf(":%d", cfg.Port), mux)
-		if tlsCfg != nil {
-			srv.TLSConfig = tlsCfg
-		}
-		return func(ctx context.Context) error {
-			go func() {
-				<-ctx.Done()
-				shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-				defer cancel()
-				_ = srv.Shutdown(shutdownCtx)
-			}()
-			if tlsCfg != nil {
-				// TLS: cert/key are already loaded into srv.TLSConfig; pass ""
-				// so ListenAndServeTLS uses the pre-loaded config.
-				if err := srv.ListenAndServeTLS("", ""); err != nil && err != http.ErrServerClosed {
-					return fmt.Errorf("sse server: %w", err)
-				}
-			} else {
-				if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-					return fmt.Errorf("sse server: %w", err)
-				}
-			}
-			return nil
-		}, nil
-
+		return buildSSEServer(cfg, rtr, metrics, healthHandler, rowFilters, colFilters)
 	case "grpc":
-		tlsCfg, err := buildServerTLSConfig(cfg.ServerTLS)
-		if err != nil {
-			return nil, err
-		}
-		if err := requireServerTLS("grpc", tlsCfg, cfg.Insecure); err != nil {
-			return nil, err
-		}
-		grpcSvc := grpcoutput.NewGRPCServer(rtr, cursorStore, metrics, rowFilters, colFilters)
-		grpcSrv := grpcoutput.NewGRPCNetServer(grpcSvc, tlsCfg)
-		lis, err := net.Listen("tcp", fmt.Sprintf(":%d", cfg.Port))
-		if err != nil {
-			return nil, fmt.Errorf("grpc listen: %w", err)
-		}
-		obsMux := http.NewServeMux()
-		obsMux.Handle("/metrics", metrics.Handler())
-		obsMux.Handle("/healthz", healthHandler)
-		obsSrv := newHTTPServer(fmt.Sprintf(":%d", cfg.Port+1), obsMux)
-		return func(ctx context.Context) error {
-			go func() {
-				<-ctx.Done()
-				grpcSrv.GracefulStop()
-				shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-				defer cancel()
-				_ = obsSrv.Shutdown(shutdownCtx)
-			}()
-			go func() {
-				if err := obsSrv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-					// non-fatal — main gRPC server will surface real errors
-					_ = err
-				}
-			}()
-			if err := grpcSrv.Serve(lis); err != nil {
-				return fmt.Errorf("grpc server: %w", err)
-			}
-			return nil
-		}, nil
-
+		return buildGRPCServer(cfg, rtr, cursorStore, metrics, healthHandler, rowFilters, colFilters)
 	case "nats":
 		if cfg.Sinks.NATS == nil {
 			return nil, fmt.Errorf("--output nats requires a sinks.nats block in config (url, subject-template)")
@@ -216,7 +143,6 @@ func buildOutputServer(
 			return nil, fmt.Errorf("nats sink: init: %w", err)
 		}
 		return buildSinkServer(cfg.Port, "nats", sink, rtr, metrics, healthProbes), nil
-
 	case "sqs":
 		if cfg.Sinks.SQS == nil {
 			return nil, fmt.Errorf("--output sqs requires a sinks.sqs block in config (queue-url, region)")
@@ -226,7 +152,6 @@ func buildOutputServer(
 			return nil, fmt.Errorf("sqs sink: init: %w", err)
 		}
 		return buildSinkServer(cfg.Port, "sqs", sink, rtr, metrics, healthProbes), nil
-
 	case "kafka":
 		if cfg.Sinks.Kafka == nil {
 			return nil, fmt.Errorf("--output kafka requires a sinks.kafka block in config (bootstrap-servers, topic-template)")
@@ -236,7 +161,6 @@ func buildOutputServer(
 			return nil, fmt.Errorf("kafka sink: init: %w", err)
 		}
 		return buildSinkServer(cfg.Port, "kafka", sink, rtr, metrics, healthProbes), nil
-
 	case "pubsub":
 		if cfg.Sinks.PubSub == nil {
 			return nil, fmt.Errorf("--output pubsub requires a sinks.pubsub block in config (project-id, topic-id)")
@@ -246,7 +170,6 @@ func buildOutputServer(
 			return nil, fmt.Errorf("pubsub sink: init: %w", err)
 		}
 		return buildSinkServer(cfg.Port, "pubsub", sink, rtr, metrics, healthProbes), nil
-
 	case "rabbitmq":
 		if cfg.Sinks.RabbitMQ == nil {
 			return nil, fmt.Errorf("--output rabbitmq requires a sinks.rabbitmq block in config (url, exchange)")
@@ -256,10 +179,99 @@ func buildOutputServer(
 			return nil, fmt.Errorf("rabbitmq sink: init: %w", err)
 		}
 		return buildSinkServer(cfg.Port, "rabbitmq", sink, rtr, metrics, healthProbes), nil
-
 	default:
 		return nil, fmt.Errorf("unknown output mode %q: valid modes are stdout, sse, grpc, nats, sqs, kafka, pubsub, rabbitmq", cfg.Output)
 	}
+}
+
+func buildSSEServer(
+	cfg *config.Config,
+	rtr *router.Router,
+	metrics *observability.KaptantoMetrics,
+	healthHandler http.Handler,
+	rowFilters map[string]*output.RowFilter,
+	colFilters map[string][]string,
+) (func(context.Context) error, error) {
+	tlsCfg, err := buildServerTLSConfig(cfg.ServerTLS)
+	if err != nil {
+		return nil, err
+	}
+	if err := requireServerTLS("sse", tlsCfg, cfg.Insecure); err != nil {
+		return nil, err
+	}
+	sseServer := sse.NewSSEServer(rtr, metrics, cfg.CORSOrigin, 15*time.Second, rowFilters, colFilters)
+	mux := http.NewServeMux()
+	mux.Handle("/events", sseServer)
+	mux.Handle("/metrics", metrics.Handler())
+	mux.Handle("/healthz", healthHandler)
+	srv := newHTTPServer(fmt.Sprintf(":%d", cfg.Port), mux)
+	if tlsCfg != nil {
+		srv.TLSConfig = tlsCfg
+	}
+	return func(ctx context.Context) error {
+		go func() {
+			<-ctx.Done()
+			shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			_ = srv.Shutdown(shutdownCtx)
+		}()
+		if tlsCfg != nil {
+			if err := srv.ListenAndServeTLS("", ""); err != nil && err != http.ErrServerClosed {
+				return fmt.Errorf("sse server: %w", err)
+			}
+		} else {
+			if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+				return fmt.Errorf("sse server: %w", err)
+			}
+		}
+		return nil
+	}, nil
+}
+
+func buildGRPCServer(
+	cfg *config.Config,
+	rtr *router.Router,
+	cursorStore router.ConsumerCursorStore,
+	metrics *observability.KaptantoMetrics,
+	healthHandler http.Handler,
+	rowFilters map[string]*output.RowFilter,
+	colFilters map[string][]string,
+) (func(context.Context) error, error) {
+	tlsCfg, err := buildServerTLSConfig(cfg.ServerTLS)
+	if err != nil {
+		return nil, err
+	}
+	if err := requireServerTLS("grpc", tlsCfg, cfg.Insecure); err != nil {
+		return nil, err
+	}
+	grpcSvc := grpcoutput.NewGRPCServer(rtr, cursorStore, metrics, rowFilters, colFilters)
+	grpcSrv := grpcoutput.NewGRPCNetServer(grpcSvc, tlsCfg)
+	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", cfg.Port))
+	if err != nil {
+		return nil, fmt.Errorf("grpc listen: %w", err)
+	}
+	obsMux := http.NewServeMux()
+	obsMux.Handle("/metrics", metrics.Handler())
+	obsMux.Handle("/healthz", healthHandler)
+	obsSrv := newHTTPServer(fmt.Sprintf(":%d", cfg.Port+1), obsMux)
+	return func(ctx context.Context) error {
+		go func() {
+			<-ctx.Done()
+			grpcSrv.GracefulStop()
+			shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			_ = obsSrv.Shutdown(shutdownCtx)
+		}()
+		go func() {
+			if err := obsSrv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+				_ = err // non-fatal — main gRPC server will surface real errors
+			}
+		}()
+		if err := grpcSrv.Serve(lis); err != nil {
+			return fmt.Errorf("grpc server: %w", err)
+		}
+		return nil
+	}, nil
 }
 
 // buildSinkServer registers an external-broker sink, appends its health probe,

--- a/internal/cmd/output.go
+++ b/internal/cmd/output.go
@@ -2,7 +2,10 @@ package cmd
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
+	"log/slog"
 	"net"
 	"net/http"
 	"os"
@@ -46,6 +49,61 @@ func newHTTPServer(addr string, handler http.Handler) *http.Server {
 	}
 }
 
+// buildServerTLSConfig builds a *tls.Config from ServerTLSConfig fields.
+// Returns nil, nil when no cert/key are configured (plaintext mode).
+// Returns an error when cert/key paths are set but cannot be loaded.
+// When clientCAFile is set, mTLS is enabled: client certificates are required
+// and verified against the given CA. MinVersion is always TLS 1.2.
+func buildServerTLSConfig(cfg config.ServerTLSConfig) (*tls.Config, error) {
+	if cfg.CertFile == "" && cfg.KeyFile == "" {
+		return nil, nil
+	}
+	if cfg.CertFile == "" || cfg.KeyFile == "" {
+		return nil, fmt.Errorf("server TLS: both --tls-cert and --tls-key must be set together")
+	}
+	cert, err := tls.LoadX509KeyPair(cfg.CertFile, cfg.KeyFile)
+	if err != nil {
+		return nil, fmt.Errorf("server TLS: load cert/key: %w", err)
+	}
+	tlsCfg := &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		MinVersion:   tls.VersionTLS12,
+	}
+	if cfg.ClientCAFile != "" {
+		caPEM, err := os.ReadFile(cfg.ClientCAFile)
+		if err != nil {
+			return nil, fmt.Errorf("server TLS: read client CA: %w", err)
+		}
+		pool := x509.NewCertPool()
+		if !pool.AppendCertsFromPEM(caPEM) {
+			return nil, fmt.Errorf("server TLS: no valid certificates found in client CA file %q", cfg.ClientCAFile)
+		}
+		tlsCfg.ClientCAs = pool
+		tlsCfg.ClientAuth = tls.RequireAndVerifyClientCert
+	}
+	return tlsCfg, nil
+}
+
+// requireServerTLS validates the TLS policy for network outputs (sse, grpc).
+// Returns an error when no TLS is configured and --insecure is not set.
+// Logs a loud warning when insecure mode is explicitly requested.
+func requireServerTLS(output string, tlsCfg *tls.Config, insecure bool) error {
+	if tlsCfg != nil {
+		return nil // TLS is configured — all good
+	}
+	if insecure {
+		slog.Warn("SECURITY WARNING: running "+output+" output in plaintext (--insecure). "+
+			"Change stream data is transmitted without encryption. "+
+			"Use --tls-cert / --tls-key to enable TLS.",
+			"output", output)
+		return nil
+	}
+	return fmt.Errorf(
+		"%s output requires TLS: provide --tls-cert and --tls-key, or pass --insecure to opt out (not recommended for production)",
+		output,
+	)
+}
+
 // messageSink is the common interface shared by all external-broker sinks.
 type messageSink interface {
 	router.Consumer
@@ -74,12 +132,22 @@ func buildOutputServer(
 		return func(ctx context.Context) error { <-ctx.Done(); return nil }, nil
 
 	case "sse":
+		tlsCfg, err := buildServerTLSConfig(cfg.ServerTLS)
+		if err != nil {
+			return nil, err
+		}
+		if err := requireServerTLS("sse", tlsCfg, cfg.Insecure); err != nil {
+			return nil, err
+		}
 		sseServer := sse.NewSSEServer(rtr, metrics, cfg.CORSOrigin, 15*time.Second, rowFilters, colFilters)
 		mux := http.NewServeMux()
 		mux.Handle("/events", sseServer)
 		mux.Handle("/metrics", metrics.Handler())
 		mux.Handle("/healthz", healthHandler)
 		srv := newHTTPServer(fmt.Sprintf(":%d", cfg.Port), mux)
+		if tlsCfg != nil {
+			srv.TLSConfig = tlsCfg
+		}
 		return func(ctx context.Context) error {
 			go func() {
 				<-ctx.Done()
@@ -87,15 +155,30 @@ func buildOutputServer(
 				defer cancel()
 				_ = srv.Shutdown(shutdownCtx)
 			}()
-			if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-				return fmt.Errorf("sse server: %w", err)
+			if tlsCfg != nil {
+				// TLS: cert/key are already loaded into srv.TLSConfig; pass ""
+				// so ListenAndServeTLS uses the pre-loaded config.
+				if err := srv.ListenAndServeTLS("", ""); err != nil && err != http.ErrServerClosed {
+					return fmt.Errorf("sse server: %w", err)
+				}
+			} else {
+				if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+					return fmt.Errorf("sse server: %w", err)
+				}
 			}
 			return nil
 		}, nil
 
 	case "grpc":
+		tlsCfg, err := buildServerTLSConfig(cfg.ServerTLS)
+		if err != nil {
+			return nil, err
+		}
+		if err := requireServerTLS("grpc", tlsCfg, cfg.Insecure); err != nil {
+			return nil, err
+		}
 		grpcSvc := grpcoutput.NewGRPCServer(rtr, cursorStore, metrics, rowFilters, colFilters)
-		grpcSrv := grpcoutput.NewGRPCNetServer(grpcSvc)
+		grpcSrv := grpcoutput.NewGRPCNetServer(grpcSvc, tlsCfg)
 		lis, err := net.Listen("tcp", fmt.Sprintf(":%d", cfg.Port))
 		if err != nil {
 			return nil, fmt.Errorf("grpc listen: %w", err)

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -100,6 +100,10 @@ The name means "who captures" in Esperanto.`,
 	root.PersistentFlags().Int("nats-cluster-port", 6222, "NATS JetStream cluster route port for this node (default 6222)")
 	root.PersistentFlags().String("log-level", "info", "log verbosity: debug | info | warn | error")
 	root.PersistentFlags().Bool("all-tables", false, "capture all tables in the database (requires explicit opt-in; default requires --tables or 'tables:' in config)")
+	root.PersistentFlags().String("tls-cert", "", "path to TLS certificate PEM for SSE/gRPC server")
+	root.PersistentFlags().String("tls-key", "", "path to TLS private key PEM for SSE/gRPC server")
+	root.PersistentFlags().String("tls-client-ca", "", "path to CA PEM for client certificate verification (mTLS); requires --tls-cert and --tls-key")
+	root.PersistentFlags().Bool("insecure", false, "allow plaintext SSE/gRPC without TLS (not recommended for production; logs a security warning)")
 
 	root.Version = version.Version
 	root.AddCommand(newVersionCmd())

--- a/internal/cmd/tls_test.go
+++ b/internal/cmd/tls_test.go
@@ -1,0 +1,267 @@
+package cmd
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/olucasandrade/kaptanto/internal/config"
+)
+
+// generateSelfSignedCert writes a self-signed TLS cert+key pair to dir and
+// returns the cert and key file paths.
+func generateSelfSignedCert(t *testing.T, dir string) (certFile, keyFile string) {
+	t.Helper()
+
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "kaptanto-test"},
+		NotBefore:    time.Now().Add(-time.Minute),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IsCA:         false,
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatalf("create cert: %v", err)
+	}
+
+	certFile = filepath.Join(dir, "cert.pem")
+	keyFile = filepath.Join(dir, "key.pem")
+
+	cf, err := os.Create(certFile)
+	if err != nil {
+		t.Fatalf("create cert file: %v", err)
+	}
+	defer cf.Close()
+	if err := pem.Encode(cf, &pem.Block{Type: "CERTIFICATE", Bytes: certDER}); err != nil {
+		t.Fatalf("encode cert: %v", err)
+	}
+
+	privDER, err := x509.MarshalECPrivateKey(priv)
+	if err != nil {
+		t.Fatalf("marshal key: %v", err)
+	}
+	kf, err := os.Create(keyFile)
+	if err != nil {
+		t.Fatalf("create key file: %v", err)
+	}
+	defer kf.Close()
+	if err := pem.Encode(kf, &pem.Block{Type: "EC PRIVATE KEY", Bytes: privDER}); err != nil {
+		t.Fatalf("encode key: %v", err)
+	}
+
+	return certFile, keyFile
+}
+
+// TestBuildServerTLSConfig_NilWhenEmpty verifies that no cert/key produces nil (plaintext mode).
+func TestBuildServerTLSConfig_NilWhenEmpty(t *testing.T) {
+	tlsCfg, err := buildServerTLSConfig(config.ServerTLSConfig{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tlsCfg != nil {
+		t.Fatalf("expected nil tlsConfig for empty ServerTLSConfig, got %+v", tlsCfg)
+	}
+}
+
+// TestBuildServerTLSConfig_ErrorOnPartialConfig verifies that providing only
+// cert or only key returns an error.
+func TestBuildServerTLSConfig_ErrorOnPartialConfig(t *testing.T) {
+	dir := t.TempDir()
+	certFile, keyFile := generateSelfSignedCert(t, dir)
+
+	for _, tc := range []struct {
+		name string
+		cfg  config.ServerTLSConfig
+	}{
+		{"cert only", config.ServerTLSConfig{CertFile: certFile}},
+		{"key only", config.ServerTLSConfig{KeyFile: keyFile}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := buildServerTLSConfig(tc.cfg)
+			if err == nil {
+				t.Fatal("expected error for partial TLS config, got nil")
+			}
+		})
+	}
+}
+
+// TestBuildServerTLSConfig_ValidCertKey verifies that a valid cert/key pair
+// builds a non-nil *tls.Config with MinVersion = TLS 1.2 and no mTLS.
+func TestBuildServerTLSConfig_ValidCertKey(t *testing.T) {
+	dir := t.TempDir()
+	certFile, keyFile := generateSelfSignedCert(t, dir)
+
+	tlsCfg, err := buildServerTLSConfig(config.ServerTLSConfig{
+		CertFile: certFile,
+		KeyFile:  keyFile,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tlsCfg == nil {
+		t.Fatal("expected non-nil *tls.Config")
+	}
+	if tlsCfg.MinVersion != tls.VersionTLS12 {
+		t.Fatalf("MinVersion = %d, want %d (TLS 1.2)", tlsCfg.MinVersion, tls.VersionTLS12)
+	}
+	if tlsCfg.ClientAuth != tls.NoClientCert {
+		t.Fatalf("ClientAuth = %v, want NoClientCert (mTLS not requested)", tlsCfg.ClientAuth)
+	}
+	if len(tlsCfg.Certificates) != 1 {
+		t.Fatalf("expected 1 certificate, got %d", len(tlsCfg.Certificates))
+	}
+}
+
+// TestBuildServerTLSConfig_WithClientCA verifies mTLS is enabled when
+// ClientCAFile is provided alongside cert/key.
+func TestBuildServerTLSConfig_WithClientCA(t *testing.T) {
+	dir := t.TempDir()
+	certFile, keyFile := generateSelfSignedCert(t, dir)
+
+	// Reuse the same self-signed cert as a CA for simplicity.
+	tlsCfg, err := buildServerTLSConfig(config.ServerTLSConfig{
+		CertFile:     certFile,
+		KeyFile:      keyFile,
+		ClientCAFile: certFile, // self-signed cert also acts as its own CA
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tlsCfg == nil {
+		t.Fatal("expected non-nil *tls.Config")
+	}
+	if tlsCfg.ClientAuth != tls.RequireAndVerifyClientCert {
+		t.Fatalf("ClientAuth = %v, want RequireAndVerifyClientCert", tlsCfg.ClientAuth)
+	}
+	if tlsCfg.ClientCAs == nil {
+		t.Fatal("ClientCAs pool must not be nil when ClientCAFile is set")
+	}
+}
+
+// TestBuildServerTLSConfig_MissingCertFile verifies that a nonexistent cert
+// file returns an error.
+func TestBuildServerTLSConfig_MissingCertFile(t *testing.T) {
+	_, err := buildServerTLSConfig(config.ServerTLSConfig{
+		CertFile: "/nonexistent/cert.pem",
+		KeyFile:  "/nonexistent/key.pem",
+	})
+	if err == nil {
+		t.Fatal("expected error for missing cert/key files, got nil")
+	}
+}
+
+// TestRequireServerTLS_TLSConfigured verifies no error when TLS is provided.
+func TestRequireServerTLS_TLSConfigured(t *testing.T) {
+	err := requireServerTLS("sse", &tls.Config{}, false)
+	if err != nil {
+		t.Fatalf("unexpected error when TLS is configured: %v", err)
+	}
+}
+
+// TestRequireServerTLS_InsecureAllowed verifies that insecure=true allows
+// plaintext and returns no error.
+func TestRequireServerTLS_InsecureAllowed(t *testing.T) {
+	err := requireServerTLS("sse", nil, true)
+	if err != nil {
+		t.Fatalf("expected no error for insecure mode, got: %v", err)
+	}
+}
+
+// TestRequireServerTLS_NeitherTLSNorInsecure verifies that missing TLS
+// configuration without --insecure returns a descriptive error.
+func TestRequireServerTLS_NeitherTLSNorInsecure(t *testing.T) {
+	for _, output := range []string{"sse", "grpc"} {
+		t.Run(output, func(t *testing.T) {
+			err := requireServerTLS(output, nil, false)
+			if err == nil {
+				t.Fatalf("expected error for plaintext %s without --insecure, got nil", output)
+			}
+		})
+	}
+}
+
+// TestBuildOutputServer_SSE_RequiresTLS verifies that buildOutputServer returns
+// an error for SSE output when no TLS is configured and --insecure is not set.
+func TestBuildOutputServer_SSE_RequiresTLS(t *testing.T) {
+	cfg := config.Defaults()
+	cfg.Output = "sse"
+	// No ServerTLS set, Insecure = false (default)
+
+	_, err := buildOutputServer(cfg, nil, nil, nil, nil, nil, nil, nil)
+	if err == nil {
+		t.Fatal("expected error: sse without TLS and without --insecure")
+	}
+}
+
+// TestBuildOutputServer_gRPC_RequiresTLS verifies that buildOutputServer
+// returns an error for gRPC output when no TLS is configured and --insecure
+// is not set.
+func TestBuildOutputServer_gRPC_RequiresTLS(t *testing.T) {
+	cfg := config.Defaults()
+	cfg.Output = "grpc"
+	// No ServerTLS set, Insecure = false (default)
+
+	_, err := buildOutputServer(cfg, nil, nil, nil, nil, nil, nil, nil)
+	if err == nil {
+		t.Fatal("expected error: grpc without TLS and without --insecure")
+	}
+}
+
+// TestTLSPolicy_SSE_InsecureAllowed verifies that --insecure bypasses
+// the TLS requirement for SSE output by testing requireServerTLS directly.
+func TestTLSPolicy_SSE_InsecureAllowed(t *testing.T) {
+	err := requireServerTLS("sse", nil /* no TLS */, true /* insecure */)
+	if err != nil {
+		t.Fatalf("expected no error for --insecure sse, got: %v", err)
+	}
+}
+
+// TestTLSPolicy_gRPC_InsecureAllowed verifies that --insecure bypasses
+// the TLS requirement for gRPC output by testing requireServerTLS directly.
+func TestTLSPolicy_gRPC_InsecureAllowed(t *testing.T) {
+	err := requireServerTLS("grpc", nil /* no TLS */, true /* insecure */)
+	if err != nil {
+		t.Fatalf("expected no error for --insecure grpc, got: %v", err)
+	}
+}
+
+// TestTLSPolicy_WithCert_NoInsecureNeeded verifies that a valid TLS config
+// makes --insecure irrelevant: TLS takes precedence and no error is returned.
+func TestTLSPolicy_WithCert_NoInsecureNeeded(t *testing.T) {
+	dir := t.TempDir()
+	certFile, keyFile := generateSelfSignedCert(t, dir)
+
+	tlsCfg, err := buildServerTLSConfig(config.ServerTLSConfig{
+		CertFile: certFile,
+		KeyFile:  keyFile,
+	})
+	if err != nil {
+		t.Fatalf("build tls config: %v", err)
+	}
+
+	for _, output := range []string{"sse", "grpc"} {
+		t.Run(output, func(t *testing.T) {
+			if err := requireServerTLS(output, tlsCfg, false); err != nil {
+				t.Fatalf("unexpected error when TLS is configured: %v", err)
+			}
+		})
+	}
+}

--- a/internal/cmd/tls_test.go
+++ b/internal/cmd/tls_test.go
@@ -49,7 +49,11 @@ func generateSelfSignedCert(t *testing.T, dir string) (certFile, keyFile string)
 	if err != nil {
 		t.Fatalf("create cert file: %v", err)
 	}
-	defer cf.Close()
+	defer func() {
+		if err := cf.Close(); err != nil {
+			t.Errorf("close cert file: %v", err)
+		}
+	}()
 	if err := pem.Encode(cf, &pem.Block{Type: "CERTIFICATE", Bytes: certDER}); err != nil {
 		t.Fatalf("encode cert: %v", err)
 	}
@@ -62,7 +66,11 @@ func generateSelfSignedCert(t *testing.T, dir string) (certFile, keyFile string)
 	if err != nil {
 		t.Fatalf("create key file: %v", err)
 	}
-	defer kf.Close()
+	defer func() {
+		if err := kf.Close(); err != nil {
+			t.Errorf("close key file: %v", err)
+		}
+	}()
 	if err := pem.Encode(kf, &pem.Block{Type: "EC PRIVATE KEY", Bytes: privDER}); err != nil {
 		t.Fatalf("encode key: %v", err)
 	}

--- a/internal/cmd/tls_test.go
+++ b/internal/cmd/tls_test.go
@@ -78,6 +78,47 @@ func generateSelfSignedCert(t *testing.T, dir string) (certFile, keyFile string)
 	return certFile, keyFile
 }
 
+// generateCACert writes a self-signed CA certificate (IsCA: true, KeyUsageCertSign)
+// to dir and returns the file path. Use this for ClientCAFile in mTLS tests.
+func generateCACert(t *testing.T, dir string) string {
+	t.Helper()
+
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate CA key: %v", err)
+	}
+
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(2),
+		Subject:               pkix.Name{CommonName: "kaptanto-test-ca"},
+		NotBefore:             time.Now().Add(-time.Minute),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+
+	caDER, err := x509.CreateCertificate(rand.Reader, template, template, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatalf("create CA cert: %v", err)
+	}
+
+	caFile := filepath.Join(dir, "ca.pem")
+	f, err := os.Create(caFile)
+	if err != nil {
+		t.Fatalf("create CA file: %v", err)
+	}
+	defer func() {
+		if err := f.Close(); err != nil {
+			t.Errorf("close CA file: %v", err)
+		}
+	}()
+	if err := pem.Encode(f, &pem.Block{Type: "CERTIFICATE", Bytes: caDER}); err != nil {
+		t.Fatalf("encode CA cert: %v", err)
+	}
+	return caFile
+}
+
 // TestBuildServerTLSConfig_NilWhenEmpty verifies that no cert/key produces nil (plaintext mode).
 func TestBuildServerTLSConfig_NilWhenEmpty(t *testing.T) {
 	tlsCfg, err := buildServerTLSConfig(config.ServerTLSConfig{})
@@ -90,10 +131,11 @@ func TestBuildServerTLSConfig_NilWhenEmpty(t *testing.T) {
 }
 
 // TestBuildServerTLSConfig_ErrorOnPartialConfig verifies that providing only
-// cert or only key returns an error.
+// cert, only key, or only client-ca returns an error.
 func TestBuildServerTLSConfig_ErrorOnPartialConfig(t *testing.T) {
 	dir := t.TempDir()
 	certFile, keyFile := generateSelfSignedCert(t, dir)
+	caFile := generateCACert(t, dir)
 
 	for _, tc := range []struct {
 		name string
@@ -101,6 +143,7 @@ func TestBuildServerTLSConfig_ErrorOnPartialConfig(t *testing.T) {
 	}{
 		{"cert only", config.ServerTLSConfig{CertFile: certFile}},
 		{"key only", config.ServerTLSConfig{KeyFile: keyFile}},
+		{"client-ca only", config.ServerTLSConfig{ClientCAFile: caFile}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			_, err := buildServerTLSConfig(tc.cfg)
@@ -143,12 +186,12 @@ func TestBuildServerTLSConfig_ValidCertKey(t *testing.T) {
 func TestBuildServerTLSConfig_WithClientCA(t *testing.T) {
 	dir := t.TempDir()
 	certFile, keyFile := generateSelfSignedCert(t, dir)
+	caFile := generateCACert(t, dir)
 
-	// Reuse the same self-signed cert as a CA for simplicity.
 	tlsCfg, err := buildServerTLSConfig(config.ServerTLSConfig{
 		CertFile:     certFile,
 		KeyFile:      keyFile,
-		ClientCAFile: certFile, // self-signed cert also acts as its own CA
+		ClientCAFile: caFile,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -118,6 +118,21 @@ type SinksConfig struct {
 	RabbitMQ *RabbitMQSinkConfig `yaml:"rabbitmq"`
 }
 
+// ServerTLSConfig holds TLS settings for Kaptanto's own inbound servers
+// (SSE and gRPC). This is distinct from TLSConfig which applies to outbound
+// sink connections.
+//
+// CertFile and KeyFile are required to enable TLS. ClientCAFile is optional
+// and enables mutual TLS (mTLS): when set, client certificates are required
+// and verified against the given CA PEM.
+//
+// Cert rotation is not supported in v1; restart the process to reload certs.
+type ServerTLSConfig struct {
+	CertFile    string `yaml:"cert-file"`    // path to server certificate PEM; required for TLS
+	KeyFile     string `yaml:"key-file"`     // path to server private key PEM; required for TLS
+	ClientCAFile string `yaml:"client-ca-file"` // path to CA PEM for client cert verification (mTLS); optional
+}
+
 // Config is the complete runtime configuration for a kaptanto pipeline.
 // YAML tags match the locked schema described in the project specification.
 type Config struct {
@@ -137,6 +152,8 @@ type Config struct {
 	ClusterPeers    []string               `yaml:"cluster-peers"`     // NATS JetStream cluster peer addresses, e.g. ["node2:6222", "node3:6222"]
 	NatsClusterPort int                    `yaml:"nats-cluster-port"` // NATS cluster route port; 0 → 6222 applied at runtime
 	Sinks           SinksConfig            `yaml:"sinks"`             // queue sink connection settings
+	ServerTLS       ServerTLSConfig        `yaml:"server-tls"`        // inbound server TLS (SSE / gRPC); distinct from sink-side TLS
+	Insecure        bool                   `yaml:"insecure"`          // allow plaintext for sse/grpc without TLS (loud warning at startup)
 }
 
 // SourceType returns the detected source database type based on the DSN prefix.
@@ -199,6 +216,9 @@ func Merge(cfg *Config, cmd *cobra.Command) error {
 		{"node-id", &cfg.NodeID},
 		{"source-id", &cfg.SourceID},
 		{"cluster-dsn", &cfg.ClusterDSN},
+		{"tls-cert", &cfg.ServerTLS.CertFile},
+		{"tls-key", &cfg.ServerTLS.KeyFile},
+		{"tls-client-ca", &cfg.ServerTLS.ClientCAFile},
 	} {
 		if err := mergeString(flags, f.name, f.dest); err != nil {
 			return err
@@ -224,6 +244,7 @@ func Merge(cfg *Config, cmd *cobra.Command) error {
 		{"ha", &cfg.HA},
 		{"cluster", &cfg.Cluster},
 		{"all-tables", &cfg.AllowAllTables},
+		{"insecure", &cfg.Insecure},
 	} {
 		if err := mergeBool(flags, f.name, f.dest); err != nil {
 			return err

--- a/internal/output/grpc/server.go
+++ b/internal/output/grpc/server.go
@@ -2,10 +2,12 @@ package grpcoutput
 
 import (
 	"context"
+	"crypto/tls"
 	"time"
 
 	grpclib "google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/status"
 
@@ -41,14 +43,19 @@ func NewGRPCServer(
 
 // NewGRPCNetServer creates and configures the grpc.Server.
 // Call Serve(lis) on the returned server to start accepting connections.
-func NewGRPCNetServer(svc *GRPCServer) *grpclib.Server {
-	srv := grpclib.NewServer(
+// tlsCfg is optional: when non-nil the server uses TLS transport credentials.
+func NewGRPCNetServer(svc *GRPCServer, tlsCfg *tls.Config) *grpclib.Server {
+	opts := []grpclib.ServerOption{
 		grpclib.MaxConcurrentStreams(1000),
 		grpclib.KeepaliveParams(keepalive.ServerParameters{
 			Time:    30 * time.Second,
 			Timeout: 10 * time.Second,
 		}),
-	)
+	}
+	if tlsCfg != nil {
+		opts = append(opts, grpclib.Creds(credentials.NewTLS(tlsCfg)))
+	}
+	srv := grpclib.NewServer(opts...)
 	proto.RegisterCdcStreamServer(srv, svc)
 	return srv
 }


### PR DESCRIPTION
## Source fix plan

`.claude/fix-plans/no-tls-data-plane-20260531-214938.md`

## Problem

Kaptanto's SSE and gRPC outputs ran in cleartext — change-stream row data (potentially PII) was transmitted over the network without encryption, exposing it to eavesdroppers and MITM attacks. The existing `TLSConfig` in `internal/config/config.go` only covered outbound sink connections (Kafka/NATS/etc.), not Kaptanto's own inbound servers.

## Implementation

- **New `ServerTLSConfig` struct** in `internal/config/config.go` (`cert-file`, `key-file`, `client-ca-file`) — distinct from the sink-side `TLSConfig`.
- **New `Insecure bool`** field in `Config` and corresponding CLI flags: `--tls-cert`, `--tls-key`, `--tls-client-ca`, `--insecure`.
- **`buildServerTLSConfig`** helper in `internal/cmd/output.go`: loads cert/key pair, enforces `MinVersion: tls.VersionTLS12`, optionally enables mTLS when `--tls-client-ca` is provided.
- **`requireServerTLS`** policy function: returns an error for `sse`/`grpc` without TLS unless `--insecure` is set; insecure mode emits a loud `slog.Warn` at startup.
- **SSE**: calls `srv.ListenAndServeTLS("", "")` when TLS config is loaded into `srv.TLSConfig`; reuses `newHTTPServer` so all timeout hardening is preserved.
- **gRPC**: `NewGRPCNetServer` now accepts an optional `*tls.Config`; when non-nil, passes `grpc.Creds(credentials.NewTLS(tlsCfg))` as a server option.

## Validation run

```
CGO_ENABLED=0 go build ./...                          # clean compile
CGO_ENABLED=0 go test ./internal/cmd/... -run "TestBuildServerTLS|TestRequireServerTLS|TestBuildOutputServer|TestTLSPolicy" -v
CGO_ENABLED=0 go test ./...                           # full suite — all PASS
```

All 13 new TLS tests pass; full suite (26 packages) passes with no regressions.

## Residual risk / follow-up

- **Cert rotation**: restarting the process is required to reload certificates (by design, v1 scope). Operators should plan for rolling restarts.
- **Auth bundling**: the fix plan recommends shipping this alongside the `network-data-plane-auth` plan so bearer tokens are never sent over cleartext. That plan is not yet implemented.
- **`--insecure` escape hatch**: existing deployments without certs must pass `--insecure` to continue running. This is a breaking change for operators upgrading from prior versions.
- **mTLS test depth**: the mTLS test verifies that `ClientAuth` and `ClientCAs` are set correctly on the `*tls.Config`, but does not perform a live TLS handshake with a client cert (integration-level test left for follow-up).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No blocking correctness, data-safety, or security issues found.

Residual risk: `--insecure` intentionally exposes SSE/gRPC in plaintext, and server cert rotation still requires a restart.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->