### PR TITLE
ci(mutation): per-package efficacy ratchet, gate parser crash failures, add internal/pk

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -27,33 +27,19 @@ jobs:
           cache: true
 
       - name: Install gremlins
-        run: go install github.com/go-gremlins/gremlins/cmd/gremlins@v0.5.0
+        run: |
+          go install github.com/go-gremlins/gremlins/cmd/gremlins@v0.5.0
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
-      # Gated: must meet threshold-efficacy from .gremlins.yaml (60%).
-      # Baselines: router 100%, backfill ~92%, eventlog ~73%.
-      - name: Run mutation testing (gated)
+      # Runs the exact same per-package thresholds as `make mutation` — the
+      # Makefile is the single source of truth, so CI and local runs cannot
+      # drift apart. router/eventlog/backfill/pk are gated at their own
+      # ratcheted --threshold-efficacy; parser/pgoutput is report-only (its FFI
+      # shim is unreachable under the pure-Go test build, tanking its score as
+      # a tooling artifact). No continue-on-error: a crashed/erroring gremlins
+      # run fails this job even for the report-only package — only the score
+      # itself is non-gating there.
+      - name: Run mutation testing
         env:
           CGO_ENABLED: "0"
-        run: |
-          set -e
-          gremlins="$(go env GOPATH)/bin/gremlins"
-          for pkg in ./internal/router ./internal/eventlog ./internal/backfill; do
-            echo "::group::gremlins (gated) $pkg"
-            "$gremlins" unleash "$pkg"
-            echo "::endgroup::"
-          done
-
-      # Report-only: gremlins mutates the //go:build rust FFI file that the
-      # pure-Go test build can't cover, so its efficacy is an artifact (~0%).
-      # The score is non-gating (--threshold-* 0); continue-on-error keeps a
-      # broken mutation run from blocking the job while still surfacing it as a
-      # warning annotation (rather than swallowing it with `|| true`).
-      - name: Run mutation testing (parser/pgoutput, report-only)
-        continue-on-error: true
-        env:
-          CGO_ENABLED: "0"
-        run: |
-          set -e
-          "$(go env GOPATH)/bin/gremlins" unleash \
-            --threshold-efficacy 0 --threshold-mutant-coverage 0 \
-            ./internal/parser/pgoutput
+        run: make mutation

--- a/.gremlins.yaml
+++ b/.gremlins.yaml
@@ -1,22 +1,43 @@
 # gremlins mutation-testing configuration.
 #
 # Mutation testing runs per-package over the highest-value correctness packages
-# (see .github/workflows/mutation.yml). Measured baselines: router 100%,
-# backfill ~92%, eventlog ~73% test efficacy — so the gate is 60%, comfortably
-# below the weakest gated package to absorb run-to-run noise (e.g. timed-out
-# mutants). Ratchet upward as efficacy improves.
+# (see Makefile's `mutation` target — the single source of truth for which
+# packages run and at what threshold; .github/workflows/mutation.yml invokes
+# `make mutation` directly so CI and local runs cannot drift apart).
 #
-# parser/pgoutput is run report-only (overridden in the workflow): gremlins
-# mutates the //go:build rust FFI file (ffi_rust.go) that the pure-Go test build
-# cannot cover, which drives its reported efficacy to ~0% — a tooling artifact,
-# not a real coverage gap.
+# Measured baselines: router 100%, backfill ~92% (of the minority of mutants
+# that are covered — threshold-mutant-coverage stays 0 below, see note),
+# eventlog ~73% test efficacy. pk measured 60% (3 killed / 2 lived / 2 not
+# covered — only 5 viable mutants total, so one mutant is 20 points of swing).
+# Rather than one shared floor, the Makefile ratchets each package's
+# --threshold-efficacy a few points under its own baseline:
+#   router 90, eventlog 65, backfill 75 (wider headroom than "a few points
+#   under 92" because most of the package is untested — threshold-mutant-
+#   coverage 0 means backfill's efficacy score is computed over a small
+#   covered-mutant sample, which is noisier run to run), pk 40 (a full
+#   mutant's worth of headroom under its measured 60%, since pk's tiny viable
+#   population makes each mutant worth 20 points).
+# The 60 below is only the fallback default for any invocation that doesn't
+# pass an explicit --threshold-efficacy flag. Ratchet the Makefile's
+# per-package values upward as efficacy improves and gets re-measured.
+#
+# parser/pgoutput is run report-only (overridden in the Makefile and CI
+# workflow): gremlins mutates the //go:build rust FFI file (ffi_rust.go) that
+# the pure-Go test build cannot cover, which drives its reported efficacy to
+# ~0% — a tooling artifact, not a real coverage gap. Report-only means the
+# *score* doesn't gate; a crashed/erroring gremlins run on this package still
+# fails the target (no continue-on-error, no `|| true`).
 unleash:
   dry-run: false
   # No special build tags: the targeted packages compile and test under the
   # default pure-Go build.
   tags: ""
   # Gating thresholds. threshold-mutant-coverage stays 0 (uncovered build-tagged
-  # code would otherwise trip it); the gate is on test efficacy.
+  # code, and backfill's largely-untested snapshot engine, would otherwise trip
+  # it — raising this is tracked separately, sequenced behind raising
+  # backfill's unit-test coverage). threshold-efficacy here is only the
+  # fallback for invocations without a per-package flag; see the Makefile's
+  # `mutation` target for the actual per-package values.
   threshold-efficacy: 60
   threshold-mutant-coverage: 0
 

--- a/Makefile
+++ b/Makefile
@@ -111,4 +111,4 @@ mutation:
 	echo "=== gremlins ./internal/pk (efficacy >= 40) ==="; \
 	gremlins unleash --threshold-efficacy 40 ./internal/pk; \
 	echo "=== gremlins ./internal/parser/pgoutput (report-only) ==="; \
-	gremlins unleash --threshold-efficacy 0 --threshold-mutant-coverage 0 ./internal/parser/pgoutput
+	gremlins unleash --threshold-efficacy 0 --threshold-mcover 0 ./internal/parser/pgoutput

--- a/Makefile
+++ b/Makefile
@@ -88,9 +88,27 @@ test-integration:
 test-e2e:
 	CGO_ENABLED=0 go test -tags e2e ./test/e2e/... -count=1 -timeout 300s -v
 
-# mutation runs gremlins over the core correctness packages. Config in .gremlins.yaml.
+# mutation runs gremlins over the core correctness packages. Base config in
+# .gremlins.yaml; per-package --threshold-efficacy values below ratchet above
+# its 60% fallback toward each package's measured baseline (see .gremlins.yaml
+# comment for the baselines and rationale). This target is the single source
+# of truth for those thresholds — .github/workflows/mutation.yml invokes it
+# directly so CI and local runs cannot drift apart.
+#
+# parser/pgoutput runs report-only: its FFI shim (ffi_rust.go, //go:build rust)
+# is unreachable under the pure-Go test build, which tanks its efficacy score
+# as a tooling artifact rather than a real coverage gap. `set -e` still fails
+# this target if that gremlins invocation crashes/errors — only its score is
+# non-gating.
 mutation:
-	@for pkg in ./internal/router ./internal/eventlog ./internal/parser/pgoutput ./internal/backfill; do \
-		echo "=== gremlins $$pkg ==="; \
-		gremlins unleash $$pkg || exit 1; \
-	done
+	@set -e; \
+	echo "=== gremlins ./internal/router (efficacy >= 90) ==="; \
+	gremlins unleash --threshold-efficacy 90 ./internal/router; \
+	echo "=== gremlins ./internal/eventlog (efficacy >= 65) ==="; \
+	gremlins unleash --threshold-efficacy 65 ./internal/eventlog; \
+	echo "=== gremlins ./internal/backfill (efficacy >= 75) ==="; \
+	gremlins unleash --threshold-efficacy 75 ./internal/backfill; \
+	echo "=== gremlins ./internal/pk (efficacy >= 40) ==="; \
+	gremlins unleash --threshold-efficacy 40 ./internal/pk; \
+	echo "=== gremlins ./internal/parser/pgoutput (report-only) ==="; \
+	gremlins unleash --threshold-efficacy 0 --threshold-mutant-coverage 0 ./internal/parser/pgoutput


### PR DESCRIPTION
## Source fix plan
`.claude/fix-plans/mutation-testing-20260702-181558.md` (source report: `.claude/reports/kaptanto-test-strictness-review-20260702-181558.md`)

## Problem
Gremlins mutation testing had three independent gaps:
1. A single global `threshold-efficacy: 60` sat 13–40 points below every measured per-package baseline (router 100%, backfill ~92%, eventlog ~73%) with no ratchet, so a large real decay in test strength could pass.
2. `parser/pgoutput` was doubly contradictory: CI ran it report-only *and* with `continue-on-error: true` (swallowing even a crashed/erroring gremlins invocation), while `make mutation` gated it at 60% locally — a contributor's local run could fail where CI silently shrugged.
3. `internal/pk` (canonical key encoding that feeds the FNV-1a partitioning behind RTR-04/BKF-02, 74.4% statement coverage) was entirely outside mutation scope.

This PR is scoped to items independent of the separate `fix/unit-testing` branch (which raises backfill and checkpoint coverage). Raising `threshold-mutant-coverage` above 0 for backfill and adding `internal/checkpoint` to scope both depend on that branch landing first and are explicitly deferred (see Residual risk below).

## Implementation
- **`.gremlins.yaml`**: rewrote the header comment to document the per-package threshold rationale and baselines; the file's `threshold-efficacy: 60` is now only the fallback for invocations without an explicit `--threshold-efficacy` flag. `threshold-mutant-coverage` stays 0 (unchanged — raising it is the deferred, dependent item).
- **`Makefile`**: the `mutation` target now passes explicit `--threshold-efficacy` per package instead of one shared gate:
  - `router` → 90 (10 under its 100% baseline)
  - `eventlog` → 65 (8 under its ~73% baseline)
  - `backfill` → 75 (wider headroom under its ~92% baseline — `threshold-mutant-coverage` stays 0, so backfill's efficacy is computed over a small covered-mutant sample, which is noisier run to run)
  - `pk` (new) → 40 (a full mutant's worth of headroom under a locally measured 60% — pk has only 5 viable mutants total, so each one is worth 20 points; see Validation below)
  - `parser/pgoutput` → report-only (`--threshold-efficacy 0 --threshold-mutant-coverage 0`), unchanged in intent, but now consistent with CI
  - This target is now the single source of truth for thresholds.
- **`.github/workflows/mutation.yml`**: collapsed the two duplicated steps (a hardcoded gated loop + a `continue-on-error: true` report-only step) into one step that installs gremlins, adds `GOPATH/bin` to `GITHUB_PATH`, and runs `make mutation`. This removes `continue-on-error` entirely — a crashed/erroring gremlins run now fails the job even for the report-only parser package, while the parser's *score* still doesn't gate. CI and local can no longer drift apart because they run the identical Makefile target.

## Validation
Ran from the worktree at `/Users/lucasandrade/kaptanto-fix-mutation-testing` (gremlins not preinstalled; installed via `go install github.com/go-gremlins/gremlins/cmd/gremlins@v0.5.0`):

- `CGO_ENABLED=0 go test ./internal/pk/... -count=1 -v` → **PASS** (all subtests green, 74.4% statement coverage confirmed)
- `CGO_ENABLED=0 go test ./internal/router/... ./internal/eventlog/... -count=1` → **PASS** (both packages ok)
- `ruby -e "require 'yaml'; YAML.load_file('.gremlins.yaml'); YAML.load_file('.github/workflows/mutation.yml')"` → **PASS** (both files parse as valid YAML)
- `make -n mutation` → confirms the recipe expands to the intended 5 per-package `gremlins unleash` invocations with correct flags
- `gremlins unleash --threshold-efficacy 40 ./internal/pk` (actual gremlins run, not a dry-run) → **PASS**, first clean run measured 3 killed / 2 lived / 2 not-covered = 60.00% test efficacy, comfortably above the new 40% gate. Two subsequent repeat runs in this sandbox timed out all viable mutants (0.00% reported) due to local resource contention but still exited 0 — gremlins appears not to hard-fail the gate when the covered-mutant sample collapses to all-timeouts. This is sandbox-specific noise, not a config defect, but it's a live demonstration of the exact "timed-out mutant" flakiness the fix plan's own Risks section calls out, and part of why `pk`'s threshold has a full mutant's headroom rather than sitting at the exact measured value.

## Residual risk / follow-up
- **Deferred, sequenced behind `fix/unit-testing`**: raising `threshold-mutant-coverage` above 0 for `internal/backfill` (currently invisible NOT_COVERED mutants across the untested majority of the snapshot engine) requires backfill's unit coverage to rise first — implementing it now would fail CI against today's unimproved coverage.
- **Deferred, same dependency**: adding `internal/checkpoint` to mutation scope depends on that package's coverage rising from its current 38.5% via the same `fix/unit-testing` branch.
- **Not done (optional, deeper fix)**: package-splitting the FFI shim (`ffi_rust.go`/`ffi_stub.go`) out of `parser/pgoutput` so that package can be gated on real thresholds instead of running report-only. The plan flagged this as "do only if straightforward"; it touches production file layout and build-tag semantics (`//go:build rust` vs stub) and depguard config, so it was left out of this focused change.
- **Job runtime**: adding `internal/pk` lengthens the mutation job slightly; the existing 25-minute CI timeout wasn't changed since `pk` is small, but worth watching on the first real CI run.
- **`pk` threshold has no historical baseline** beyond the single local measurement in this PR (30% headroom is a full-mutant margin given only 5 viable mutants) — re-measure and ratchet once CI has run it a few times.