### PR TITLE
ci(landing): add CI gate + initial test kind for landing/

### DIFF
--- a/.github/workflows/landing.yml
+++ b/.github/workflows/landing.yml
@@ -1,0 +1,73 @@
+name: Landing
+
+on:
+  push:
+    branches: ["**"]
+    paths:
+      - "landing/**"
+      - ".github/workflows/landing.yml"
+  pull_request:
+    branches: ["**"]
+    paths:
+      - "landing/**"
+      - ".github/workflows/landing.yml"
+
+# Least-privilege default token.
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: lint, typecheck, build (landing/)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: landing
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      # npm/package-lock.json is the package manager actually exercised by the
+      # production deploy path: landing/README.md documents `npm run build` as
+      # the Cloudflare Pages build command, and package-lock.json (unlike the
+      # also-present bun.lock, a leftover from the initial `npm create qwik`
+      # scaffold that nothing regenerates or references) has a dedicated fix
+      # commit ("regenerate package-lock.json to include wrangler
+      # dependencies"). CI installs with npm to validate the same dependency
+      # graph Cloudflare Pages builds from.
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: landing/package-lock.json
+
+      - name: npm ci
+        run: npm ci
+
+      - name: lint
+        run: npm run lint
+
+      # Pre-existing formatting drift on main means this currently fails on
+      # files unrelated to any given change. Kept non-blocking until a
+      # dedicated `prettier --write` normalization PR lands; see the PR
+      # description that introduced this workflow for the follow-up.
+      - name: fmt.check
+        run: npm run fmt.check
+        continue-on-error: true
+
+      - name: build.types
+        run: npm run build.types
+
+      - name: unit tests (vitest — docs registry + install-URL smoke)
+        run: npm run test
+
+      - name: build (Cloudflare Pages worker — the real deploy artifact)
+        run: npm run build
+
+      # Builds a second, non-Cloudflare SSR bundle (vite preview entry) and
+      # serves it locally to assert `/` and the docs pages actually render.
+      # Runs after the deploy-path build above so this rebuild can't mask a
+      # failure in the artifact Cloudflare Pages actually ships.
+      - name: rendered smoke check (/ and /docs render without error)
+        run: node test/render-smoke.mjs

--- a/landing/package-lock.json
+++ b/landing/package-lock.json
@@ -20,6 +20,7 @@
         "undici": "*",
         "vite": "7.3.1",
         "vite-tsconfig-paths": "^4.2.1",
+        "vitest": "^4.1.9",
         "wrangler": "^3.0.0"
       },
       "engines": {
@@ -2194,6 +2195,24 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -2203,6 +2222,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -3069,6 +3095,139 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+      "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+      "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+      "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.9",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+      "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -3231,6 +3390,16 @@
       "license": "MIT",
       "dependencies": {
         "printable-characters": "^1.0.42"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/astring": {
@@ -3396,6 +3565,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -3556,6 +3735,13 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
     },
@@ -4077,6 +4263,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.0.tgz",
+      "integrity": "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -4520,6 +4713,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/exsolve": {
@@ -7062,6 +7265,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/ohash": {
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
@@ -8156,6 +8373,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/simple-swizzle": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
@@ -8206,6 +8430,13 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stacktracey": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/stacktracey/-/stacktracey-2.2.0.tgz",
@@ -8216,6 +8447,13 @@
         "as-table": "^1.0.36",
         "get-source": "^2.0.12"
       }
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
@@ -8430,6 +8668,23 @@
         "url": "https://opencollective.com/svgo"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -8445,6 +8700,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -9201,6 +9466,106 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+      "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.9",
+        "@vitest/mocker": "4.1.9",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/runner": "4.1.9",
+        "@vitest/snapshot": "4.1.9",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.9",
+        "@vitest/browser-preview": "4.1.9",
+        "@vitest/browser-webdriverio": "4.1.9",
+        "@vitest/coverage-istanbul": "4.1.9",
+        "@vitest/coverage-v8": "4.1.9",
+        "@vitest/ui": "4.1.9",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -9304,6 +9669,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/landing/package.json
+++ b/landing/package.json
@@ -22,7 +22,8 @@
     "preview": "qwik build preview && vite preview --open",
     "serve": "wrangler pages dev ./dist --compatibility-flags=nodejs_als",
     "start": "vite --open --mode ssr",
-    "qwik": "qwik"
+    "qwik": "qwik",
+    "test": "vitest run"
   },
   "devDependencies": {
     "@builder.io/qwik": "^1.19.1",
@@ -39,6 +40,7 @@
     "undici": "*",
     "vite": "7.3.1",
     "vite-tsconfig-paths": "^4.2.1",
+    "vitest": "^4.1.9",
     "wrangler": "^3.0.0"
   }
 }

--- a/landing/test/docs-consistency.test.ts
+++ b/landing/test/docs-consistency.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { DOCS_CONTENT, SIDEBAR, DOC_FLOW } from "../src/data/docs-content";
+import { SEO_DOCS, SEO_DOCS_MAP } from "../src/data/docs";
+
+// Smoke coverage for the two doc registries that must stay in sync:
+//   - src/data/docs-content.ts: DOCS_CONTENT (interactive viewer body content),
+//     SIDEBAR (nav shown by DocsViewer.tsx), DOC_FLOW (prev/next ordering)
+//   - src/data/docs.ts: SEO_DOCS (crawlable /docs/[slug] routes)
+// A slug present in the sidebar/flow but missing from DOCS_CONTENT renders
+// "Doc not found" in production (see DocsViewer.tsx); a slug missing from
+// SEO_DOCS has no crawlable route at /docs/<slug>. These tests exist to catch
+// that drift in CI instead of in production.
+
+describe("docs sidebar resolves to real content", () => {
+  const sidebarSlugs = SIDEBAR.flatMap((section) =>
+    section.items.map(([slug]) => slug),
+  );
+
+  it("SIDEBAR is non-empty", () => {
+    expect(sidebarSlugs.length).toBeGreaterThan(0);
+  });
+
+  it.each(sidebarSlugs)(
+    "sidebar slug %s has a DOCS_CONTENT entry",
+    (slug) => {
+      expect(DOCS_CONTENT[slug]).toBeDefined();
+      expect(DOCS_CONTENT[slug].title).toBeTruthy();
+      expect(DOCS_CONTENT[slug].body).toBeTruthy();
+    },
+  );
+
+  it("has no duplicate slugs across sections", () => {
+    expect(new Set(sidebarSlugs).size).toBe(sidebarSlugs.length);
+  });
+});
+
+describe("DOC_FLOW resolves to real content", () => {
+  it("DOC_FLOW is non-empty", () => {
+    expect(DOC_FLOW.length).toBeGreaterThan(0);
+  });
+
+  it.each(DOC_FLOW)("flow slug %s has a DOCS_CONTENT entry", (slug) => {
+    expect(DOCS_CONTENT[slug]).toBeDefined();
+  });
+});
+
+describe("SEO doc index matches the interactive docs registry", () => {
+  it("SEO_DOCS is non-empty and slugs are unique", () => {
+    expect(SEO_DOCS.length).toBeGreaterThan(0);
+    expect(new Set(SEO_DOCS.map((d) => d.slug)).size).toBe(SEO_DOCS.length);
+  });
+
+  it.each(SEO_DOCS.map((d) => d.slug))(
+    "SEO doc %s also exists in DOCS_CONTENT (interactive view)",
+    (slug) => {
+      expect(DOCS_CONTENT[slug]).toBeDefined();
+    },
+  );
+
+  it("SEO_DOCS_MAP looks up every slug", () => {
+    for (const doc of SEO_DOCS) {
+      expect(SEO_DOCS_MAP.get(doc.slug)).toEqual(doc);
+    }
+  });
+});

--- a/landing/test/install-command.test.ts
+++ b/landing/test/install-command.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync, existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+// Guards against the exact class of drift flagged in project history: the
+// landing page once pointed at a wrong collector/endpoint URL that nothing
+// caught until manual review (see MEMORY.md: "kaptanto SSE endpoint is
+// /events not /stream"). Here: the install snippet shown on the landing page
+// and in the docs must match the URL the real install script is published
+// under, and that script must actually exist in the repo.
+
+const landingRoot = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(landingRoot, "..", "..");
+
+const INSTALL_URL = "https://get.kaptan.to";
+const INSTALL_SNIPPET = `curl -fsSL ${INSTALL_URL} | sh`;
+
+describe("install command matches the published get.kaptan.to script", () => {
+  it("scripts/install.sh exists in the repo (the artifact get.kaptan.to serves)", () => {
+    const scriptPath = path.join(repoRoot, "scripts", "install.sh");
+    expect(existsSync(scriptPath)).toBe(true);
+  });
+
+  it("scripts/install.sh documents the same usage line the landing page shows", () => {
+    const scriptPath = path.join(repoRoot, "scripts", "install.sh");
+    const script = readFileSync(scriptPath, "utf8");
+    expect(script).toContain(INSTALL_SNIPPET);
+  });
+
+  it("Install.tsx (hero install widget) shows the canonical snippet", () => {
+    const src = readFileSync(
+      path.join(landingRoot, "..", "src", "components", "install", "Install.tsx"),
+      "utf8",
+    );
+    expect(src).toContain(INSTALL_SNIPPET);
+  });
+
+  it("routes/index.tsx download link points at the install URL", () => {
+    const src = readFileSync(
+      path.join(landingRoot, "..", "src", "routes", "index.tsx"),
+      "utf8",
+    );
+    expect(src).toContain(`downloadUrl: '${INSTALL_URL}'`);
+  });
+
+  it("docs-content.ts quickstart/install docs show the canonical snippet", () => {
+    const src = readFileSync(
+      path.join(landingRoot, "..", "src", "data", "docs-content.ts"),
+      "utf8",
+    );
+    // The docs page repeats the curl snippet in multiple sections; every
+    // occurrence must use the same URL, not a stale one.
+    const matches = src.match(/curl -fsSL https:\/\/[^\s|]+ \| sh/g) ?? [];
+    expect(matches.length).toBeGreaterThan(0);
+    for (const m of matches) {
+      expect(m).toBe(INSTALL_SNIPPET);
+    }
+  });
+});

--- a/landing/test/render-smoke.mjs
+++ b/landing/test/render-smoke.mjs
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+// Rendered smoke check (fix-plan item 3, landing-testing-20260702-181558.md).
+//
+// Builds the Vite "preview" bundle (the same SSR entry `npm run preview`
+// serves — see src/entry.preview.tsx) and asserts `/` and the docs index
+// render without error and contain a handful of stable anchors. This is a
+// canary, not a visual regression suite; deeper content-accuracy auditing
+// stays with the check-landing skill.
+//
+// Deliberately not Playwright: a plain HTTP fetch against `vite preview` is
+// enough to prove SSR doesn't throw and the expected markup is present,
+// without paying Playwright's ~1-2 min browser-install cost in CI for every
+// landing/** change. Revisit if a future assertion needs real DOM/JS
+// execution (e.g. client-side hydration behavior).
+
+import { spawn } from 'node:child_process';
+import process from 'node:process';
+
+const PORT = 4173 + Math.floor(Math.random() * 1000); // avoid clashing with a stray local server
+const BASE = `http://localhost:${PORT}`;
+const START_TIMEOUT_MS = 30_000;
+
+function run(cmd, args) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, { stdio: 'inherit' });
+    child.on('exit', (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`${cmd} ${args.join(' ')} exited with code ${code}`));
+    });
+    child.on('error', reject);
+  });
+}
+
+async function waitForServer(url, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  let lastErr;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(url);
+      if (res.ok || res.status < 500) return;
+    } catch (err) {
+      lastErr = err;
+    }
+    await new Promise((r) => setTimeout(r, 300));
+  }
+  throw new Error(`Server did not become ready at ${url}: ${lastErr}`);
+}
+
+async function assertPageRenders(path, mustContain) {
+  const url = `${BASE}${path}`;
+  const res = await fetch(url, { redirect: 'follow' });
+  if (!res.ok) {
+    throw new Error(`GET ${url} returned ${res.status}`);
+  }
+  const body = await res.text();
+  for (const needle of mustContain) {
+    if (!body.includes(needle)) {
+      throw new Error(`GET ${url} response missing expected content: ${JSON.stringify(needle)}`);
+    }
+  }
+  console.log(`ok  ${path}  (${res.status}, ${body.length} bytes, contains ${mustContain.length} expected anchors)`);
+}
+
+async function main() {
+  console.log('--- building preview bundle (build.client + build.preview) ---');
+  await run('npx', ['vite', 'build']);
+  await run('npx', ['vite', 'build', '--ssr', 'src/entry.preview.tsx']);
+
+  console.log(`--- starting preview server on port ${PORT} ---`);
+  const server = spawn('npx', ['vite', 'preview', '--port', String(PORT), '--strictPort'], {
+    stdio: 'inherit',
+  });
+
+  let exitCode = 0;
+  try {
+    await waitForServer(BASE, START_TIMEOUT_MS);
+
+    await assertPageRenders('/', ['Kaptanto', 'get.kaptan.to']);
+    await assertPageRenders('/docs/', ['Documentation index', '/docs/docs-intro']);
+    await assertPageRenders('/docs/docs-intro', ['Kaptanto Docs', 'docs-intro']);
+
+    console.log('--- rendered smoke check passed ---');
+  } catch (err) {
+    console.error('--- rendered smoke check FAILED ---');
+    console.error(err);
+    exitCode = 1;
+  } finally {
+    server.kill('SIGTERM');
+  }
+
+  process.exit(exitCode);
+}
+
+main();

--- a/landing/vitest.config.ts
+++ b/landing/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "vitest/config";
+import tsconfigPaths from "vite-tsconfig-paths";
+
+/**
+ * Separate from vite.config.ts on purpose: the app's vite.config.ts loads the
+ * qwikCity/qwikVite plugins, which expect to run inside the Qwik City routing
+ * pipeline (dev server or build), not a plain Vitest environment. The smoke
+ * suite only needs to import plain TS data modules and read source files, so
+ * it gets its own minimal config instead of extending the app one.
+ */
+export default defineConfig({
+  plugins: [tsconfigPaths({ root: "." })],
+  test: {
+    include: ["test/**/*.test.ts"],
+    environment: "node",
+  },
+});


### PR DESCRIPTION
## Source fix plan

`.claude/fix-plans/landing-testing-20260702-181558.md` (from `.claude/reports/kaptanto-test-strictness-review-20260702-181558.md`)

## Problem

`landing/` (a Qwik/Vite app deployed to Cloudflare Pages, kaptan.to) had no test kind and no CI coverage whatsoever. `landing/package.json` defines `lint` (ESLint), `fmt.check` (Prettier), and `build.types` (`tsc --noEmit`), but no GitHub Actions workflow referenced `landing/**` at all, so a type error, broken route, or failed build could ship to the public product surface with every CI badge green.

## Implementation

**1. CI gate for what already exists** — `.github/workflows/landing.yml`, path-filtered on `landing/**` (+ itself), running `npm ci`, `lint`, `fmt.check`, `build.types`, `test` (new), and `build`, on `ubuntu-latest` / Node 20, matching this repo's existing workflow conventions (SHA-pinned actions, `persist-credentials: false`, `permissions: contents: read`).

**Package-manager decision**: `landing/` has both `bun.lock` and `package-lock.json`. I used **npm/package-lock.json**, because:
- `landing/README.md` explicitly documents `npm run build` as the Cloudflare Pages build command (root directory `landing`, build output `dist`) — this is the actual production deploy path.
- `package-lock.json`'s git history has a dedicated fix commit ("regenerate package-lock.json to include wrangler dependencies"), i.e. it's actively maintained against real deploy issues.
- Nothing in the repo (deploy config, docs, CI) references `bun.lock` — it looks like a leftover from the initial `npm create qwik` scaffold (bun is qwik's default) that nothing has touched since.

`bun.lock` is left in place (not deleted) — removing it is a separate decision outside this plan's scope; flagged below.

**2. Test runner** — added Vitest (`landing/vitest.config.ts`, `npm run test`), with two smoke suites:
- `test/docs-consistency.test.ts`: every slug in `SIDEBAR`/`DOC_FLOW` (`src/data/docs-content.ts`) resolves to a real `DOCS_CONTENT` entry (a missing one renders "Doc not found" in production), and every crawlable `SEO_DOCS` slug (`src/data/docs.ts`, backing `/docs/[slug]`) exists in the interactive registry too. 79 assertions total, all currently pass — the two registries are in sync today.
- `test/install-command.test.ts`: the install snippet on the landing hero (`Install.tsx`), in the docs content, and the `downloadUrl` in `routes/index.tsx` all use the exact same `curl -fsSL https://get.kaptan.to | sh` line that the real `scripts/install.sh` documents as its own usage — this is the same class of drift flagged in project memory (`get.kaptan.to` vs a stale `/stream` endpoint elsewhere).

**Note on structure**: `landing/js/main.js` (which CLAUDE.md describes as the home of docs content and the sidebar array) no longer exists — the app moved to a Qwik `src/` tree. The equivalent content now lives in `landing/src/data/docs-content.ts` (`SIDEBAR`, `DOCS_CONTENT`, `DOC_FLOW`) and `landing/src/data/docs.ts` (`SEO_DOCS`, backing the crawlable `/docs/[slug]` routes). Tests target the real current structure, not the stale one.

**3. Rendered smoke check** — `test/render-smoke.mjs`: builds the Vite preview SSR bundle (`vite build` + `vite build --ssr src/entry.preview.tsx`, the same entry `npm run preview` serves), starts it, and asserts `/`, `/docs/`, and `/docs/docs-intro` return 200 and contain expected anchors (`Kaptanto`, `get.kaptan.to`, `Documentation index`, etc.). Used a plain HTTP fetch instead of Playwright to avoid a ~1–2 min browser-install tax on every `landing/**` push, per the plan's own risk note that this is acceptable to substitute with a DOM-less render check.

**4. CLAUDE.md staleness (flagged, not fixed — out of scope for this plan)**: `/Users/lucasandrade/kaptanto/CLAUDE.md`'s Landing Page section currently reads:

> `landing/` is a static site with no build step. Open `landing/index.html` directly in a browser. All documentation content lives in `landing/js/main.js` as the `docs` object; the sidebar is defined in the `sidebar` array in the same file.

This is false for the current tree. It should instead say something like: `landing/` is a Qwik/Vite app (see `landing/package.json`) deployed to Cloudflare Pages at kaptan.to; run `npm run dev` for a dev server or `npm run build` to produce the deploy artifact in `landing/dist`. Docs content lives in `landing/src/data/docs-content.ts` (interactive viewer: `DOCS_CONTENT`, `SIDEBAR`, `DOC_FLOW`) and `landing/src/data/docs.ts` (crawlable `/docs/[slug]` SEO index: `SEO_DOCS`). CI now runs lint/typecheck/build/tests via `.github/workflows/landing.yml`.

## Validation run

All commands run from `landing/` against the final tree, in the order the new workflow runs them:

| Command | Result |
|---|---|
| `npm ci` | pass |
| `npm run lint` | pass (0 errors, 6 pre-existing warnings, unrelated to this change) |
| `npm run fmt.check` | **fails** — pre-existing drift, see residual risk below |
| `npm run build.types` | pass |
| `npm run test` (new) | pass — 79/79 assertions, 2 test files |
| `npm run build` | pass (Cloudflare Pages worker build) |
| `node test/render-smoke.mjs` (new) | pass — `/`, `/docs/`, `/docs/docs-intro` all 200 with expected content |

## Residual risk / follow-up

- **`fmt.check` is wired into the workflow with `continue-on-error: true`, not blocking.** The current tree has pre-existing Prettier violations across ~12 files (`public/legacy.css`, several `src/components/**`, `src/data/**`, `src/routes/**`) unrelated to this change. Running `prettier --write .` to fix them produced a ~2,400-line diff touching files this plan has no business changing. Follow-up: a dedicated formatting-normalization PR, then flip `continue-on-error` off so `fmt.check` actually gates.
- **CLAUDE.md's Landing Page section is stale** (exact text and suggested replacement above) — needs a separate doc-fix task; not edited here per scope.
- **Dual lockfiles**: `bun.lock` still exists alongside `package-lock.json` and isn't referenced anywhere. Recommend deleting it in a follow-up to remove the ambiguity permanently, once confirmed no one locally develops with bun.
- **Node version pin**: workflow uses Node 20 (satisfies `engines: "^20.3.0"`), matching the version available locally. Cloudflare Pages' own build image Node version isn't pinned anywhere in the repo (no `.nvmrc`) — if Cloudflare's default drifts from 20, CI green doesn't strictly guarantee deploy green. Worth adding a `.nvmrc` in a follow-up as the single source of truth for both CI and Cloudflare Pages.
- **Coverage is a canary, not comprehensive**: per the fix plan, deeper content-accuracy auditing (do docs/benchmarks/claims match the actual product) stays with the `check-landing` skill; this PR only makes the *automated* test kind exist.