### PR TITLE
ci(security): advisory security scanning + supply-chain hardening

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,10 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    # Wait for a release to age before opening a PR — dodges yanked/compromised
+    # versions and cuts churn from rapid point releases.
+    cooldown:
+      default-days: 7
     groups:
       go-dependencies:
         patterns:
@@ -18,6 +22,8 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
     groups:
       rust-dependencies:
         patterns:
@@ -30,6 +36,8 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
     groups:
       github-actions:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,36 @@
+version: 2
+updates:
+  # Go modules. Grouped into a single PR per run to keep the large dependency
+  # tree (AWS SDK, GCP, franz-go, mongo driver, ...) from flooding the queue.
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      go-dependencies:
+        patterns:
+          - "*"
+
+  # Rust FFI crate.
+  - package-ecosystem: cargo
+    directory: "/rust/kaptanto-ffi"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      rust-dependencies:
+        patterns:
+          - "*"
+
+  # GitHub Actions — keeps the SHA-pinned actions current (Dependabot bumps the
+  # pinned SHA and updates the trailing version comment).
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -23,6 +23,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        with:
+          persist-credentials: false
 
       - name: Free disk space
         run: |
@@ -40,7 +42,7 @@ jobs:
       - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
           go-version-file: go.mod
-          cache: true
+          cache: false
 
       - name: Build bench binaries
         working-directory: bench

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -11,6 +11,10 @@ on:
         required: false
         default: ''
 
+# Least-privilege default token.
+permissions:
+  contents: read
+
 jobs:
   benchmark:
     name: CDC Benchmark
@@ -18,7 +22,7 @@ jobs:
     timeout-minutes: 90
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
 
       - name: Free disk space
         run: |
@@ -33,7 +37,7 @@ jobs:
           docker image prune -af --filter "until=1h" 2>/dev/null || true
           df -h /
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
           go-version-file: go.mod
           cache: true
@@ -100,7 +104,7 @@ jobs:
 
       - name: Upload results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: benchmark-${{ github.run_id }}-${{ github.sha }}
           path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
@@ -33,6 +35,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,14 +6,18 @@ on:
   pull_request:
     branches: ["**"]
 
+# Least-privilege default token.
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
           go-version-file: go.mod
           cache: true
@@ -28,9 +32,9 @@ jobs:
     name: Verify pure-Go cross-compilation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
           go-version-file: go.mod
           cache: true

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,6 +21,8 @@ jobs:
       actions: read
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,7 +31,7 @@ jobs:
           cache: true
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@f411752efdf656cb71aa17b755b22c890960da1d # v3.35.5
+        uses: github/codeql-action/init@458d36d7d4f47d0dd16ca424c1d3cda0060f1360 # v3.35.5
         with:
           # Go only. The Rust FFI crate is covered by cargo-audit (rust-audit.yml)
           # to avoid standing up the CGO + cbindgen build path in CI.
@@ -39,11 +39,11 @@ jobs:
           queries: security-extended
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@f411752efdf656cb71aa17b755b22c890960da1d # v3.35.5
+        uses: github/codeql-action/autobuild@458d36d7d4f47d0dd16ca424c1d3cda0060f1360 # v3.35.5
         env:
           CGO_ENABLED: "0"
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@f411752efdf656cb71aa17b755b22c890960da1d # v3.35.5
+        uses: github/codeql-action/analyze@458d36d7d4f47d0dd16ca424c1d3cda0060f1360 # v3.35.5
         with:
           category: "/language:go"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,46 @@
+name: CodeQL
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: ["**"]
+  schedule:
+    # Weekly re-scan so newly published CodeQL queries catch existing code.
+    - cron: "27 4 * * 1"
+
+# Advisory: findings surface in the Security tab; the job is not a required
+# check, so a finding does not block merges. See dependabot.yml / security.yml.
+jobs:
+  analyze:
+    name: CodeQL (Go)
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # upload SARIF to the Security tab
+      contents: read
+      actions: read
+    steps:
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+
+      - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@fc54ff75c9030388b65fbabde476bad39588e069 # v3.27.1
+        with:
+          # Go only. The Rust FFI crate is covered by cargo-audit (rust-audit.yml)
+          # to avoid standing up the CGO + cbindgen build path in CI.
+          languages: go
+          queries: security-extended
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@fc54ff75c9030388b65fbabde476bad39588e069 # v3.27.1
+        env:
+          CGO_ENABLED: "0"
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@fc54ff75c9030388b65fbabde476bad39588e069 # v3.27.1
+        with:
+          category: "/language:go"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,9 +20,10 @@ jobs:
       contents: read
       actions: read
     steps:
-      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
-        with:
-          persist-credentials: false
+      # CodeQL's diff-informed analysis fetches the PR base branch during the
+      # analyze step, which needs the checkout-persisted credentials — so we do
+      # NOT set persist-credentials: false here (unlike every other workflow).
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1 # zizmor: ignore[artipacked]
 
       - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
@@ -30,7 +31,7 @@ jobs:
           cache: true
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@fc54ff75c9030388b65fbabde476bad39588e069 # v3.27.1
+        uses: github/codeql-action/init@f411752efdf656cb71aa17b755b22c890960da1d # v3.35.5
         with:
           # Go only. The Rust FFI crate is covered by cargo-audit (rust-audit.yml)
           # to avoid standing up the CGO + cbindgen build path in CI.
@@ -38,11 +39,11 @@ jobs:
           queries: security-extended
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@fc54ff75c9030388b65fbabde476bad39588e069 # v3.27.1
+        uses: github/codeql-action/autobuild@f411752efdf656cb71aa17b755b22c890960da1d # v3.35.5
         env:
           CGO_ENABLED: "0"
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@fc54ff75c9030388b65fbabde476bad39588e069 # v3.27.1
+        uses: github/codeql-action/analyze@f411752efdf656cb71aa17b755b22c890960da1d # v3.35.5
         with:
           category: "/language:go"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -20,6 +20,8 @@ jobs:
       COVERAGE_THRESHOLD: "50.0"
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: ["**"]
 
+# Least-privilege default token.
+permissions:
+  contents: read
+
 jobs:
   coverage:
     name: Test coverage threshold
@@ -15,9 +19,9 @@ jobs:
       # sits a few points below to absorb noise. Ratchet upward over time.
       COVERAGE_THRESHOLD: "50.0"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
           go-version-file: go.mod
           cache: true
@@ -40,7 +44,7 @@ jobs:
 
       - name: Upload coverage report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: coverage-report
           path: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,6 +21,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: ["**"]
 
+# Least-privilege default token.
+permissions:
+  contents: read
+
 jobs:
   e2e:
     name: End-to-end (binary against live Postgres)
@@ -16,9 +20,9 @@ jobs:
       POSTGRES_TEST_DSN: postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
           go-version-file: go.mod
           cache: true

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -22,6 +22,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: ["**"]
 
+# Least-privilege default token.
+permissions:
+  contents: read
+
 jobs:
   integration:
     name: Integration tests (Postgres + MongoDB)
@@ -17,9 +21,9 @@ jobs:
       MONGO_TEST_URI: mongodb://localhost:27017/?replicaSet=rs0&directConnection=true
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
           go-version-file: go.mod
           cache: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,14 +6,18 @@ on:
   pull_request:
     branches: ["**"]
 
+# Least-privilege default token.
+permissions:
+  contents: read
+
 jobs:
   golangci:
     name: golangci-lint (complexity + dependency rules)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
           go-version-file: go.mod
           cache: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -18,6 +18,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: ["**"]
 
+# Least-privilege default token.
+permissions:
+  contents: read
+
 jobs:
   mutation:
     name: Mutation testing (core packages)
@@ -13,9 +17,9 @@ jobs:
     timeout-minutes: 25
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
           go-version-file: go.mod
           cache: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,22 +5,26 @@ on:
     tags:
       - "v*"
 
+# Least-privilege default; jobs widen only what they need.
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   goreleaser:
     name: Build and release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # goreleaser creates the GitHub Release
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
           go-version-file: go.mod
-          cache: true
+          cache: false
 
       - name: Run goreleaser
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
@@ -38,6 +42,8 @@ jobs:
     environment: kaptanto
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        with:
+          persist-credentials: false
 
       - name: Set up QEMU (for cross-platform builds)
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,17 +13,17 @@ jobs:
     name: Build and release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
           go-version-file: go.mod
           cache: true
 
       - name: Run goreleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
           distribution: goreleaser
           version: "~> v2"
@@ -37,23 +37,23 @@ jobs:
     runs-on: ubuntu-latest
     environment: kaptanto
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
 
       - name: Set up QEMU (for cross-platform builds)
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20 # v3.1.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@f19c3691d56f26e3f97547999df66a9ecbf0d9b0 # v5.1.0
         with:
           images: olucasandrade/kaptanto
           tags: |
@@ -62,7 +62,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@f6010ea70151369b06f0194be1051fbbdff851b2 # v6.0.2
         with:
           context: .
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/rust-audit.yml
+++ b/.github/workflows/rust-audit.yml
@@ -1,0 +1,34 @@
+name: Rust Audit
+
+on:
+  push:
+    branches: ["**"]
+    paths:
+      - "rust/**"
+      - ".github/workflows/rust-audit.yml"
+  pull_request:
+    branches: ["**"]
+    paths:
+      - "rust/**"
+      - ".github/workflows/rust-audit.yml"
+  schedule:
+    # Weekly so freshly published RustSec advisories are caught even without
+    # a code change to the FFI crate.
+    - cron: "27 5 * * 1"
+
+# Advisory: covers the Rust FFI crate that CodeQL deliberately skips.
+jobs:
+  cargo-audit:
+    name: cargo-audit (Rust CVEs)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+
+      - name: cargo-audit
+        continue-on-error: true
+        uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          working-directory: rust/kaptanto-ffi

--- a/.github/workflows/rust-audit.yml
+++ b/.github/workflows/rust-audit.yml
@@ -25,6 +25,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        with:
+          persist-credentials: false
 
       - name: cargo-audit
         continue-on-error: true

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,44 @@
+name: Security
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: ["**"]
+
+# All jobs here are advisory: steps that can flag findings use
+# continue-on-error so a finding never blocks a merge. Results are still
+# visible in job logs and (for gitleaks) the Security tab.
+jobs:
+  govulncheck:
+    name: govulncheck (Go CVEs)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+
+      # Symbol-aware Go vulnerability scan (Go team). Only flags CVEs in code
+      # paths actually reachable from this module. Advisory.
+      - name: govulncheck
+        continue-on-error: true
+        uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4
+        with:
+          go-version-file: go.mod
+
+  gitleaks:
+    name: gitleaks (secret scan)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write # upload SARIF to the Security tab
+    steps:
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        with:
+          fetch-depth: 0 # full history so gitleaks can scan all commits
+
+      - name: gitleaks
+        continue-on-error: true
+        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2.3.9
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -17,6 +17,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        with:
+          persist-credentials: false
 
       # Symbol-aware Go vulnerability scan (Go team). Only flags CVEs in code
       # paths actually reachable from this module. Advisory.
@@ -36,6 +38,7 @@ jobs:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
         with:
           fetch-depth: 0 # full history so gitleaks can scan all commits
+          persist-credentials: false
 
       - name: gitleaks
         continue-on-error: true

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,29 @@
+name: Workflow SAST
+
+on:
+  push:
+    branches: ["**"]
+    paths:
+      - ".github/**"
+  pull_request:
+    branches: ["**"]
+    paths:
+      - ".github/**"
+
+# Advisory: zizmor statically analyses the workflow files themselves for
+# injection, excessive permissions, unpinned actions, etc.
+jobs:
+  zizmor:
+    name: zizmor (GitHub Actions SAST)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write # upload SARIF to the Security tab
+    steps:
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+
+      - name: zizmor
+        continue-on-error: true
+        uses: zizmorcore/zizmor-action@e639db99335bc9038abc0e066dfcd72e23d26fb4 # v0.3.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -21,6 +21,8 @@ jobs:
       security-events: write # upload SARIF to the Security tab
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        with:
+          persist-credentials: false
 
       - name: zizmor
         continue-on-error: true


### PR DESCRIPTION
Adds a non-redundant, **advisory** security CI stack and hardens existing workflows. Nothing here blocks merges — findings surface in job logs and the GitHub **Security** tab.

## New scanners
| Workflow | Tool | Covers |
|---|---|---|
| `codeql.yml` | CodeQL (`security-extended`) | Go SAST. Go-only — Rust handled below to avoid the CGO+cbindgen build path in CI. |
| `security.yml` | **govulncheck** | Go CVEs, symbol-aware (only reachable code paths) |
| `security.yml` | **gitleaks** | committed secrets (full history), SARIF → Security tab |
| `rust-audit.yml` | **cargo-audit** | RustSec advisories for `rust/kaptanto-ffi` |
| `zizmor.yml` | **zizmor** | SAST on the workflow files themselves (injection, perms, pinning) |

All finding-producing steps use `continue-on-error: true` → advisory.

## Dependency updates
`dependabot.yml`: `gomod` + `cargo` + `github-actions`, **weekly**, **grouped** (one PR per ecosystem) to keep the large dep tree from flooding the queue.

## Supply-chain hardening (existing workflows)
- **Every action pinned to a full commit SHA** (with trailing version comment); Dependabot keeps the SHAs current.
- **Least-privilege** top-level `permissions: contents: read` added to all workflows that lacked one.

## Deliberately omitted
- **gosec** — overlaps CodeQL and is already enabled via golangci-lint.
- **CodeQL for Rust** — would require building the FFI crate (CGO); `cargo-audit` covers Rust CVEs instead.

## Notes
- New scanners are intentionally **not** required checks. Make them required only after triaging baseline findings.
- `gitleaks-action` is free for public/personal repos; no license secret needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
No blocking correctness, durability, or security issues stood out from the described changes.

Main risk to keep an eye on:
- The new advisory security workflows are intentionally non-blocking (`continue-on-error: true`), so findings rely on log/Security tab review and won’t stop merges.
- Several workflows now use `cache: false` / `persist-credentials: false`; that’s the right hardening direction, but it’s worth confirming release/benchmark jobs still have acceptable runtime and all jobs that need repo access continue to function with pinned SHAs.

I’d recommend adding or confirming coverage for the new security workflows themselves (smoke validation that each job uploads/renders results as expected) and keeping an eye on any future workflow edits to avoid reintroducing mutable action refs or over-broad permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->