### PR TITLE
test(bench): fix scenario count test and run bench module tests in CI

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       scenarios:
-        description: 'Comma-separated scenarios (empty = all 5: steady,burst,large-batch,crash-recovery,idle)'
+        description: 'Comma-separated scenarios (empty = all 6: steady,burst,large-batch,crash-recovery,idle,cluster)'
         required: false
         default: ''
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,31 @@ jobs:
       - name: go test
         run: CGO_ENABLED=0 go test ./... -v -count=1 -timeout 120s
 
+  bench-test:
+    name: Bench module tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version-file: bench/go.mod
+          cache: true
+
+      # bench/ is a separate Go module (bench/go.mod), so the root `go test
+      # ./...` above never descends into it. This runs the harness's own
+      # regression tests (percentile math, metrics parser, collector
+      # adapters, scenario registry) — no Docker required, ~10s.
+      - name: go vet
+        working-directory: bench
+        run: CGO_ENABLED=0 go vet ./...
+
+      - name: go test
+        working-directory: bench
+        run: CGO_ENABLED=0 go test ./... -count=1
+
   race:
     name: Race detector
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: go test
         working-directory: bench
-        run: CGO_ENABLED=0 go test ./... -count=1
+        run: CGO_ENABLED=0 go test ./... -count=1 -timeout 120s
 
   race:
     name: Race detector

--- a/bench/README.md
+++ b/bench/README.md
@@ -35,7 +35,7 @@ All entries should show `(healthy)` status.
 go run ./cmd/scenarios -- --scenario steady
 ```
 
-Available scenarios: `steady`, `burst`, `large-batch`, `crash-recovery`, `idle`.
+Available scenarios: `steady`, `burst`, `large-batch`, `crash-recovery`, `idle`, `cluster`.
 
 Results are written to `bench/results/`. After the run:
 

--- a/bench/internal/reporter/aggregator.go
+++ b/bench/internal/reporter/aggregator.go
@@ -9,7 +9,7 @@ import (
 )
 
 var canonicalTools = []string{"kaptanto", "kaptanto-rust", "kaptanto-kafka", "kaptanto-nats", "debezium", "debezium-connector", "sequin", "peerdb"}
-var canonicalScenarios = []string{"steady", "burst", "large-batch", "crash-recovery", "idle"}
+var canonicalScenarios = []string{"steady", "burst", "large-batch", "crash-recovery", "idle", "cluster"}
 
 // ScenarioStats holds the aggregated statistics for a single (tool, scenario) pair.
 type ScenarioStats struct {

--- a/bench/internal/scenarios/runner.go
+++ b/bench/internal/scenarios/runner.go
@@ -20,7 +20,7 @@ type ScenarioDef struct {
 	PostWaitS   int      // seconds to wait after loadgen finishes, before writing the END marker
 }
 
-// Scenarios is the canonical ordered list of all five benchmark scenarios.
+// Scenarios is the canonical ordered list of all six benchmark scenarios.
 var Scenarios = []ScenarioDef{
 	{
 		Name:        "steady",

--- a/bench/internal/scenarios/runner_test.go
+++ b/bench/internal/scenarios/runner_test.go
@@ -160,15 +160,23 @@ func TestBuildLoadgenCmd(t *testing.T) {
 	}
 }
 
-// Test 6: Scenarios slice has exactly 5 entries with names: steady, burst, large-batch, crash-recovery, idle
-func TestScenariosCount(t *testing.T) {
-	if len(Scenarios) != 5 {
-		t.Fatalf("expected 5 scenarios, got %d", len(Scenarios))
-	}
-}
+// Test 6: Scenarios slice matches the documented registry exactly, in order.
+//
+// This asserts the full named set rather than a bare length, so adding or
+// removing a scenario fails with a readable name diff instead of an opaque
+// count mismatch. Updating expectedNames here must be paired with updating
+// the docs that enumerate the scenario set: .github/workflows/benchmark.yml
+// (workflow_dispatch "scenarios" input description) and bench/README.md.
+func TestScenarioRegistry(t *testing.T) {
+	expectedNames := []string{"steady", "burst", "large-batch", "crash-recovery", "idle", "cluster"}
 
-func TestScenarioDefs(t *testing.T) {
-	expectedNames := []string{"steady", "burst", "large-batch", "crash-recovery", "idle"}
+	if len(Scenarios) != len(expectedNames) {
+		gotNames := make([]string, len(Scenarios))
+		for i, s := range Scenarios {
+			gotNames[i] = s.Name
+		}
+		t.Fatalf("Scenarios registry drifted from documented set: expected %v, got %v", expectedNames, gotNames)
+	}
 	for i, name := range expectedNames {
 		if Scenarios[i].Name != name {
 			t.Errorf("Scenarios[%d].Name: expected %q, got %q", i, name, Scenarios[i].Name)


### PR DESCRIPTION
## Source fix plan
`.claude/fix-plans/benchmark-testing-20260702-181558.md`

## Problem

`bench/` is a separate Go module (`bench/go.mod`), so the root `go test ./...` in `ci.yml` never descends into it, and `.github/workflows/benchmark.yml` only builds the bench binaries and runs Docker scenarios — it never runs `go test` inside `bench/`. As a result the bench harness's own regression tests (percentile math in `internal/reporter`, the metrics parser, collector adapters, the scenario runner) were dead code in CI.

Proof this was live: `cd bench && go test ./...` failed before this change — `TestScenariosCount` (`bench/internal/scenarios/runner_test.go:166`) asserted exactly 5 scenarios, but the registry (`bench/internal/scenarios/runner.go`) has 6. Checked git history: the 6th scenario (`cluster`) was added intentionally in `a113a78` ("feat(quick-001-03): add cluster scenario and two-node compose services") for HA/cluster testing — it was never a leftover, just an untracked drift because nothing ran this test in CI.

`.github/workflows/benchmark.yml`'s `workflow_dispatch` description and `bench/README.md` also still documented "all 5" scenarios.

## Implementation

1. **Fixed the failing test**: replaced `TestScenariosCount` (hardcoded `len(Scenarios) != 5`) and the separate `TestScenarioDefs` with a single `TestScenarioRegistry` that asserts the full documented name set (`steady, burst, large-batch, crash-recovery, idle, cluster`) against the registry, in order. A future scenario addition/removal now fails with a readable name diff instead of an opaque count mismatch, and the test comment points at the docs (`benchmark.yml`, `bench/README.md`) that must be updated alongside it.
2. Updated the `Scenarios` doc comment in `bench/internal/scenarios/runner.go` ("all five" → "all six").
3. Corrected `.github/workflows/benchmark.yml`'s `workflow_dispatch` description and `bench/README.md`'s "Available scenarios" line to list `cluster`.
4. Added a `bench-test` job to `.github/workflows/ci.yml` that runs `go vet ./...` and `go test ./... -count=1` with `working-directory: bench`, using `go-version-file: bench/go.mod` (bench pins `go 1.25.0`, root pins `1.25.8` — using bench's own go.mod avoids relying on that compatibility). No Docker required; runs in a few seconds alongside the existing `test`/`race`/`verify-no-cgo` jobs.

## Validation

Before (on the pre-fix code, reproduced locally):
```
$ cd bench && go test ./... -count=1
...
--- FAIL: TestScenariosCount (0.00s)
    runner_test.go:166: expected 5 scenarios, got 6
FAIL
FAIL	github.com/olucasandrade/kaptanto/bench/internal/scenarios	1.585s
FAIL
```

After:
```
$ cd bench && CGO_ENABLED=0 go test ./... -count=1
ok  	github.com/olucasandrade/kaptanto/bench/internal/collector	0.765s
ok  	github.com/olucasandrade/kaptanto/bench/internal/collector/adapters	0.604s
ok  	github.com/olucasandrade/kaptanto/bench/internal/reporter	0.966s
ok  	github.com/olucasandrade/kaptanto/bench/internal/scenarios	1.298s
ok  	github.com/olucasandrade/kaptanto/bench/internal/statsd	1.601s
PASS
```

```
$ cd bench && go vet ./...
(no output — clean)
```

Gap-proofing check (scratch edit, reverted, not committed): temporarily inserted a 7th scenario into the registry and reran `TestScenarioRegistry` — it failed with:
```
runner_test.go:178: Scenarios registry drifted from documented set: expected [steady burst large-batch crash-recovery idle cluster], got [steady burst large-batch crash-recovery idle hypothetical-seventh cluster]
```
confirming the new test catches registry drift with an actionable diff rather than silently passing or emitting an opaque count mismatch. Restored the file before committing (`git diff` showed no residual change from this check).

Also validated workflow YAML syntax for both modified files (`ci.yml`, `benchmark.yml`) parses cleanly.

## Residual risk / follow-up

- The optional hardening item from the fix plan (adding `bench` to the root `race` job, i.e. `cd bench && go test ./... -race`) was left out — it's explicitly marked optional in the plan and out of scope for the two required items; can be a fast follow if the collector's concurrency needs race coverage in CI.
- `bench-test` uses `go-version-file: bench/go.mod` rather than the root `go.mod`, matching the plan's stated risk mitigation; if bench's Go version pin is bumped independently of root, no action is needed since the job reads it directly.
- This PR does not touch the Docker-based `benchmark.yml` scenario run itself (still requires Docker Compose, unchanged) — only its documentation string.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- low — `.github/workflows/benchmark.yml`, `bench/internal/scenarios/runner_test.go`, and `bench/internal/scenarios/runner.go` now consistently define the full six-scenario set (`steady, burst, large-batch, crash-recovery, idle, cluster`). `bench/README.md` is aligned as well: its “Available scenarios” list includes both `crash-recovery` and `cluster`, so the previously noted README mismatch is no longer present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->