### PR TITLE
fix(backfill): discover real primary-key columns instead of hardcoding "id"

### DIFF
--- a/internal/cmd/filters.go
+++ b/internal/cmd/filters.go
@@ -32,7 +32,16 @@ func buildTableFilters(tables map[string]config.TableConfig) (
 	return rowFilters, colFilters, nil
 }
 
-func buildBackfillConfigs(tables map[string]config.TableConfig, sourceID string) []backfill.BackfillConfig {
+// buildBackfillConfigs assembles one BackfillConfig per table. pkCols must
+// hold the real, discovered primary-key columns for every key in tables
+// (see discoverPrimaryKeys) — this function does no discovery itself and
+// trusts the caller; production wiring in runPipeline fails fast before
+// calling this if discovery found a table with no primary key.
+func buildBackfillConfigs(
+	tables map[string]config.TableConfig,
+	sourceID string,
+	pkCols map[string][]string,
+) []backfill.BackfillConfig {
 	configs := make([]backfill.BackfillConfig, 0, len(tables))
 	for tableKey := range tables {
 		schema, table := "", tableKey
@@ -44,7 +53,7 @@ func buildBackfillConfigs(tables map[string]config.TableConfig, sourceID string)
 			Schema:        schema,
 			Table:         table,
 			Strategy:      "snapshot_and_stream",
-			PKCols:        []string{"id"},
+			PKCols:        pkCols[tableKey],
 			NumPartitions: numEventLogPartitions,
 		})
 	}

--- a/internal/cmd/pk_discovery.go
+++ b/internal/cmd/pk_discovery.go
@@ -1,0 +1,90 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/olucasandrade/kaptanto/internal/config"
+)
+
+// pkDiscoveryQuery returns the ordered primary-key column names for a table.
+// The table identity is bound as $1 (never string-interpolated into SQL) and
+// resolved through Postgres's own ::regclass identifier resolution, so it
+// honors schema qualification and search_path the same way the rest of
+// Postgres does. array_position(i.indkey, a.attnum) preserves the index's
+// declared column order, which matters for composite keys: keyset pagination
+// and the WAL-derived watermark key must agree on column order.
+const pkDiscoveryQuery = `
+SELECT a.attname
+FROM pg_index i
+JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = ANY(i.indkey)
+WHERE i.indrelid = $1::regclass AND i.indisprimary
+ORDER BY array_position(i.indkey, a.attnum)`
+
+// pkQuerier is the minimal slice of *pgx.Conn's API used for primary-key
+// discovery. Its method signature matches *pgx.Conn.Query exactly, so
+// *pgx.Conn satisfies it structurally with no adapter; unit tests use a fake.
+type pkQuerier interface {
+	Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error)
+}
+
+// discoverPrimaryKey queries the Postgres catalog for the ordered
+// primary-key column names of tableIdentity (e.g. "public.orders" or,
+// relying on search_path, "orders"). It returns a nil/empty slice — not an
+// error — when the table has no primary key; callers decide how to treat
+// that. See discoverPrimaryKeys for the fail-fast policy used by production
+// wiring.
+func discoverPrimaryKey(ctx context.Context, q pkQuerier, tableIdentity string) ([]string, error) {
+	rows, err := q.Query(ctx, pkDiscoveryQuery, tableIdentity)
+	if err != nil {
+		return nil, fmt.Errorf("query primary key columns for %q: %w", tableIdentity, err)
+	}
+	defer rows.Close()
+
+	var cols []string
+	for rows.Next() {
+		var col string
+		if err := rows.Scan(&col); err != nil {
+			return nil, fmt.Errorf("scan primary key column for %q: %w", tableIdentity, err)
+		}
+		cols = append(cols, col)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read primary key columns for %q: %w", tableIdentity, err)
+	}
+	return cols, nil
+}
+
+// discoverPrimaryKeys resolves the ordered primary-key columns for every
+// table in tables (keyed the same way as config.Config.Tables, e.g.
+// "public.orders" or "orders") against a live, non-replication Postgres
+// connection.
+//
+// SRC-01: q must be a dedicated snapshot connection, never the replication
+// connection — callers are expected to open and close a short-lived
+// *pgx.Conn just for this call, separate from the connection the backfill
+// engine's openConnFn later opens for the actual snapshot.
+//
+// Fails fast (returns an error, discovers nothing) for any table with no
+// primary key: BKF-02's watermark suppression can never byte-match the
+// WAL-derived key without one, so a table silently falling back to a guessed
+// key would double-deliver or drop rows without any visible symptom. A
+// clear startup error is safer than that.
+func discoverPrimaryKeys(ctx context.Context, q pkQuerier, tables map[string]config.TableConfig) (map[string][]string, error) {
+	result := make(map[string][]string, len(tables))
+	for tableKey := range tables {
+		cols, err := discoverPrimaryKey(ctx, q, tableKey)
+		if err != nil {
+			return nil, fmt.Errorf("discover primary key for table %q: %w", tableKey, err)
+		}
+		if len(cols) == 0 {
+			return nil, fmt.Errorf(
+				"table %q has no primary key: backfill requires one for keyset pagination and BKF-02 "+
+					"watermark suppression — add a primary key to %q or remove it from the configured tables",
+				tableKey, tableKey)
+		}
+		result[tableKey] = cols
+	}
+	return result, nil
+}

--- a/internal/cmd/pk_discovery_integration_test.go
+++ b/internal/cmd/pk_discovery_integration_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/olucasandrade/kaptanto/internal/config"
@@ -26,10 +27,7 @@ func TestDiscoverPrimaryKeys_Integration(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	conn, err := pgx.Connect(ctx, dsn)
-	if err != nil {
-		t.Fatalf("connect: %v", err)
-	}
+	conn := connectWithPingRetry(t, ctx, dsn)
 	defer func() { _ = conn.Close(ctx) }()
 
 	const (
@@ -127,4 +125,37 @@ func TestDiscoverPrimaryKeys_Integration(t *testing.T) {
 			t.Fatalf("order_items PK = %v, want [order_id line_no]", result[orderItemsTbl])
 		}
 	})
+}
+
+// connectWithPingRetry connects to Postgres and verifies the connection with
+// a Ping, retrying the connect+ping pair a few times on failure. This CI
+// environment's freshly-started Postgres container has, on this test, been
+// observed to accept a connection successfully (pgx.Connect returns no
+// error) that is then immediately unusable (`conn closed` on the first
+// query) even though the server's own log shows nothing wrong — a transient
+// condition in the container/network handshake, not the database itself.
+// This mirrors the readiness-retry pattern already used for RabbitMQ/MongoDB
+// startup elsewhere in this repo's CI workflows.
+func connectWithPingRetry(t *testing.T, ctx context.Context, dsn string) *pgx.Conn {
+	t.Helper()
+
+	const maxAttempts = 5
+	var lastErr error
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		conn, err := pgx.Connect(ctx, dsn)
+		if err != nil {
+			lastErr = err
+			time.Sleep(100 * time.Millisecond)
+			continue
+		}
+		if pingErr := conn.Ping(ctx); pingErr != nil {
+			lastErr = pingErr
+			_ = conn.Close(ctx)
+			time.Sleep(100 * time.Millisecond)
+			continue
+		}
+		return conn
+	}
+	t.Fatalf("connect (with ping) after %d attempts: %v", maxAttempts, lastErr)
+	return nil
 }

--- a/internal/cmd/pk_discovery_integration_test.go
+++ b/internal/cmd/pk_discovery_integration_test.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/olucasandrade/kaptanto/internal/config"
@@ -27,8 +26,16 @@ func TestDiscoverPrimaryKeys_Integration(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	conn := connectWithPingRetry(t, ctx, dsn)
-	defer func() { _ = conn.Close(ctx) }()
+	conn, err := pgx.Connect(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	// Registered before t.Cleanup(dropAll) below so it runs LAST: t.Cleanup
+	// callbacks run in LIFO order relative to each other, but only after this
+	// function's own defers have already unwound — so a plain `defer
+	// conn.Close()` here would close the connection before dropAll's cleanup
+	// runs, and dropAll would fail with "conn closed" on every run.
+	t.Cleanup(func() { _ = conn.Close(ctx) })
 
 	const (
 		ordersTable   = "pk_discovery_orders"
@@ -125,37 +132,4 @@ func TestDiscoverPrimaryKeys_Integration(t *testing.T) {
 			t.Fatalf("order_items PK = %v, want [order_id line_no]", result[orderItemsTbl])
 		}
 	})
-}
-
-// connectWithPingRetry connects to Postgres and verifies the connection with
-// a Ping, retrying the connect+ping pair a few times on failure. This CI
-// environment's freshly-started Postgres container has, on this test, been
-// observed to accept a connection successfully (pgx.Connect returns no
-// error) that is then immediately unusable (`conn closed` on the first
-// query) even though the server's own log shows nothing wrong — a transient
-// condition in the container/network handshake, not the database itself.
-// This mirrors the readiness-retry pattern already used for RabbitMQ/MongoDB
-// startup elsewhere in this repo's CI workflows.
-func connectWithPingRetry(t *testing.T, ctx context.Context, dsn string) *pgx.Conn {
-	t.Helper()
-
-	const maxAttempts = 5
-	var lastErr error
-	for attempt := 1; attempt <= maxAttempts; attempt++ {
-		conn, err := pgx.Connect(ctx, dsn)
-		if err != nil {
-			lastErr = err
-			time.Sleep(100 * time.Millisecond)
-			continue
-		}
-		if pingErr := conn.Ping(ctx); pingErr != nil {
-			lastErr = pingErr
-			_ = conn.Close(ctx)
-			time.Sleep(100 * time.Millisecond)
-			continue
-		}
-		return conn
-	}
-	t.Fatalf("connect (with ping) after %d attempts: %v", maxAttempts, lastErr)
-	return nil
 }

--- a/internal/cmd/pk_discovery_integration_test.go
+++ b/internal/cmd/pk_discovery_integration_test.go
@@ -1,0 +1,130 @@
+package cmd
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/olucasandrade/kaptanto/internal/config"
+)
+
+// TestDiscoverPrimaryKeys_Integration exercises discoverPrimaryKey and
+// discoverPrimaryKeys against a live Postgres instance, covering the three
+// cases the hardcoded []string{"id"} bug got wrong: a table whose primary
+// key isn't named "id", a composite-PK table, and a table with no primary
+// key at all.
+//
+// Set POSTGRES_TEST_DSN to a valid Postgres DSN to run these tests, e.g.:
+//
+//	POSTGRES_TEST_DSN="postgres://user:pass@localhost:5432/testdb" go test ./internal/cmd/... -run TestDiscoverPrimaryKeys_Integration
+func TestDiscoverPrimaryKeys_Integration(t *testing.T) {
+	dsn := os.Getenv("POSTGRES_TEST_DSN")
+	if dsn == "" {
+		t.Skip("set POSTGRES_TEST_DSN to run Postgres integration tests")
+	}
+
+	ctx := context.Background()
+	conn, err := pgx.Connect(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer func() { _ = conn.Close(ctx) }()
+
+	const (
+		ordersTable   = "pk_discovery_orders"
+		orderItemsTbl = "pk_discovery_order_items"
+		auditLogTable = "pk_discovery_audit_log"
+	)
+
+	dropAll := func() {
+		for _, tbl := range []string{ordersTable, orderItemsTbl, auditLogTable} {
+			if _, err := conn.Exec(context.Background(), "DROP TABLE IF EXISTS "+tbl); err != nil {
+				t.Fatalf("drop table %s: %v", tbl, err)
+			}
+		}
+	}
+
+	dropAll()
+	t.Cleanup(dropAll)
+
+	setup := []string{
+		// Primary key named order_id, not "id" — the case that previously
+		// made the snapshot query fail outright (`column "id" does not exist`).
+		`CREATE TABLE ` + ordersTable + ` (order_id bigint PRIMARY KEY, total numeric)`,
+		// Composite primary key — the case that previously broke BKF-02
+		// watermark suppression because the watermark pkMap could never
+		// byte-match a two-column WAL key against a single hardcoded "id".
+		`CREATE TABLE ` + orderItemsTbl + ` (order_id bigint, line_no int, qty int, PRIMARY KEY (order_id, line_no))`,
+		// No primary key at all — must fail fast, not silently fall back.
+		`CREATE TABLE ` + auditLogTable + ` (event_id bigint, message text)`,
+	}
+	for _, stmt := range setup {
+		if _, err := conn.Exec(ctx, stmt); err != nil {
+			t.Fatalf("setup %q: %v", stmt, err)
+		}
+	}
+
+	t.Run("non-id primary key is discovered", func(t *testing.T) {
+		cols, err := discoverPrimaryKey(ctx, conn, ordersTable)
+		if err != nil {
+			t.Fatalf("discoverPrimaryKey: %v", err)
+		}
+		if len(cols) != 1 || cols[0] != "order_id" {
+			t.Fatalf("got %v, want [order_id]", cols)
+		}
+	})
+
+	t.Run("composite primary key preserves index column order", func(t *testing.T) {
+		cols, err := discoverPrimaryKey(ctx, conn, orderItemsTbl)
+		if err != nil {
+			t.Fatalf("discoverPrimaryKey: %v", err)
+		}
+		if len(cols) != 2 || cols[0] != "order_id" || cols[1] != "line_no" {
+			t.Fatalf("got %v, want [order_id line_no]", cols)
+		}
+	})
+
+	t.Run("table with no primary key resolves to an empty slice, not an error", func(t *testing.T) {
+		cols, err := discoverPrimaryKey(ctx, conn, auditLogTable)
+		if err != nil {
+			t.Fatalf("discoverPrimaryKey: %v", err)
+		}
+		if len(cols) != 0 {
+			t.Fatalf("got %v, want empty", cols)
+		}
+	})
+
+	t.Run("discoverPrimaryKeys fails fast when any configured table has no primary key", func(t *testing.T) {
+		tables := map[string]config.TableConfig{
+			ordersTable:   {},
+			orderItemsTbl: {},
+			auditLogTable: {},
+		}
+		_, err := discoverPrimaryKeys(ctx, conn, tables)
+		if err == nil {
+			t.Fatal("expected an error because of the PK-less table, got nil")
+		}
+		if !strings.Contains(err.Error(), auditLogTable) {
+			t.Fatalf("error should mention %s, got: %v", auditLogTable, err)
+		}
+	})
+
+	t.Run("discoverPrimaryKeys succeeds when every table has a primary key", func(t *testing.T) {
+		tables := map[string]config.TableConfig{
+			ordersTable:   {},
+			orderItemsTbl: {},
+		}
+		result, err := discoverPrimaryKeys(ctx, conn, tables)
+		if err != nil {
+			t.Fatalf("discoverPrimaryKeys: %v", err)
+		}
+		if len(result[ordersTable]) != 1 || result[ordersTable][0] != "order_id" {
+			t.Fatalf("orders PK = %v, want [order_id]", result[ordersTable])
+		}
+		if len(result[orderItemsTbl]) != 2 || result[orderItemsTbl][0] != "order_id" || result[orderItemsTbl][1] != "line_no" {
+			t.Fatalf("order_items PK = %v, want [order_id line_no]", result[orderItemsTbl])
+		}
+	})
+}

--- a/internal/cmd/pk_discovery_test.go
+++ b/internal/cmd/pk_discovery_test.go
@@ -1,0 +1,184 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/olucasandrade/kaptanto/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeRows is a minimal pgx.Rows fake driven by a canned set of single
+// string-column rows (primary-key column names in index order), or a canned
+// post-iteration error surfaced from Err().
+type fakeRows struct {
+	values []string
+	idx    int
+	err    error
+}
+
+var _ pgx.Rows = (*fakeRows)(nil)
+
+func (f *fakeRows) Close()                                       {}
+func (f *fakeRows) Err() error                                   { return f.err }
+func (f *fakeRows) CommandTag() pgconn.CommandTag                { return pgconn.CommandTag{} }
+func (f *fakeRows) FieldDescriptions() []pgconn.FieldDescription { return nil }
+func (f *fakeRows) Values() ([]any, error)                       { return nil, nil }
+func (f *fakeRows) RawValues() [][]byte                          { return nil }
+func (f *fakeRows) Conn() *pgx.Conn                              { return nil }
+
+func (f *fakeRows) Next() bool {
+	if f.err != nil || f.idx >= len(f.values) {
+		return false
+	}
+	f.idx++
+	return true
+}
+
+func (f *fakeRows) Scan(dest ...any) error {
+	ptr, ok := dest[0].(*string)
+	if !ok {
+		return errors.New("fakeRows: unsupported scan destination")
+	}
+	*ptr = f.values[f.idx-1]
+	return nil
+}
+
+// fakeQuerier is a pkQuerier fake keyed by the bound table-identity argument
+// ($1), so each test controls exactly what each table "resolves" to without
+// ever building real SQL or a real connection.
+type fakeQuerier struct {
+	byIdentity map[string]*fakeRows
+	queryErr   map[string]error
+	calls      []string
+}
+
+func (f *fakeQuerier) Query(_ context.Context, _ string, args ...any) (pgx.Rows, error) {
+	identity, _ := args[0].(string)
+	f.calls = append(f.calls, identity)
+	if err, ok := f.queryErr[identity]; ok {
+		return nil, err
+	}
+	rows, ok := f.byIdentity[identity]
+	if !ok {
+		return &fakeRows{}, nil
+	}
+	// Return a fresh copy so repeated calls against the same fixture in one
+	// test don't share iteration state (idx).
+	cp := *rows
+	return &cp, nil
+}
+
+func TestDiscoverPrimaryKey(t *testing.T) {
+	t.Run("single-column PK", func(t *testing.T) {
+		q := &fakeQuerier{byIdentity: map[string]*fakeRows{
+			"public.orders": {values: []string{"order_id"}},
+		}}
+		cols, err := discoverPrimaryKey(context.Background(), q, "public.orders")
+		require.NoError(t, err)
+		assert.Equal(t, []string{"order_id"}, cols)
+	})
+
+	t.Run("composite PK preserves index column order", func(t *testing.T) {
+		q := &fakeQuerier{byIdentity: map[string]*fakeRows{
+			"public.order_items": {values: []string{"order_id", "line_no"}},
+		}}
+		cols, err := discoverPrimaryKey(context.Background(), q, "public.order_items")
+		require.NoError(t, err)
+		assert.Equal(t, []string{"order_id", "line_no"}, cols)
+	})
+
+	t.Run("no primary key returns empty slice, not error", func(t *testing.T) {
+		q := &fakeQuerier{byIdentity: map[string]*fakeRows{
+			"public.no_pk_table": {values: nil},
+		}}
+		cols, err := discoverPrimaryKey(context.Background(), q, "public.no_pk_table")
+		require.NoError(t, err)
+		assert.Empty(t, cols)
+	})
+
+	t.Run("query error is wrapped with the table identity", func(t *testing.T) {
+		q := &fakeQuerier{queryErr: map[string]error{
+			"public.missing": errors.New(`relation "public.missing" does not exist`),
+		}}
+		_, err := discoverPrimaryKey(context.Background(), q, "public.missing")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "public.missing")
+	})
+
+	t.Run("rows.Err after iteration is surfaced", func(t *testing.T) {
+		q := &fakeQuerier{byIdentity: map[string]*fakeRows{
+			"public.flaky": {values: []string{"id"}, err: errors.New("connection reset")},
+		}}
+		_, err := discoverPrimaryKey(context.Background(), q, "public.flaky")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "connection reset")
+	})
+
+	t.Run("table identity is passed as a bind parameter, not interpolated", func(t *testing.T) {
+		q := &fakeQuerier{byIdentity: map[string]*fakeRows{
+			`public."weird; drop table x"`: {values: []string{"id"}},
+		}}
+		cols, err := discoverPrimaryKey(context.Background(), q, `public."weird; drop table x"`)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"id"}, cols)
+		require.Len(t, q.calls, 1)
+		assert.Equal(t, `public."weird; drop table x"`, q.calls[0])
+	})
+}
+
+func TestDiscoverPrimaryKeys(t *testing.T) {
+	t.Run("resolves PK for every configured table", func(t *testing.T) {
+		q := &fakeQuerier{byIdentity: map[string]*fakeRows{
+			"public.orders":      {values: []string{"order_id"}},
+			"public.order_items": {values: []string{"order_id", "line_no"}},
+		}}
+		tables := map[string]config.TableConfig{
+			"public.orders":      {},
+			"public.order_items": {},
+		}
+		result, err := discoverPrimaryKeys(context.Background(), q, tables)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"order_id"}, result["public.orders"])
+		assert.Equal(t, []string{"order_id", "line_no"}, result["public.order_items"])
+	})
+
+	t.Run("fails fast for a table with no primary key", func(t *testing.T) {
+		q := &fakeQuerier{byIdentity: map[string]*fakeRows{
+			"public.orders":    {values: []string{"order_id"}},
+			"public.audit_log": {values: nil},
+		}}
+		tables := map[string]config.TableConfig{
+			"public.orders":    {},
+			"public.audit_log": {},
+		}
+		_, err := discoverPrimaryKeys(context.Background(), q, tables)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "public.audit_log")
+		assert.Contains(t, err.Error(), "no primary key")
+	})
+
+	t.Run("empty tables map returns empty result and issues no queries", func(t *testing.T) {
+		q := &fakeQuerier{}
+		result, err := discoverPrimaryKeys(context.Background(), q, nil)
+		require.NoError(t, err)
+		assert.Empty(t, result)
+		assert.Empty(t, q.calls)
+	})
+
+	t.Run("propagates the underlying query error for a bad table", func(t *testing.T) {
+		q := &fakeQuerier{queryErr: map[string]error{
+			"public.ghost": errors.New(`relation "public.ghost" does not exist`),
+		}}
+		tables := map[string]config.TableConfig{
+			"public.ghost": {},
+		}
+		_, err := discoverPrimaryKeys(context.Background(), q, tables)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "public.ghost")
+	})
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -426,12 +426,15 @@ func runPipeline(ctx context.Context, cfg *config.Config) error {
 	// lazily-opened snapshot connection below.
 	var bkPKCols map[string][]string
 	if len(cfg.Tables) > 0 {
-		pkConn, err := pgx.Connect(ctx, cfg.Source)
+		pkCtx, pkCancel := context.WithTimeout(ctx, 10*time.Second)
+		pkConn, err := pgx.Connect(pkCtx, cfg.Source)
 		if err != nil {
+			pkCancel()
 			return fmt.Errorf("backfill: connect for primary-key discovery: %w", err)
 		}
-		bkPKCols, err = discoverPrimaryKeys(ctx, pkConn, cfg.Tables)
+		bkPKCols, err = discoverPrimaryKeys(pkCtx, pkConn, cfg.Tables)
 		closeErr := pkConn.Close(context.Background())
+		pkCancel()
 		if err != nil {
 			return fmt.Errorf("backfill: %w", err)
 		}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -416,7 +416,31 @@ func runPipeline(ctx context.Context, cfg *config.Config) error {
 		bkStore = sqliteBkStore
 	}
 
-	bkConfigs := buildBackfillConfigs(cfg.Tables, connCfg.SourceID)
+	// Discover each table's real primary-key columns before building backfill
+	// configs — hardcoding "id" breaks any table whose PK isn't named "id",
+	// silently mispaginates non-unique "id" columns, and can never
+	// byte-match a composite-PK WAL key for BKF-02 watermark suppression.
+	//
+	// SRC-01: this uses its own short-lived pgx.Conn (connect, discover,
+	// close), never the replication connection and never openConnFn's
+	// lazily-opened snapshot connection below.
+	var bkPKCols map[string][]string
+	if len(cfg.Tables) > 0 {
+		pkConn, err := pgx.Connect(ctx, cfg.Source)
+		if err != nil {
+			return fmt.Errorf("backfill: connect for primary-key discovery: %w", err)
+		}
+		bkPKCols, err = discoverPrimaryKeys(ctx, pkConn, cfg.Tables)
+		closeErr := pkConn.Close(context.Background())
+		if err != nil {
+			return fmt.Errorf("backfill: %w", err)
+		}
+		if closeErr != nil {
+			slog.Warn("backfill: close primary-key discovery connection", "err", closeErr)
+		}
+	}
+
+	bkConfigs := buildBackfillConfigs(cfg.Tables, connCfg.SourceID, bkPKCols)
 	openConnFn := func(ctx context.Context) (*pgx.Conn, error) {
 		return pgx.Connect(ctx, cfg.Source)
 	}

--- a/internal/cmd/root_backfill_test.go
+++ b/internal/cmd/root_backfill_test.go
@@ -20,38 +20,65 @@ import (
 
 // --- Task 1: buildBackfillConfigs helper ---
 
-// TestBuildBackfillConfigs verifies the four behaviour cases.
+// TestBuildBackfillConfigs verifies buildBackfillConfigs's assembly logic.
+// buildBackfillConfigs itself does no PK discovery (that's discoverPrimaryKeys,
+// called by runPipeline before this); it just trusts the pkCols map passed in.
 func TestBuildBackfillConfigs(t *testing.T) {
 	t.Run("nil tables returns empty slice without panic", func(t *testing.T) {
-		result := buildBackfillConfigs(nil, "default")
+		result := buildBackfillConfigs(nil, "default", nil)
 		require.NotNil(t, result)
 		assert.Empty(t, result)
 	})
 
-	t.Run("single schema-qualified table", func(t *testing.T) {
+	t.Run("single schema-qualified table uses discovered PK, not a hardcoded id", func(t *testing.T) {
 		tables := map[string]config.TableConfig{
 			"public.orders": {},
 		}
-		result := buildBackfillConfigs(tables, "default")
+		pkCols := map[string][]string{"public.orders": {"order_id"}}
+		result := buildBackfillConfigs(tables, "default", pkCols)
 		require.Len(t, result, 1)
 		cfg := result[0]
 		assert.Equal(t, "default", cfg.SourceID)
 		assert.Equal(t, "public", cfg.Schema)
 		assert.Equal(t, "orders", cfg.Table)
 		assert.Equal(t, "snapshot_and_stream", cfg.Strategy)
-		assert.Equal(t, []string{"id"}, cfg.PKCols)
+		assert.Equal(t, []string{"order_id"}, cfg.PKCols)
 		assert.Equal(t, uint32(numEventLogPartitions), cfg.NumPartitions)
+	})
+
+	t.Run("composite PK columns preserved in index order", func(t *testing.T) {
+		tables := map[string]config.TableConfig{
+			"public.order_items": {},
+		}
+		pkCols := map[string][]string{"public.order_items": {"order_id", "line_no"}}
+		result := buildBackfillConfigs(tables, "default", pkCols)
+		require.Len(t, result, 1)
+		assert.Equal(t, []string{"order_id", "line_no"}, result[0].PKCols)
 	})
 
 	t.Run("unqualified table no schema prefix", func(t *testing.T) {
 		tables := map[string]config.TableConfig{
 			"orders": {},
 		}
-		result := buildBackfillConfigs(tables, "default")
+		pkCols := map[string][]string{"orders": {"id"}}
+		result := buildBackfillConfigs(tables, "default", pkCols)
 		require.Len(t, result, 1)
 		cfg := result[0]
 		assert.Equal(t, "", cfg.Schema)
 		assert.Equal(t, "orders", cfg.Table)
+	})
+
+	t.Run("missing pkCols entry yields nil PKCols", func(t *testing.T) {
+		// buildBackfillConfigs does not itself enforce "every table has a PK" —
+		// that fail-fast check lives in discoverPrimaryKeys, which runPipeline
+		// calls before buildBackfillConfigs. This case documents that trust
+		// boundary rather than duplicating the check here.
+		tables := map[string]config.TableConfig{
+			"public.orders": {},
+		}
+		result := buildBackfillConfigs(tables, "default", nil)
+		require.Len(t, result, 1)
+		assert.Nil(t, result[0].PKCols)
 	})
 
 	t.Run("two table entries returns two configs", func(t *testing.T) {
@@ -59,7 +86,11 @@ func TestBuildBackfillConfigs(t *testing.T) {
 			"public.orders": {},
 			"public.users":  {},
 		}
-		result := buildBackfillConfigs(tables, "default")
+		pkCols := map[string][]string{
+			"public.orders": {"id"},
+			"public.users":  {"id"},
+		}
+		result := buildBackfillConfigs(tables, "default", pkCols)
 		assert.Len(t, result, 2)
 	})
 }


### PR DESCRIPTION
## Source fix plan

`.claude/fix-plans/backfill-pk-discovery-20260702-131544.md` (not committed; local to the fix worktree)

## Problem

`buildBackfillConfigs` (`internal/cmd/filters.go`, formerly line 35-52) hardcoded `PKCols: []string{"id"}` for every configured table, regardless of the table's actual primary key. Consequences:

- Tables whose PK isn't named `id` fail the snapshot query outright (`column "id" does not exist`).
- Tables with a non-unique `id` column silently produce broken keyset pagination (skipped/duplicated rows).
- Composite-PK tables build a watermark `pkMap` that can never byte-match the WAL-derived key, silently breaking BKF-02 suppression even where the snapshot query happens to succeed.
- The WAL path (`internal/parser/pgoutput`) extracts the true PK from `RelationMessage` flags, so the two paths disagreed for any non-`id` PK.

## Implementation

1. **`internal/cmd/pk_discovery.go`** (new): `discoverPrimaryKey(ctx, pkQuerier, tableIdentity)` runs
   ```sql
   SELECT a.attname
   FROM pg_index i
   JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = ANY(i.indkey)
   WHERE i.indrelid = $1::regclass AND i.indisprimary
   ORDER BY array_position(i.indkey, a.attnum)
   ```
   with the table identity bound as `$1` (never string-interpolated), preserving index column order for composite keys. `discoverPrimaryKeys(ctx, pkQuerier, tables)` runs this per configured table and **fails fast** (returns an error, discovers nothing) if any table has no primary key — silently falling back to a guessed key would break BKF-02 without any visible symptom, so a clear startup error is the safer default.

   `pkQuerier` is a 1-method interface matching `*pgx.Conn.Query`'s exact signature, satisfied structurally with no adapter — production passes a real `*pgx.Conn`, unit tests pass a fake.

2. **`internal/cmd/filters.go`**: `buildBackfillConfigs` now takes a `pkCols map[string][]string` parameter and uses `pkCols[tableKey]` instead of the hardcoded `[]string{"id"}`. It does no discovery itself — it trusts the caller, keeping it a pure, easily-testable assembly function.

3. **`internal/cmd/root.go`** (`runPipeline`): before calling `buildBackfillConfigs`, opens a **dedicated, short-lived `pgx.Conn`** (connect → discover → close) to run `discoverPrimaryKeys` over `cfg.Tables`, satisfying **SRC-01** (never reuses the replication connection, and never the backfill engine's lazily-opened `openConnFn` snapshot connection). Discovery is skipped entirely when `cfg.Tables` is empty (`--all-tables` mode), matching today's existing behavior of building zero backfill configs in that mode — that's an intentional, separate scope decision called out in the original fix plan, not something this PR changes.

4. MongoDB path is untouched — `_id` is universal there, no discovery needed.

5. `[]string{"id"}` is now only used as an explicit literal in tests that construct `backfill.BackfillConfig` directly (e.g. `root_backfill_test.go`'s `BackfillEngineImpl` tests) — the production wiring path always discovers.

### Scoping decision on `runPipeline` wiring

The plan allowed scoping this down to "unit-test the discovery function only" if live wiring seemed too risky to verify without a live Postgres. I chose **not** to scope down, after checking:

- Before this change, no Postgres connection was attempted synchronously in `runPipeline` before the pipeline goroutines start (the health-check probe is registered but not invoked at startup; the replication/backfill connections are opened lazily inside `connector.Run`/`openConnFn`, which run concurrently in the `errgroup`). Adding a synchronous discovery connect-and-query *is* a new synchronous startup requirement, but only when `cfg.Tables` is non-empty — i.e. only when backfill would need real Postgres connectivity moments later anyway. This trades a slightly earlier, clearer failure for a later, murkier one; it doesn't add a failure mode that didn't already exist.
- I audited every existing `internal/cmd` test that exercises `runPipeline`/`ExecuteWithArgs` against an unreachable Postgres DSN. All of them either use `--all-tables` (empty `cfg.Tables`, discovery skipped), target MongoDB, or are gated behind `POSTGRES_TEST_DSN`. None exercise the Postgres + non-empty-`cfg.Tables` path against a DSN, so none could regress from the new discovery call. This was confirmed by running the full suite (see below), not just by inspection.

## Validation run

From the worktree root:

```
CGO_ENABLED=0 go build ./...     # PASS
CGO_ENABLED=0 go vet ./...       # PASS
CGO_ENABLED=0 go test ./... -count=1   # PASS, all 27 packages ok
```

Targeted run of the new/changed tests:

```
CGO_ENABLED=0 go test ./internal/cmd/... -run 'TestDiscoverPrimaryKey|TestBuildBackfillConfigs|TestDiscoverPrimaryKeys_Integration' -v
```
- `TestDiscoverPrimaryKeys_Integration` — SKIP (no `POSTGRES_TEST_DSN`), confirmed it skips cleanly rather than failing.
- `TestDiscoverPrimaryKey` (6 subtests: single-column PK, composite PK order, no-PK table, wrapped query error, `rows.Err()` surfaced, bind-parameter-not-interpolation) — PASS.
- `TestDiscoverPrimaryKeys` (4 subtests: resolves all, fails fast on PK-less table, empty map issues no queries, propagates query error) — PASS.
- `TestBuildBackfillConfigs` (6 subtests, updated for the new `pkCols` parameter, including a composite-PK case) — PASS.

`golangci-lint` was **not** run — the binary isn't available in this sandbox. Code is `gofmt`-clean and `go vet`-clean; the new functions are small and low-branching (well under the repo's gocyclo-25 gate by inspection), but this is not lint-verified.

## Residual risk / follow-up

- **Not verified against a live Postgres in this session**: the SQL query itself (`pg_index`/`pg_attribute`/`::regclass` resolution), and the full `runPipeline` startup path with real PK discovery. Unit tests fully cover `discoverPrimaryKey`/`discoverPrimaryKeys`'s logic against a fake `pkQuerier`; the new `TestDiscoverPrimaryKeys_Integration` test (env-gated on `POSTGRES_TEST_DSN`, following the existing pattern in `internal/checkpoint/postgres_test.go`) exercises all three cases from the plan's test plan — non-`id` PK (`order_id`), composite PK (`order_id, line_no`), and a PK-less table — but I could not run it here. Recommend running `POSTGRES_TEST_DSN=... make test-integration` (or targeting just this test) before merge.
- **`golangci-lint` not run** — recommend CI's lint job as the real gate here.
- **`--all-tables` mode still has zero backfill configs**, discovery included — this PR does not change that; the original fix plan explicitly flagged extending discovery to enumerate all tables in that mode as a separate scope decision.
- **pk.Canonical / commit 92526b6 interaction**: the plan notes composite-PK watermark equality should be asserted end-to-end once both PK-discovery and the canonical-value work are in. That end-to-end assertion is not part of this PR (it needs a live Postgres run per the point above) — worth a follow-up integration test once both land.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

A detailed high-level summary could not be generated for this review. Here is an overview derived from the analyzed file changes:

- **internal/cmd/filters.go**: ## AI-generated summary of changes
- **internal/cmd/pk_discovery.go**: ## AI-generated summary of changes
- **internal/cmd/pk_discovery_integration_test.go**: ## AI-generated summary of changes
- **internal/cmd/pk_discovery_test.go**: ## AI-generated summary of changes
- **internal/cmd/root.go**: ## AI-generated summary of changes
- **internal/cmd/root_backfill_test.go**: ## AI-generated summary of changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->