### PR TITLE
ci: add deeper test & quality workflows

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,49 @@
+name: Coverage
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: ["**"]
+
+jobs:
+  coverage:
+    name: Test coverage threshold
+    runs-on: ubuntu-latest
+    env:
+      # In-repo gate. Current baseline over internal/ + cmd/ is ~54.3%; the gate
+      # sits a few points below to absorb noise. Ratchet upward over time.
+      COVERAGE_THRESHOLD: "50.0"
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run tests with coverage
+        run: |
+          CGO_ENABLED=0 go test ./internal/... ./cmd/... \
+            -count=1 -timeout 180s \
+            -coverprofile=coverage.out -covermode=count
+
+      - name: Generate HTML report
+        run: go tool cover -html=coverage.out -o coverage.html
+
+      - name: Enforce coverage threshold
+        run: |
+          total=$(go tool cover -func=coverage.out | awk '/^total:/ {gsub(/%/,"",$3); print $3}')
+          echo "Total coverage: ${total}% (threshold: ${COVERAGE_THRESHOLD}%)"
+          awk -v t="$total" -v min="$COVERAGE_THRESHOLD" \
+            'BEGIN { if (t+0 < min+0) { printf "FAIL: coverage %.1f%% is below threshold %.1f%%\n", t, min; exit 1 } else { printf "PASS: coverage %.1f%% meets threshold %.1f%%\n", t, min } }'
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: |
+            coverage.out
+            coverage.html
+          retention-days: 30

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,50 @@
+name: E2E
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: ["**"]
+
+jobs:
+  e2e:
+    name: End-to-end (binary against live Postgres)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    env:
+      POSTGRES_TEST_DSN: postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Start Postgres (logical replication)
+        run: |
+          docker run -d --name postgres \
+            -e POSTGRES_USER=postgres \
+            -e POSTGRES_PASSWORD=postgres \
+            -e POSTGRES_DB=postgres \
+            -p 5432:5432 \
+            postgres:16 \
+            -c wal_level=logical \
+            -c max_replication_slots=10 \
+            -c max_wal_senders=10
+          echo "Waiting for Postgres..."
+          for i in $(seq 1 30); do
+            if docker exec postgres pg_isready -U postgres >/dev/null 2>&1; then
+              echo "Postgres ready"; break
+            fi
+            echo "  waiting ($i)..."; sleep 2
+          done
+
+      - name: Run e2e tests
+        run: CGO_ENABLED=0 go test -tags e2e ./test/e2e/... -count=1 -timeout 300s -v
+
+      - name: Postgres logs on failure
+        if: failure()
+        run: docker logs postgres 2>&1 | tail -50 || true

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -60,11 +60,17 @@ jobs:
           done
           docker exec mongo mongosh --quiet --eval 'rs.initiate({_id: "rs0", members: [{_id: 0, host: "localhost:27017"}]})'
           echo "Waiting for PRIMARY..."
+          primary_ready=false
           for i in $(seq 1 30); do
             state=$(docker exec mongo mongosh --quiet --eval 'rs.status().myState' 2>/dev/null || echo "")
-            if [ "$state" = "1" ]; then echo "PRIMARY ready"; break; fi
+            if [ "$state" = "1" ]; then echo "PRIMARY ready"; primary_ready=true; break; fi
             echo "  state=$state ($i)..."; sleep 2
           done
+          if [ "$primary_ready" != "true" ]; then
+            echo "ERROR: MongoDB replica set never reached PRIMARY; aborting." >&2
+            docker logs mongo 2>&1 | tail -50 || true
+            exit 1
+          fi
 
       - name: Run integration tests
         run: CGO_ENABLED=0 go test ./... -count=1 -timeout 300s

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,76 @@
+name: Integration
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: ["**"]
+
+jobs:
+  integration:
+    name: Integration tests (Postgres + MongoDB)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    env:
+      POSTGRES_TEST_DSN: postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable
+      MONGO_TEST_URI: mongodb://localhost:27017/?replicaSet=rs0&directConnection=true
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      # Both databases need non-default startup args (Postgres: logical
+      # replication; Mongo: a replica set for Change Streams), which the GitHub
+      # `services:` block cannot pass reliably. Run them as explicit containers.
+      - name: Start Postgres (logical replication)
+        run: |
+          docker run -d --name postgres \
+            -e POSTGRES_USER=postgres \
+            -e POSTGRES_PASSWORD=postgres \
+            -e POSTGRES_DB=postgres \
+            -p 5432:5432 \
+            postgres:16 \
+            -c wal_level=logical \
+            -c max_replication_slots=10 \
+            -c max_wal_senders=10
+          echo "Waiting for Postgres..."
+          for i in $(seq 1 30); do
+            if docker exec postgres pg_isready -U postgres >/dev/null 2>&1; then
+              echo "Postgres ready"; break
+            fi
+            echo "  waiting ($i)..."; sleep 2
+          done
+
+      - name: Start MongoDB (single-node replica set)
+        run: |
+          docker run -d --name mongo \
+            -p 27017:27017 \
+            mongo:7 --replSet rs0 --bind_ip_all
+          echo "Waiting for mongod..."
+          for i in $(seq 1 30); do
+            if docker exec mongo mongosh --quiet --eval 'db.adminCommand({ ping: 1 })' >/dev/null 2>&1; then
+              break
+            fi
+            echo "  waiting ($i)..."; sleep 2
+          done
+          docker exec mongo mongosh --quiet --eval 'rs.initiate({_id: "rs0", members: [{_id: 0, host: "localhost:27017"}]})'
+          echo "Waiting for PRIMARY..."
+          for i in $(seq 1 30); do
+            state=$(docker exec mongo mongosh --quiet --eval 'rs.status().myState' 2>/dev/null || echo "")
+            if [ "$state" = "1" ]; then echo "PRIMARY ready"; break; fi
+            echo "  state=$state ($i)..."; sleep 2
+          done
+
+      - name: Run integration tests
+        run: CGO_ENABLED=0 go test ./... -count=1 -timeout 300s
+
+      - name: Container logs on failure
+        if: failure()
+        run: |
+          echo "=== postgres ==="; docker logs postgres 2>&1 | tail -50 || true
+          echo "=== mongo ==="; docker logs mongo 2>&1 | tail -50 || true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,27 @@
+name: Lint
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: ["**"]
+
+jobs:
+  golangci:
+    name: golangci-lint (complexity + dependency rules)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v2.1.6
+          args: ./internal/... ./cmd/...
+        env:
+          CGO_ENABLED: "0"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,8 @@ jobs:
 
       - name: golangci-lint
         # v7 is required for golangci-lint v2 configs.
-        uses: golangci/golangci-lint-action@v7
+        # SHA-pinned for supply-chain safety; mutable tags can be repointed.
+        uses: golangci/golangci-lint-action@9fae48acfc02a90574d7c304a1758ef9895495fa # v7
         with:
           # Must be built with Go >= go.mod's version (1.25); v2.12.2 satisfies it.
           version: v2.12.2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,7 +22,8 @@ jobs:
         # v7 is required for golangci-lint v2 configs.
         uses: golangci/golangci-lint-action@v7
         with:
-          version: v2.1.6
+          # Must be built with Go >= go.mod's version (1.25); v2.12.2 satisfies it.
+          version: v2.12.2
           args: ./internal/... ./cmd/...
         env:
           CGO_ENABLED: "0"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,8 @@ jobs:
           cache: true
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        # v7 is required for golangci-lint v2 configs.
+        uses: golangci/golangci-lint-action@v7
         with:
           version: v2.1.6
           args: ./internal/... ./cmd/...

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -1,0 +1,45 @@
+name: Mutation
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: ["**"]
+
+jobs:
+  mutation:
+    name: Mutation testing (core packages)
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Install gremlins
+        run: go install github.com/go-gremlins/gremlins/cmd/gremlins@v0.5.0
+
+      - name: Run mutation testing
+        env:
+          CGO_ENABLED: "0"
+        run: |
+          # Scope to the highest-value correctness packages; full-repo mutation
+          # is too slow for per-PR. Run each independently so one package's
+          # results are legible. Thresholds come from .gremlins.yaml (currently
+          # report-only); raise them once a baseline is established.
+          set -e
+          packages=(
+            ./internal/router
+            ./internal/eventlog
+            ./internal/parser/pgoutput
+            ./internal/backfill
+          )
+          for pkg in "${packages[@]}"; do
+            echo "::group::gremlins $pkg"
+            "$(go env GOPATH)/bin/gremlins" unleash "$pkg"
+            echo "::endgroup::"
+          done

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,104 @@
+# golangci-lint configuration (v2 schema).
+#
+# This is the umbrella for two of the deeper CI gates:
+#   - Cyclomatic complexity (#6)         -> gocyclo
+#   - Dependency-structure validation (#4) -> depguard (layered import rules)
+#
+# Plus baseline hygiene linters. Thresholds are set to land green on the current
+# tree and are intended to be ratcheted tighter over time.
+version: "2"
+
+linters:
+  # Scoped intentionally to the two gates this umbrella owns. General hygiene
+  # (govet, etc.) is covered by the separate `go vet` step in ci.yml; adding
+  # more linters here would duplicate that and surface unrelated pre-existing
+  # findings. Add linters deliberately, with a green baseline each time.
+  default: none
+  enable:
+    - gocyclo
+    - depguard
+
+  settings:
+    gocyclo:
+      # Current production max is 48 (runPipeline) and 36 (tokenize), both
+      # explicitly //nolint:gocyclo-exempted with a refactor note. Everything
+      # else sits at <=30, so 31 catches new offenders without churn.
+      min-complexity: 31
+
+    depguard:
+      # Layered architecture (verified from the import graph):
+      #   event  <  eventlog / parser  <  backfill / checkpoint  <  source / output / router  <  cmd
+      # Lower layers must never import upper layers. Rules use deny-lists keyed
+      # by the offending upper-layer package prefixes (prefix match covers
+      # sub-packages, e.g. internal/source also matches internal/source/postgres).
+      rules:
+        # internal/event is a pure domain leaf: it must not import any other
+        # internal package.
+        event-leaf:
+          files:
+            - "**/internal/event/**"
+          deny:
+            - pkg: github.com/olucasandrade/kaptanto/internal/eventlog
+              desc: "internal/event is a leaf; it must not depend on other internal packages"
+            - pkg: github.com/olucasandrade/kaptanto/internal/parser
+              desc: "internal/event is a leaf; it must not depend on other internal packages"
+            - pkg: github.com/olucasandrade/kaptanto/internal/backfill
+              desc: "internal/event is a leaf; it must not depend on other internal packages"
+            - pkg: github.com/olucasandrade/kaptanto/internal/checkpoint
+              desc: "internal/event is a leaf; it must not depend on other internal packages"
+            - pkg: github.com/olucasandrade/kaptanto/internal/source
+              desc: "internal/event is a leaf; it must not depend on other internal packages"
+            - pkg: github.com/olucasandrade/kaptanto/internal/output
+              desc: "internal/event is a leaf; it must not depend on other internal packages"
+            - pkg: github.com/olucasandrade/kaptanto/internal/router
+              desc: "internal/event is a leaf; it must not depend on other internal packages"
+            - pkg: github.com/olucasandrade/kaptanto/internal/cmd
+              desc: "internal/event is a leaf; it must not depend on other internal packages"
+
+        # eventlog and parser sit just above event: they may use event (and
+        # observability) but must not reach into higher layers.
+        low-layer:
+          files:
+            - "**/internal/eventlog/**"
+            - "**/internal/parser/**"
+          deny:
+            - pkg: github.com/olucasandrade/kaptanto/internal/backfill
+              desc: "eventlog/parser must not import upper layers"
+            - pkg: github.com/olucasandrade/kaptanto/internal/checkpoint
+              desc: "eventlog/parser must not import upper layers"
+            - pkg: github.com/olucasandrade/kaptanto/internal/source
+              desc: "eventlog/parser must not import upper layers"
+            - pkg: github.com/olucasandrade/kaptanto/internal/output
+              desc: "eventlog/parser must not import upper layers"
+            - pkg: github.com/olucasandrade/kaptanto/internal/router
+              desc: "eventlog/parser must not import upper layers"
+            - pkg: github.com/olucasandrade/kaptanto/internal/cmd
+              desc: "eventlog/parser must not import upper layers"
+
+        # checkpoint persists state; it must not depend on the sources/outputs
+        # that drive it, nor on the CLI assembly layer.
+        checkpoint-layer:
+          files:
+            - "**/internal/checkpoint/**"
+          deny:
+            - pkg: github.com/olucasandrade/kaptanto/internal/source
+              desc: "checkpoint must not import source/output/router/cmd"
+            - pkg: github.com/olucasandrade/kaptanto/internal/output
+              desc: "checkpoint must not import source/output/router/cmd"
+            - pkg: github.com/olucasandrade/kaptanto/internal/router
+              desc: "checkpoint must not import source/output/router/cmd"
+            - pkg: github.com/olucasandrade/kaptanto/internal/cmd
+              desc: "checkpoint must not import source/output/router/cmd"
+
+  exclusions:
+    generated: lax
+    rules:
+      # Tests are allowed to be long/branchy and to cross layers freely.
+      - path: _test\.go
+        linters:
+          - gocyclo
+          - depguard
+
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0

--- a/.gremlins.yaml
+++ b/.gremlins.yaml
@@ -1,0 +1,16 @@
+# gremlins mutation-testing configuration.
+#
+# Mutation testing is run per-package over the highest-value correctness
+# packages (see .github/workflows/mutation.yml). Thresholds start at 0
+# (report-only, non-gating) so the first runs establish a real baseline; raise
+# threshold-efficacy / threshold-mutant-coverage once that baseline is known.
+unleash:
+  dry-run: false
+  # No special build tags: the targeted packages compile and test under the
+  # default pure-Go build.
+  tags: ""
+  # Gating thresholds — 0 means "never fail" (informational). Ratchet upward.
+  threshold-efficacy: 0
+  threshold-mutant-coverage: 0
+
+silent: false

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,11 @@
 # Makefile for kaptanto — builds a single static binary with no CGO dependency.
 
-.PHONY: build test test-race verify-no-cgo clean build-rust
+.PHONY: build test test-race verify-no-cgo clean build-rust \
+        lint cover test-integration test-e2e mutation
+
+# Coverage gate threshold (percent). Mirrors COVERAGE_THRESHOLD in
+# .github/workflows/coverage.yml. Ratchet upward over time.
+COVERAGE_THRESHOLD ?= 50.0
 
 # Version injection — reads from git tag if available, falls back to "dev".
 VERSION    ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
@@ -58,3 +63,34 @@ $(RUST_LIB):
 	@echo "[kaptanto] Building Rust static library..."
 	cd $(RUST_DIR) && cargo build --release
 	@echo "[kaptanto] Rust static library built -> $(RUST_LIB)"
+
+# ---- Quality gates (mirror the CI workflows; run locally before pushing) ----
+
+# lint runs the golangci-lint umbrella: cyclomatic complexity (gocyclo) and
+# dependency-structure rules (depguard). Config in .golangci.yml.
+lint:
+	CGO_ENABLED=0 golangci-lint run ./internal/... ./cmd/...
+
+# cover runs tests with coverage and fails if total is below COVERAGE_THRESHOLD.
+cover:
+	CGO_ENABLED=0 go test ./internal/... ./cmd/... -count=1 -coverprofile=coverage.out -covermode=count
+	@go tool cover -func=coverage.out | tail -1
+	@total=$$(go tool cover -func=coverage.out | awk '/^total:/ {gsub(/%/,"",$$3); print $$3}'); \
+	awk -v t="$$total" -v min="$(COVERAGE_THRESHOLD)" 'BEGIN { if (t+0 < min+0) { printf "FAIL: coverage %.1f%% < threshold %.1f%%\n", t, min; exit 1 } else { printf "PASS: coverage %.1f%% >= threshold %.1f%%\n", t, min } }'
+
+# test-integration runs the env-gated Postgres + MongoDB integration tests.
+# Requires POSTGRES_TEST_DSN (logical replication) and MONGO_TEST_URI (replica set).
+test-integration:
+	CGO_ENABLED=0 go test ./... -count=1 -timeout 300s
+
+# test-e2e runs the black-box binary tests against a live Postgres.
+# Requires POSTGRES_TEST_DSN (logical replication).
+test-e2e:
+	CGO_ENABLED=0 go test -tags e2e ./test/e2e/... -count=1 -timeout 300s -v
+
+# mutation runs gremlins over the core correctness packages. Config in .gremlins.yaml.
+mutation:
+	@for pkg in ./internal/router ./internal/eventlog ./internal/parser/pgoutput ./internal/backfill; do \
+		echo "=== gremlins $$pkg ==="; \
+		gremlins unleash $$pkg || exit 1; \
+	done

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -137,6 +137,7 @@ func ensureDataDir(dir string) error {
 	return os.MkdirAll(dir, 0o700)
 }
 
+//nolint:gocyclo // pipeline assembly wires many optional components; splitting it would obscure the linear startup sequence. Tracked for incremental refactor.
 func runPipeline(ctx context.Context, cfg *config.Config) error {
 	slog.Info("kaptanto starting",
 		"source", redactDSN(cfg.Source),

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -210,10 +210,19 @@ func TestNonHAPathUnchanged(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	// Run with a source but HA=false (default). The pipeline will fail quickly
-	// when it can't connect to Postgres, but we only care that no "ha:" lines
-	// appear before the failure.
-	_ = cmd.ExecuteWithArgs([]string{"--source", os.Getenv("POSTGRES_TEST_DSN")}, &buf)
+	// Run with a source but HA=false (default). When POSTGRES_TEST_DSN points at
+	// a reachable Postgres the pipeline streams indefinitely, so bound it with a
+	// timeout context: we only care that no "ha:" lines appear while it runs.
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+	defer cancel()
+	root := cmd.NewRootCmd()
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+	root.SetArgs([]string{
+		"--source", os.Getenv("POSTGRES_TEST_DSN"),
+		"--data-dir", t.TempDir(),
+	})
+	_ = root.ExecuteContext(ctx)
 	out := buf.String()
 	assert.False(t, strings.Contains(out, "ha:"), "non-HA path must not emit ha: log lines; got: %s", out)
 }

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/olucasandrade/kaptanto/internal/cmd"
 	"github.com/olucasandrade/kaptanto/internal/event"
 	"github.com/olucasandrade/kaptanto/internal/eventlog"
+	"github.com/olucasandrade/kaptanto/internal/logging"
 	"github.com/olucasandrade/kaptanto/internal/router"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -245,6 +246,19 @@ func TestNonHAPathUnchanged(t *testing.T) {
 	// streams indefinitely and its graceful shutdown may not return promptly, so
 	// we do NOT wait for ExecuteContext to return — run it in the background.
 	ctx, cancel := context.WithCancel(context.Background())
+
+	// Teardown runs unconditionally (even if a require below fails), so we never
+	// leave os.Stderr or the process-wide slog default pointed at a closed pipe
+	// fd, which would corrupt later tests. logging.Setup re-routes the global
+	// logger back to the real stderr through the same path PersistentPreRunE uses.
+	t.Cleanup(func() {
+		cancel()
+		os.Stderr = origStderr
+		logging.Setup(origStderr, "info")
+		_ = pw.Close()
+		<-copyDone
+	})
+
 	root := cmd.NewRootCmd()
 	root.SetArgs([]string{
 		"--source", os.Getenv("POSTGRES_TEST_DSN"),
@@ -261,12 +275,6 @@ func TestNonHAPathUnchanged(t *testing.T) {
 
 	out := logs.String()
 	assert.False(t, strings.Contains(out, "ha:"), "non-HA path must not emit ha: log lines; got: %s", out)
-
-	// Stop the pipeline and the stderr-capture goroutine, then restore stderr.
-	cancel()
-	os.Stderr = origStderr
-	_ = pw.Close()
-	<-copyDone
 }
 
 // TestMongoDBFlagRoute verifies that when --source starts with "mongodb://",

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"os"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -28,6 +29,25 @@ func (f *fakeEventLogForCmd) ReadPartition(_ context.Context, _ uint32, _ uint64
 	return nil, nil
 }
 func (f *fakeEventLogForCmd) Close() error { return nil }
+
+// lockedBuffer is a goroutine-safe bytes.Buffer, used when a background
+// pipeline writes log output concurrently with the test reading it.
+type lockedBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (l *lockedBuffer) Write(p []byte) (int, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.buf.Write(p)
+}
+
+func (l *lockedBuffer) String() string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.buf.String()
+}
 
 func TestHelpContainsKaptanto(t *testing.T) {
 	buf := &bytes.Buffer{}
@@ -209,20 +229,25 @@ func TestNonHAPathUnchanged(t *testing.T) {
 		t.Skip("POSTGRES_TEST_DSN not set; skipping non-HA path test")
 	}
 
-	var buf bytes.Buffer
-	// Run with a source but HA=false (default). When POSTGRES_TEST_DSN points at
-	// a reachable Postgres the pipeline streams indefinitely, so bound it with a
-	// timeout context: we only care that no "ha:" lines appear while it runs.
-	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+	// When POSTGRES_TEST_DSN points at a reachable Postgres the non-HA pipeline
+	// streams indefinitely and its graceful shutdown may not return promptly, so
+	// we do NOT wait for ExecuteContext to return. We run it in the background,
+	// observe the log output for a bounded window, then assert. A lock-guarded
+	// buffer makes concurrent reads safe while the pipeline keeps writing.
+	buf := &lockedBuffer{}
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	root := cmd.NewRootCmd()
-	root.SetOut(&buf)
-	root.SetErr(&buf)
+	root.SetOut(buf)
+	root.SetErr(buf)
 	root.SetArgs([]string{
 		"--source", os.Getenv("POSTGRES_TEST_DSN"),
 		"--data-dir", t.TempDir(),
 	})
-	_ = root.ExecuteContext(ctx)
+	go func() { _ = root.ExecuteContext(ctx) }()
+
+	// Let the non-HA path run long enough to emit startup logs, then assert.
+	time.Sleep(3 * time.Second)
 	out := buf.String()
 	assert.False(t, strings.Contains(out, "ha:"), "non-HA path must not emit ha: log lines; got: %s", out)
 }

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -3,6 +3,7 @@ package cmd_test
 import (
 	"bytes"
 	"context"
+	"io"
 	"os"
 	"strings"
 	"sync"
@@ -229,27 +230,43 @@ func TestNonHAPathUnchanged(t *testing.T) {
 		t.Skip("POSTGRES_TEST_DSN not set; skipping non-HA path test")
 	}
 
+	// Logging is configured via logging.Setup(os.Stderr, ...) in the command's
+	// PersistentPreRunE, so cobra's SetOut/SetErr do NOT capture slog output.
+	// Redirect os.Stderr to a pipe for the duration to capture the real logs.
+	origStderr := os.Stderr
+	pr, pw, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stderr = pw
+	logs := &lockedBuffer{}
+	copyDone := make(chan struct{})
+	go func() { _, _ = io.Copy(logs, pr); close(copyDone) }()
+
 	// When POSTGRES_TEST_DSN points at a reachable Postgres the non-HA pipeline
 	// streams indefinitely and its graceful shutdown may not return promptly, so
-	// we do NOT wait for ExecuteContext to return. We run it in the background,
-	// observe the log output for a bounded window, then assert. A lock-guarded
-	// buffer makes concurrent reads safe while the pipeline keeps writing.
-	buf := &lockedBuffer{}
+	// we do NOT wait for ExecuteContext to return — run it in the background.
 	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 	root := cmd.NewRootCmd()
-	root.SetOut(buf)
-	root.SetErr(buf)
 	root.SetArgs([]string{
 		"--source", os.Getenv("POSTGRES_TEST_DSN"),
 		"--data-dir", t.TempDir(),
 	})
 	go func() { _ = root.ExecuteContext(ctx) }()
 
-	// Let the non-HA path run long enough to emit startup logs, then assert.
-	time.Sleep(3 * time.Second)
-	out := buf.String()
+	// Wait until the pipeline logs its startup line — this proves the non-HA
+	// path actually started (so the "ha:" check below is meaningful), and is
+	// bounded so a failure to start fails fast rather than hanging.
+	require.Eventually(t, func() bool {
+		return strings.Contains(logs.String(), "kaptanto starting")
+	}, 15*time.Second, 100*time.Millisecond, "non-HA pipeline did not start")
+
+	out := logs.String()
 	assert.False(t, strings.Contains(out, "ha:"), "non-HA path must not emit ha: log lines; got: %s", out)
+
+	// Stop the pipeline and the stderr-capture goroutine, then restore stderr.
+	cancel()
+	os.Stderr = origStderr
+	_ = pw.Close()
+	<-copyDone
 }
 
 // TestMongoDBFlagRoute verifies that when --source starts with "mongodb://",

--- a/internal/output/row_filter.go
+++ b/internal/output/row_filter.go
@@ -277,6 +277,7 @@ type wToken struct {
 	value string
 }
 
+//nolint:gocyclo // single-pass lexer; the branch-per-token-kind structure is clearer as one function. Tracked for incremental refactor.
 func tokenize(s string) ([]wToken, error) {
 	var tokens []wToken
 	i := 0

--- a/internal/source/mongodb/connector_integration_test.go
+++ b/internal/source/mongodb/connector_integration_test.go
@@ -1,0 +1,122 @@
+package mongodb_test
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/olucasandrade/kaptanto/internal/event"
+	mongodb "github.com/olucasandrade/kaptanto/internal/source/mongodb"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
+)
+
+// These tests exercise the real MongoDB Change Stream path. They require a
+// MongoDB running as a replica set (Change Streams are unavailable on a
+// standalone server). Set MONGO_TEST_URI to enable them, e.g.:
+//
+//	MONGO_TEST_URI="mongodb://localhost:27017/?replicaSet=rs0" go test ./internal/source/mongodb/...
+//
+// The integration workflow (.github/workflows/integration.yml) provisions a
+// single-node replica set and exports MONGO_TEST_URI.
+
+func mongoTestURI(t *testing.T) string {
+	t.Helper()
+	uri := os.Getenv("MONGO_TEST_URI")
+	if uri == "" {
+		t.Skip("set MONGO_TEST_URI (replica-set MongoDB) to run MongoDB integration tests")
+	}
+	return uri
+}
+
+// connectMongo returns a real client and registers cleanup.
+func connectMongo(t *testing.T, uri string) *mongo.Client {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	cli, err := mongo.Connect(options.Client().ApplyURI(uri))
+	require.NoError(t, err, "connect to MongoDB")
+	require.NoError(t, cli.Ping(ctx, nil), "ping MongoDB")
+	t.Cleanup(func() {
+		_ = cli.Disconnect(context.Background())
+	})
+	return cli
+}
+
+// readEvent waits for the next ChangeEvent or fails on timeout.
+func readEvent(t *testing.T, ch <-chan *event.ChangeEvent, within time.Duration) *event.ChangeEvent {
+	t.Helper()
+	select {
+	case ev := <-ch:
+		require.NotNil(t, ev)
+		return ev
+	case <-time.After(within):
+		t.Fatalf("timed out after %s waiting for ChangeEvent", within)
+		return nil
+	}
+}
+
+// TestMongoIntegration_ChangeStream_CRUD verifies that inserts, updates and
+// deletes against a watched collection surface as ordered ChangeEvents with
+// the correct operations.
+func TestMongoIntegration_ChangeStream_CRUD(t *testing.T) {
+	uri := mongoTestURI(t)
+	cli := connectMongo(t, uri)
+
+	// Unique collection per run to avoid cross-test interference.
+	dbName := "kaptanto_it"
+	collName := "events_" + time.Now().Format("150405.000000")
+	coll := cli.Database(dbName).Collection(collName)
+	t.Cleanup(func() {
+		_ = coll.Drop(context.Background())
+	})
+
+	conn, err := mongodb.New(mongodb.Config{
+		URI:         uri,
+		Database:    dbName,
+		Collections: []string{collName},
+		SourceID:    "it_" + collName,
+	}, newFakeStore(), event.NewIDGenerator())
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	runErr := make(chan error, 1)
+	go func() { runErr <- conn.Run(ctx) }()
+
+	// Give the change stream a moment to open before producing writes, so the
+	// resume position starts ahead of our operations.
+	time.Sleep(2 * time.Second)
+
+	docID := bson.NewObjectID()
+	_, err = coll.InsertOne(ctx, bson.M{"_id": docID, "status": "new"})
+	require.NoError(t, err)
+	_, err = coll.UpdateOne(ctx, bson.M{"_id": docID}, bson.M{"$set": bson.M{"status": "done"}})
+	require.NoError(t, err)
+	_, err = coll.DeleteOne(ctx, bson.M{"_id": docID})
+	require.NoError(t, err)
+
+	ch := conn.Events()
+	ins := readEvent(t, ch, 15*time.Second)
+	upd := readEvent(t, ch, 15*time.Second)
+	del := readEvent(t, ch, 15*time.Second)
+
+	require.Equal(t, event.OpInsert, ins.Operation, "first event should be insert")
+	require.Equal(t, event.OpUpdate, upd.Operation, "second event should be update")
+	require.Equal(t, event.OpDelete, del.Operation, "third event should be delete")
+
+	// All three events concern the same document key, in order.
+	require.JSONEq(t, string(ins.Key), string(upd.Key), "insert/update share the document key")
+	require.JSONEq(t, string(upd.Key), string(del.Key), "update/delete share the document key")
+
+	cancel()
+	select {
+	case <-runErr:
+	case <-time.After(5 * time.Second):
+		t.Fatal("connector did not stop after context cancellation")
+	}
+}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -103,6 +103,7 @@ func TestE2E_Postgres_CRUDStream(t *testing.T) {
 	type result struct {
 		ops  []event.Operation
 		keys []string
+		err  error
 	}
 	got := make(chan result, 1)
 	go func() {
@@ -125,6 +126,15 @@ func TestE2E_Postgres_CRUDStream(t *testing.T) {
 				}
 			}
 		}
+		// The stream ended before three DML events arrived. Surface why (a
+		// scanner error, or the process closing stdout) instead of letting the
+		// consumer time out with no explanation.
+		if err := scanner.Err(); err != nil {
+			r.err = fmt.Errorf("reading event stream: %w", err)
+		} else {
+			r.err = fmt.Errorf("event stream ended after %d/3 DML events", len(r.ops))
+		}
+		got <- r
 	}()
 
 	// Let the replication slot get created and streaming start before writing.
@@ -138,6 +148,7 @@ func TestE2E_Postgres_CRUDStream(t *testing.T) {
 
 	select {
 	case r := <-got:
+		require.NoError(t, r.err, "event stream collection failed")
 		require.Equal(t, []event.Operation{event.OpInsert, event.OpUpdate, event.OpDelete}, r.ops,
 			"events must arrive in insert→update→delete order (RTR-04 per-key ordering)")
 		require.Equal(t, r.keys[0], r.keys[1], "all events share the same primary key")

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1,0 +1,148 @@
+//go:build e2e
+
+// Package e2e exercises the kaptanto binary end-to-end against a live Postgres
+// using logical replication. It builds the binary, streams to stdout (NDJSON),
+// drives INSERT/UPDATE/DELETE through a real connection, and asserts the
+// resulting ChangeEvents arrive in per-key order with the correct operations.
+//
+// Requires a Postgres with wal_level=logical. Set POSTGRES_TEST_DSN, e.g.:
+//
+//	POSTGRES_TEST_DSN="postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable" \
+//	  go test -tags e2e ./test/e2e/...
+//
+// The e2e workflow (.github/workflows/e2e.yml) provisions Postgres and sets it.
+package e2e
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/olucasandrade/kaptanto/internal/event"
+	"github.com/stretchr/testify/require"
+)
+
+// buildBinary compiles the kaptanto binary to a temp path and returns it.
+func buildBinary(t *testing.T) string {
+	t.Helper()
+	repoRoot, err := filepath.Abs("../..")
+	require.NoError(t, err)
+	bin := filepath.Join(t.TempDir(), "kaptanto")
+	cmd := exec.Command("go", "build", "-o", bin, "./cmd/kaptanto")
+	cmd.Dir = repoRoot
+	cmd.Env = append(os.Environ(), "CGO_ENABLED=0")
+	out, err := cmd.CombinedOutput()
+	require.NoErrorf(t, err, "build kaptanto: %s", out)
+	return bin
+}
+
+func TestE2E_Postgres_CRUDStream(t *testing.T) {
+	dsn := os.Getenv("POSTGRES_TEST_DSN")
+	if dsn == "" {
+		t.Skip("set POSTGRES_TEST_DSN (logical-replication Postgres) to run e2e tests")
+	}
+
+	ctx := context.Background()
+	conn, err := pgx.Connect(ctx, dsn)
+	require.NoError(t, err)
+	defer conn.Close(ctx)
+
+	// Unique names so concurrent/repeat runs do not collide on slot/publication.
+	suffix := time.Now().Format("150405000")
+	table := "e2e_" + suffix
+	sourceID := "e2e_" + suffix
+
+	_, err = conn.Exec(ctx, fmt.Sprintf(
+		"CREATE TABLE public.%s (id int PRIMARY KEY, status text)", table))
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		c, err := pgx.Connect(context.Background(), dsn)
+		if err != nil {
+			return
+		}
+		defer c.Close(context.Background())
+		_, _ = c.Exec(context.Background(), fmt.Sprintf("DROP TABLE IF EXISTS public.%s", table))
+		// Drop the replication slot/publication kaptanto creates (best effort).
+		_, _ = c.Exec(context.Background(),
+			fmt.Sprintf("SELECT pg_drop_replication_slot('kaptanto_%s')", sourceID))
+		_, _ = c.Exec(context.Background(),
+			fmt.Sprintf("DROP PUBLICATION IF EXISTS kaptanto_pub_%s", sourceID))
+	})
+
+	bin := buildBinary(t)
+
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	cmd := exec.CommandContext(runCtx, bin,
+		"--source", dsn,
+		"--tables", "public."+table,
+		"--output", "stdout",
+		"--source-id", sourceID,
+		"--data-dir", t.TempDir(),
+		"--log-level", "warn",
+	)
+	stdout, err := cmd.StdoutPipe()
+	require.NoError(t, err)
+	cmd.Stderr = os.Stderr
+	require.NoError(t, cmd.Start())
+	t.Cleanup(func() {
+		cancel()
+		_ = cmd.Wait()
+	})
+
+	// Collect events for our table off the NDJSON stream.
+	type result struct {
+		ops  []event.Operation
+		keys []string
+	}
+	got := make(chan result, 1)
+	go func() {
+		scanner := bufio.NewScanner(stdout)
+		scanner.Buffer(make([]byte, 0, 64*1024), 1<<20)
+		var r result
+		for scanner.Scan() {
+			var ev event.ChangeEvent
+			if err := json.Unmarshal(scanner.Bytes(), &ev); err != nil {
+				continue // skip non-event lines defensively
+			}
+			// Only care about DML on our table; ignore snapshot reads/controls.
+			switch ev.Operation {
+			case event.OpInsert, event.OpUpdate, event.OpDelete:
+				r.ops = append(r.ops, ev.Operation)
+				r.keys = append(r.keys, string(ev.Key))
+				if len(r.ops) == 3 {
+					got <- r
+					return
+				}
+			}
+		}
+	}()
+
+	// Let the replication slot get created and streaming start before writing.
+	time.Sleep(3 * time.Second)
+	_, err = conn.Exec(ctx, fmt.Sprintf("INSERT INTO public.%s (id, status) VALUES (1, 'new')", table))
+	require.NoError(t, err)
+	_, err = conn.Exec(ctx, fmt.Sprintf("UPDATE public.%s SET status='done' WHERE id=1", table))
+	require.NoError(t, err)
+	_, err = conn.Exec(ctx, fmt.Sprintf("DELETE FROM public.%s WHERE id=1", table))
+	require.NoError(t, err)
+
+	select {
+	case r := <-got:
+		require.Equal(t, []event.Operation{event.OpInsert, event.OpUpdate, event.OpDelete}, r.ops,
+			"events must arrive in insert→update→delete order (RTR-04 per-key ordering)")
+		require.Equal(t, r.keys[0], r.keys[1], "all events share the same primary key")
+		require.Equal(t, r.keys[1], r.keys[2], "all events share the same primary key")
+	case <-time.After(30 * time.Second):
+		t.Fatal("timed out waiting for insert/update/delete events on stdout stream")
+	}
+}


### PR DESCRIPTION
Adds five additive CI workflows for deeper test & quality coverage, all triggered on every push/PR (per request). Existing `ci.yml` is unchanged.

## New checks
| Workflow | Covers | Notes |
|---|---|---|
| `lint.yml` | Cyclomatic complexity (#6) + Dependency-structure validation (#4) | golangci-lint umbrella: `gocyclo` (min-complexity 31) + `depguard` layered import rules. Config in `.golangci.yml`. |
| `coverage.yml` | Test coverage (#5) | In-repo threshold gate at **50%** (baseline 54.3%) + HTML artifact. No external service. |
| `integration.yml` | Integration tests (#2) | Spins up Postgres (logical replication) and MongoDB (single-node replica set), exports `POSTGRES_TEST_DSN` / `MONGO_TEST_URI`, runs the previously-skipped env-gated tests for real. |
| `e2e.yml` | E2E tests (#3) | Builds the binary, runs it against live Postgres, asserts insert→update→delete stream in per-key order (RTR-04). `test/e2e/e2e_test.go`, `//go:build e2e`. |
| `mutation.yml` | Mutation tests (#1) | `gremlins` over core packages (`router`, `eventlog`, `parser/pgoutput`, `backfill`). Report-only baseline (thresholds 0); ratchet later. |

## Other changes
- New `MONGO_TEST_URI`-gated Mongo Change Stream integration test (`internal/source/mongodb/connector_integration_test.go`).
- `Makefile` targets mirroring the workflows: `lint`, `cover`, `test-integration`, `test-e2e`, `mutation`.
- `//nolint:gocyclo` exemptions (with refactor notes) on the two pre-existing complexity outliers: `runPipeline` (48) and `tokenize` (36).

## Thresholds (chosen to land green, then ratchet)
- Complexity: `min-complexity: 31` — catches new offenders above the existing cluster.
- Coverage: `50%` vs measured `54.3%`.
- Mutation: report-only until a baseline is observed from the first run.

## Verification done locally
- `make lint` → 0 issues
- `make cover` → PASS 54.3% ≥ 50%
- Full `go test ./internal/... ./cmd/...` → green
- e2e + Mongo integration tests compile under their tags/gates (no Docker locally; integration/e2e validated by the new workflows on this PR).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
# Code Review: CI/Testing Infrastructure PR — Updated Review

## ✅ High-level verdict
Ready to merge with the requested CI/test hardening changes. The new workflows substantially improve confidence (lint gates, coverage gate, integration + e2e assertions on per-key ordering) and the small test fixes address real observability/robustness gaps. No critical correctness/data-loss/security issues found, but there is one security-adjacent CI log-safety risk and one likely flakiness vector.

---

## Blocking / High-severity items (must fix or acknowledge before merge)

1. **Potential DSN leakage in e2e failure output (CI log safety)**
   - Where: `test/e2e/e2e_test.go` — Postgres connection + assertion:
     - `conn, err := pgx.Connect(ctx, dsn)` (line **53**)
     - `require.NoError(t, err)` (line **54**)
   - Why it matters: if `pgx.Connect` fails, the testify assertion prints `err.Error()`; depending on `pgx`, that error may include the full DSN (host/user/password/query params). Even in CI, this violates “don’t leak credentials/DSNs in logs.”
   - Smallest safe fix: replace `require.NoError(t, err)` with logic that **does not include** `err.Error()` in the failure message (e.g., `if err != nil { t.Fatal("failed to connect to Postgres") }`), or sanitize `err` before printing.

2. **Mongo integration test shutdown timeout may be flaky on busy runners**
   - Where: `internal/source/mongodb/connector_integration_test.go` — shutdown wait:
     - context cancel + `time.After(5 * time.Second)` then `t.Fatal(...)` (lines **116–121**)
   - Why it matters: 5s can be tight under CI contention; connector goroutine not stopping will intermittently fail PRs.
   - Smallest safe fix: increase to **10s** (or make it env-configurable) and/or wait on `runErr` with a longer grace period.

---

## Medium-severity observations / recommended improvements

1. **Mongo PRIMARY polling hard-fails the whole workflow (acceptable, but noisy)**
   - Where: `.github/workflows/integration.yml` — PRIMARY readiness loop and abort:
     - PRIMARY polling with `exit 1` after attempts; prints `docker logs mongo | tail -50` (lines **62–73**)
   - Why it matters: this is operationally intentional, but expect full PR failures when the container doesn’t bootstrap.
   - Recommendation: acceptable as-is; if CI flakiness occurs, increase retries beyond 30×2s.

2. **e2e test readiness uses fixed sleep**
   - Where: `test/e2e/e2e_test.go` — `time.Sleep(3 * time.Second)` before INSERT/UPDATE/DELETE (line **141**)
   - Why it matters: can cause occasional timing failures if logical replication setup is slower than usual.
   - Recommendation: replace with a poll on “slot/publication exists” (or a lightweight readiness signal from the running binary) to eliminate fixed-delay flakiness.

3. **`TestNonHAPathUnchanged` improvement is correct and meaningfully safer**
   - Where: `internal/cmd/root_test.go`
     - `lockedBuffer` + `os.Pipe()` capture to read *real* `os.Stderr` slog output (lines **34–51**, **233–270**)
   - Why it matters: this directly addresses the previous correctness gap where the test asserted against an empty buffer; the current approach is appropriate for concurrent/background pipeline logs.

---

## Low-severity / informational items

1. **nolint exemptions are justified and explicitly tracked**
   - Where:
     - `internal/cmd/root.go` — `//nolint:gocyclo` above `runPipeline` (line **140**)
     - `internal/output/row_filter.go` — `//nolint:gocyclo` above `tokenize` (line **280**)
   - Why it matters: comments state the reason and that it’s tracked for incremental refactor; no functional risk.

2. **Supply-chain hardening applied correctly**
   - Where: `.github/workflows/lint.yml` — `golangci/golangci-lint-action@9fae48acfc02a90574d7c304a1758ef9895495fa` (line **24**) with `# v7` comment
   - Why it matters: avoids mutable tags and matches the intended v7 config compatibility.

---

## Concrete file/line references (quick review anchors)
- **DSN leak risk:** `test/e2e/e2e_test.go` lines **47–55** (`pgx.Connect` + `require.NoError`)
- **Mongo shutdown timeout:** `internal/source/mongodb/connector_integration_test.go` lines **116–121**
- **Mongo PRIMARY readiness hard-fail:** `.github/workflows/integration.yml` lines **62–73**
- **e2e fixed readiness sleep:** `test/e2e/e2e_test.go` line **141**
- **TestNonHAPathUnchanged stderr capture:** `internal/cmd/root_test.go` lines **34–51** and **233–270**
- **nolint sites:** `internal/cmd/root.go` line **140**; `internal/output/row_filter.go` line **280**
- **lint action pin:** `.github/workflows/lint.yml` line **24**
- **e2e per-key ordering assertion:** `test/e2e/e2e_test.go` lines **149–158** (insert→update→delete ordering + same key)

---

## Required action checklist
- [ ] Update `test/e2e/e2e_test.go` to avoid printing `err.Error()` from `pgx.Connect` failures (line **54**) so DSN/credentials cannot appear in CI logs.
- [ ] Increase Mongo connector shutdown grace period from **5s → 10s** (or make configurable) in `internal/source/mongodb/connector_integration_test.go` (lines **116–121**).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->