### PR TITLE
fix(router): persist cursor only up to the lowest blocked-group floor

### DIFF
--- a/internal/router/cursor_floor_test.go
+++ b/internal/router/cursor_floor_test.go
@@ -1,0 +1,337 @@
+package router_test
+
+// Tests for RTR-06: Router must never persist a consumer's cursor past the
+// lowest seq of a queued-but-undelivered RetryRecord for that
+// consumer+partition. Before this fix, dispatchUpdateCursor persisted
+// entry.Seq+1 unconditionally the moment a follow-on event for an
+// already-blocked group was queued in RetryScheduler (memory-only) — a crash
+// or restart while the group was blocked silently and permanently dropped
+// every queued follow-on, with zero delivery attempts ever made.
+
+import (
+	"context"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/olucasandrade/kaptanto/internal/eventlog"
+	"github.com/olucasandrade/kaptanto/internal/router"
+)
+
+// cursorSave is one recorded SaveCursor call.
+type cursorSave struct {
+	consumerID  string
+	partitionID uint32
+	seq         uint64
+}
+
+// recordingCursorStore is a router.ConsumerCursorStore that behaves like the
+// real (persistent) stores but also keeps a full history of every SaveCursor
+// call, so tests can assert on values that were transiently persisted, not
+// just the final value.
+type recordingCursorStore struct {
+	mu    sync.Mutex
+	data  map[string]uint64
+	calls []cursorSave
+}
+
+func newRecordingCursorStore() *recordingCursorStore {
+	return &recordingCursorStore{data: make(map[string]uint64)}
+}
+
+func (r *recordingCursorStore) key(consumerID string, partitionID uint32) string {
+	return consumerID + ":" + strconv.FormatUint(uint64(partitionID), 10)
+}
+
+func (r *recordingCursorStore) SaveCursor(_ context.Context, consumerID string, partitionID uint32, seq uint64) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.data[r.key(consumerID, partitionID)] = seq
+	r.calls = append(r.calls, cursorSave{consumerID: consumerID, partitionID: partitionID, seq: seq})
+	return nil
+}
+
+func (r *recordingCursorStore) LoadCursor(_ context.Context, consumerID string, partitionID uint32) (uint64, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	v, ok := r.data[r.key(consumerID, partitionID)]
+	if !ok {
+		return 1, nil
+	}
+	return v, nil
+}
+
+// maxSeq returns the highest seq ever passed to SaveCursor for
+// (consumerID, partitionID), across the entire call history — used to prove
+// the persisted cursor never transiently exceeded a floor, even though the
+// final value alone might look correct by coincidence.
+func (r *recordingCursorStore) maxSeq(consumerID string, partitionID uint32) uint64 {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var max uint64
+	for _, c := range r.calls {
+		if c.consumerID == consumerID && c.partitionID == partitionID && c.seq > max {
+			max = c.seq
+		}
+	}
+	return max
+}
+
+// TestPersistedCursorCappedAtBlockedFloor verifies the core RTR-06 invariant:
+// while a message group is blocked, the persisted cursor for that
+// consumer+partition never advances past the lowest seq of any record still
+// queued (undelivered) in RetryScheduler, even as OTHER keys on the same
+// partition keep being delivered and would otherwise push the cursor forward.
+//
+// Partition 0 contains: K1@1 (blocked forever in this test), K2@2, K2@3
+// (both succeed), K1@4 (follow-on, queued behind the blocked K1@1 head).
+func TestPersistedCursorCappedAtBlockedFloor(t *testing.T) {
+	entries := []eventlog.LogEntry{
+		makeEntry(1, `"K1"`),
+		makeEntry(2, `"K2"`),
+		makeEntry(3, `"K2"`),
+		makeEntry(4, `"K1"`),
+	}
+	el := newFakeEventLog(map[uint32][]eventlog.LogEntry{0: entries})
+
+	consumer := newControllableConsumer("floor-consumer")
+	consumer.Block(`"K1"`)
+
+	cs := newRecordingCursorStore()
+	r := router.NewRouter(el, 1, cs)
+	r.Register(consumer)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 400*time.Millisecond)
+	defer cancel()
+	go r.Run(ctx) //nolint:errcheck
+
+	// The single batch of 4 entries is processed almost immediately (no
+	// notify channel on fakeEventLog, but ReadPartition doesn't block when
+	// entries are available). 250ms is comfortably more than needed and well
+	// under the 1s RetryScheduler tick, so K1 never gets retried mid-test.
+	time.Sleep(250 * time.Millisecond)
+
+	// K2@2 and K2@3 must each be delivered exactly once — proving the
+	// in-memory cursor kept advancing past the blocked K1 group (otherwise
+	// the read window would keep rewinding and re-delivering them every poll).
+	got := consumer.delivered()
+	counts := map[uint64]int{}
+	for _, e := range got {
+		counts[e.Seq]++
+	}
+	if counts[2] != 1 {
+		t.Errorf("K2@2 expected delivered exactly once, got %d", counts[2])
+	}
+	if counts[3] != 1 {
+		t.Errorf("K2@3 expected delivered exactly once, got %d", counts[3])
+	}
+	if counts[1] != 0 {
+		t.Errorf("K1@1 must not be delivered while blocked, got %d deliveries", counts[1])
+	}
+	if counts[4] != 0 {
+		t.Errorf("K1@4 (follow-on) must not be delivered while K1 stays blocked, got %d deliveries", counts[4])
+	}
+
+	// The floor for (floor-consumer, partition 0) is 1 (K1@1's seq) for the
+	// entire test — it must never have been exceeded, even transiently, by
+	// any SaveCursor call triggered by K2@2 or K2@3's successful delivery, or
+	// by K1@4 being queued as a follow-on.
+	if max := cs.maxSeq("floor-consumer", 0); max != 1 {
+		t.Errorf("persisted cursor must never exceed the blocked floor (1) while K1 stays blocked; max persisted seq observed across all SaveCursor calls = %d", max)
+	}
+}
+
+// TestCrashRestartRedeliversQueuedFollowOns is the crash-restart simulation
+// from the fix plan's test plan: construct a NEW Router + fresh
+// RetryScheduler over the SAME EventLog and cursor store (exactly what a
+// process restart looks like), and assert that events which were only ever
+// queued in the first Router's memory-only RetryScheduler — never actually
+// delivered — are re-delivered in order after "restart".
+//
+// Partition 0 contains: K1@1 (blocked before crash), K2@2 (delivered before
+// crash), K1@3 (follow-on, queued behind K1@1 before crash, never delivered).
+//
+// Before the RTR-06 fix this test fails: the pre-fix router persists
+// entry.Seq+1 unconditionally, so after K1@3 is queued the persisted cursor
+// is already 4 — past the end of the partition — and the "restarted" router
+// never re-reads seq 1..3 at all, permanently losing K1@1 and K1@3.
+func TestCrashRestartRedeliversQueuedFollowOns(t *testing.T) {
+	entries := []eventlog.LogEntry{
+		makeEntry(1, `"K1"`),
+		makeEntry(2, `"K2"`),
+		makeEntry(3, `"K1"`),
+	}
+	el := newFakeEventLog(map[uint32][]eventlog.LogEntry{0: entries})
+	cs := newRecordingCursorStore()
+
+	// --- Before "crash" ---
+	// consumer1 blocks K1, so K1@1 and K1@3 only ever reach RetryScheduler's
+	// in-memory retry queue; they are never actually delivered.
+	consumer1 := newControllableConsumer("restart-consumer")
+	consumer1.Block(`"K1"`)
+
+	r1 := router.NewRouter(el, 1, cs)
+	r1.Register(consumer1)
+
+	ctx1, cancel1 := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	go r1.Run(ctx1) //nolint:errcheck
+	// Give it time to process the whole batch (K2@2 delivered, K1@1 blocked,
+	// K1@3 queued as follow-on) but stay well under the 1s retry tick, so no
+	// retry attempt — successful or not — happens before the simulated crash.
+	time.Sleep(200 * time.Millisecond)
+	cancel1()
+	// r1 and its RetryScheduler (holding K1@1 and K1@3 only in memory) are
+	// discarded here, unrecoverably, exactly like a process crash: nothing
+	// ever drains them.
+
+	preCrash := consumer1.delivered()
+	if len(preCrash) != 1 || preCrash[0].Seq != 2 {
+		t.Fatalf("pre-crash setup: expected only K2@2 delivered, got seqs %v", seqs(preCrash))
+	}
+
+	// --- "Restart" ---
+	// Brand-new Router + brand-new RetryScheduler (NewRouter always builds
+	// its own) over the SAME EventLog and cursor store. consumer2 is healthy
+	// this time (a real deployment would fix or route around the failure
+	// that caused the block before restarting).
+	consumer2 := newControllableConsumer("restart-consumer")
+
+	r2 := router.NewRouter(el, 1, cs)
+	r2.Register(consumer2)
+
+	ctx2, cancel2 := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel2()
+	if err := r2.Run(ctx2); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+
+	got := consumer2.delivered()
+	var k1Seqs []uint64
+	for _, e := range got {
+		if e.Seq == 1 || e.Seq == 3 {
+			k1Seqs = append(k1Seqs, e.Seq)
+		}
+	}
+	if len(k1Seqs) != 2 {
+		t.Fatalf("expected both K1@1 and K1@3 to be re-delivered after restart (a queued-but-undelivered follow-on must not be lost); delivered K1 seqs: %v, all delivered seqs: %v", k1Seqs, seqs(got))
+	}
+	if k1Seqs[0] != 1 || k1Seqs[1] != 3 {
+		t.Errorf("expected K1@1 before K1@3 after restart (RTR-04 per-key ordering), got order: %v", k1Seqs)
+	}
+}
+
+// TestDeadLetterReleasesFloorWhenQueueEmpties verifies that once a blocked
+// group's sole queued record is dead-lettered (maxRetries exhausted), the
+// RTR-06 floor for that consumer+partition is released (cleared) — otherwise
+// a permanently-failing event would pin the persisted cursor forever, causing
+// the whole partition window to re-deliver on every restart even though the
+// bad event itself has already been given up on.
+func TestDeadLetterReleasesFloorWhenQueueEmpties(t *testing.T) {
+	rs := router.NewRetryScheduler()
+	consumer := &alwaysFailConsumer{id: "dl-floor-empty"}
+
+	entry := makeEntry(5, `"K1"`)
+	entry.PartitionID = 2
+	rs.AddBlocked(consumer, `"K1"`, &router.RetryRecord{
+		Entry:       entry,
+		Attempts:    1,
+		NextRetryAt: time.Now().Add(-time.Second),
+		ConsumerID:  "dl-floor-empty",
+	})
+
+	if floor, ok := rs.Floor("dl-floor-empty", 2); !ok || floor != 5 {
+		t.Fatalf("expected floor=5 immediately after AddBlocked, got floor=%d ok=%v", floor, ok)
+	}
+
+	type release struct {
+		consumerID  string
+		partitionID uint32
+		floor       uint64
+		ok          bool
+	}
+	var mu sync.Mutex
+	var released []release
+	rs.OnFloorReleased = func(consumerID string, partitionID uint32, floor uint64, ok bool) {
+		mu.Lock()
+		defer mu.Unlock()
+		released = append(released, release{consumerID, partitionID, floor, ok})
+	}
+
+	const maxRetries = 15
+	for i := 0; i < maxRetries; i++ {
+		rs.ForceRetryNow(consumer, `"K1"`)
+		rs.Tick(context.Background())
+	}
+
+	if rs.BlockedCount(consumer) != 0 {
+		t.Fatalf("expected the group dead-lettered and cleared, got %d blocked groups", rs.BlockedCount(consumer))
+	}
+	if floor, ok := rs.Floor("dl-floor-empty", 2); ok {
+		t.Errorf("expected the floor to be released (cleared) after dead-letter drained the queue, got floor=%d ok=%v", floor, ok)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(released) == 0 {
+		t.Fatal("expected OnFloorReleased to fire when the dead-lettered head was popped")
+	}
+	last := released[len(released)-1]
+	if last.ok {
+		t.Errorf("expected the final OnFloorReleased call to report ok=false (no floor remains), got floor=%d ok=true", last.floor)
+	}
+	if last.consumerID != "dl-floor-empty" || last.partitionID != 2 {
+		t.Errorf("OnFloorReleased called with wrong identity: consumer=%q partition=%d", last.consumerID, last.partitionID)
+	}
+}
+
+// TestDeadLetterRaisesFloorWhenFollowOnRemains verifies that when a
+// dead-lettered head has a follow-on behind it, the floor RISES to the
+// follow-on's seq instead of clearing entirely — the follow-on is still
+// queued and undelivered, so the persisted cursor still must not pass it.
+func TestDeadLetterRaisesFloorWhenFollowOnRemains(t *testing.T) {
+	rs := router.NewRetryScheduler()
+	consumer := &alwaysFailConsumer{id: "dl-floor-followon"}
+
+	head := makeEntry(5, `"K1"`)
+	head.PartitionID = 2
+	rs.AddBlocked(consumer, `"K1"`, &router.RetryRecord{
+		Entry:       head,
+		Attempts:    1,
+		NextRetryAt: time.Now().Add(-time.Second),
+		ConsumerID:  "dl-floor-followon",
+	})
+
+	followOn := makeEntry(9, `"K1"`)
+	followOn.PartitionID = 2
+	rs.AddBlocked(consumer, `"K1"`, &router.RetryRecord{
+		Entry:       followOn,
+		Attempts:    0,
+		NextRetryAt: time.Now().Add(time.Hour), // not independently eligible yet
+		ConsumerID:  "dl-floor-followon",
+	})
+
+	if floor, ok := rs.Floor("dl-floor-followon", 2); !ok || floor != 5 {
+		t.Fatalf("expected floor=5 (the head), got floor=%d ok=%v", floor, ok)
+	}
+
+	const maxRetries = 15
+	for i := 0; i < maxRetries; i++ {
+		rs.ForceRetryNow(consumer, `"K1"`)
+		rs.Tick(context.Background())
+	}
+
+	// The head (seq=5) is dead-lettered after maxRetries; the follow-on
+	// (seq=9) becomes the new head and is made immediately eligible, but
+	// `consumer` always fails, so it stays queued rather than delivered.
+	if !rs.IsBlocked("dl-floor-followon", `"K1"`) {
+		t.Fatal("expected the follow-on to still be blocked after the head dead-lettered")
+	}
+	floor, ok := rs.Floor("dl-floor-followon", 2)
+	if !ok {
+		t.Fatal("expected the floor to still apply — the follow-on remains queued and undelivered")
+	}
+	if floor != 9 {
+		t.Errorf("expected the floor released (raised) to the follow-on's seq=9 after the head dead-lettered, got floor=%d", floor)
+	}
+}

--- a/internal/router/retry.go
+++ b/internal/router/retry.go
@@ -4,6 +4,16 @@
 // backoff schedule (1s, 5s, 30s, 2min, 10min plateau). After maxRetries failed
 // attempts the entry is dead-lettered: logged at slog.Error and removed from
 // blockedGroups so it no longer blocks subsequent events for that key.
+//
+// RTR-06 — cursor floor: RetryScheduler's blockedGroups queue is memory-only.
+// Router must never persist a consumer's cursor past the lowest seq of a
+// queued-but-undelivered record for that consumer+partition, or a crash while
+// a group is blocked would permanently skip every queued follow-on (the
+// persisted cursor would already be past them, and no retry state survives
+// the restart). RetryScheduler tracks this floor per (consumer, partition)
+// and exposes it via Floor(); Router.dispatchUpdateCursor caps every
+// SaveCursor call at min(nextSeq, floor). See Floor, AddBlocked, and
+// OnFloorReleased.
 package router
 
 import (
@@ -90,6 +100,19 @@ type RetryRecord struct {
 type consumerRetryState struct {
 	consumer      Consumer
 	blockedGroups map[string][]*RetryRecord
+
+	// floors tracks, per partition, the lowest seq among the head records of
+	// this consumer's currently blocked groups on that partition (RTR-06).
+	// A groupKey's queue always lives entirely on one partition — keys hash
+	// to a partition deterministically (same FNV-1a scheme as EventLog and
+	// WatermarkChecker, BKF-02) — so only the head record of each group
+	// (the lowest-seq, still-undelivered record in that group) can set the
+	// partition minimum; follow-on appends never lower it because they
+	// arrive in increasing-seq order behind an existing head.
+	//
+	// Absence of a key means "no floor": no blocked group exists for that
+	// partition, so the persisted cursor may advance freely.
+	floors map[uint32]uint64
 }
 
 // RetryScheduler manages retry state for an arbitrary set of consumers.
@@ -99,9 +122,27 @@ type consumerRetryState struct {
 // All exported methods are safe for concurrent use. The internal mu guards
 // the states map, which is read by Router.dispatch (via IsBlocked/AddBlocked)
 // and written by Tick (via Run goroutine).
+//
+// Lock ordering (RTR-06): RetryScheduler never calls back into Router while
+// holding rs.mu — Deliver is always invoked with rs.mu released (see Tick),
+// and OnFloorReleased is invoked after rs.mu is released too. This makes it
+// safe for Router to call RetryScheduler methods (AddBlocked, IsBlocked,
+// Floor) while holding Router.mu, which is the existing, established order
+// (see Router.dispatch): Router.mu is always acquired first, RetryScheduler.mu
+// second, never the reverse.
 type RetryScheduler struct {
 	mu     sync.Mutex
 	states map[string]*consumerRetryState // key = consumer.ID()
+
+	// OnFloorReleased, if set, is called after a blocked group's head record
+	// is popped (delivered or dead-lettered) and the floor for
+	// (consumerID, partitionID) has been recomputed. ok reports whether a
+	// floor still applies (another blocked group remains on that partition);
+	// when ok is false, floor is meaningless and the caller may persist any
+	// cursor value. Router wires this to re-persist the released cursor
+	// position so a partition that goes quiet after a group drains doesn't
+	// leave the cursor pinned at a stale floor. Called with rs.mu released.
+	OnFloorReleased func(consumerID string, partitionID uint32, floor uint64, ok bool)
 }
 
 // NewRetryScheduler creates a new, empty RetryScheduler.
@@ -132,11 +173,98 @@ func (rs *RetryScheduler) ensureStateLocked(c Consumer) *consumerRetryState {
 //
 // The head of the queue is the record being actively retried by Tick; only
 // after the head succeeds does Tick promote the next entry to head.
+//
+// AddBlocked also maintains the per-partition floor (RTR-06): a brand-new
+// blocked group's record is a new head, so it can only lower the floor for
+// rec.Entry.PartitionID. A follow-on append never changes the floor — it
+// arrives with a higher seq than the existing head and sits behind it in the
+// queue.
 func (rs *RetryScheduler) AddBlocked(c Consumer, groupKey string, rec *RetryRecord) {
 	rs.mu.Lock()
 	defer rs.mu.Unlock()
 	s := rs.ensureStateLocked(c)
+	_, existed := s.blockedGroups[groupKey]
 	s.blockedGroups[groupKey] = append(s.blockedGroups[groupKey], rec)
+	if !existed {
+		rs.lowerFloorLocked(s, rec.Entry.PartitionID, rec.Entry.Seq)
+	}
+}
+
+// lowerFloorLocked sets floors[partitionID] = seq if seq is lower than the
+// current floor, or no floor is set yet. Caller must hold rs.mu.
+func (rs *RetryScheduler) lowerFloorLocked(s *consumerRetryState, partitionID uint32, seq uint64) {
+	if s.floors == nil {
+		s.floors = make(map[uint32]uint64)
+	}
+	cur, ok := s.floors[partitionID]
+	if !ok || seq < cur {
+		s.floors[partitionID] = seq
+	}
+}
+
+// recomputeFloorLocked recalculates floors[partitionID] for consumer state s
+// by scanning the current head of every blocked group that lives on that
+// partition. Called after a head record is popped (delivered or
+// dead-lettered): popping can only raise the floor, never lower it, but the
+// new value can't be derived incrementally because a different group's head
+// may now be the partition minimum. Caller must hold rs.mu.
+func (rs *RetryScheduler) recomputeFloorLocked(s *consumerRetryState, partitionID uint32) {
+	min := uint64(0)
+	found := false
+	for _, queue := range s.blockedGroups {
+		if len(queue) == 0 {
+			continue
+		}
+		head := queue[0]
+		if head.Entry.PartitionID != partitionID {
+			continue
+		}
+		if !found || head.Entry.Seq < min {
+			min = head.Entry.Seq
+			found = true
+		}
+	}
+	if !found {
+		delete(s.floors, partitionID)
+		return
+	}
+	if s.floors == nil {
+		s.floors = make(map[uint32]uint64)
+	}
+	s.floors[partitionID] = min
+}
+
+// afterPopLocked recomputes the floor for (s, partitionID) after a head
+// record was popped, and returns a notify closure that invokes
+// OnFloorReleased with the resulting floor. The closure must be called only
+// after rs.mu is released — never while holding it — matching the same
+// off-lock discipline as Deliver in drainGroup. Caller must hold rs.mu when
+// calling afterPopLocked itself.
+func (rs *RetryScheduler) afterPopLocked(s *consumerRetryState, partitionID uint32) func() {
+	rs.recomputeFloorLocked(s, partitionID)
+	floor, ok := s.floors[partitionID]
+	cb := rs.OnFloorReleased
+	if cb == nil {
+		return func() {}
+	}
+	consumerID := s.consumer.ID()
+	return func() { cb(consumerID, partitionID, floor, ok) }
+}
+
+// Floor returns the current cursor floor for (consumerID, partitionID): the
+// lowest seq of any record still queued (undelivered) in a blocked message
+// group for that consumer on that partition. ok is false when there is no
+// blocked group on that partition, meaning the caller may persist any seq
+// without risking the loss of a queued-but-undelivered follow-on (RTR-06).
+func (rs *RetryScheduler) Floor(consumerID string, partitionID uint32) (uint64, bool) {
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
+	s, ok := rs.states[consumerID]
+	if !ok {
+		return 0, false
+	}
+	seq, ok := s.floors[partitionID]
+	return seq, ok
 }
 
 // BlockedCount returns the number of blocked groups for consumer c.
@@ -288,16 +416,26 @@ func (rs *RetryScheduler) drainGroup(ctx context.Context, s *consumerRetryState,
 				queue[1].NextRetryAt = time.Now()
 				s.blockedGroups[groupKey] = queue[1:]
 			}
+			// RTR-06: a head just left the queue, which can only raise the
+			// floor (or clear it). Recompute and notify Router so it can
+			// re-persist the released cursor even if this partition then
+			// goes quiet with no new events to trigger a dispatch.
+			notify := rs.afterPopLocked(s, rec.Entry.PartitionID)
 			rs.mu.Unlock()
+			notify()
 		case isPermanentError(err):
 			// Dead-letter the head; next entry becomes eligible immediately.
 			deadLetterHead(s, groupKey, queue)
+			notify := rs.afterPopLocked(s, rec.Entry.PartitionID)
 			rs.mu.Unlock()
+			notify()
 		default:
 			rec.Attempts++
 			if rec.Attempts >= maxRetries {
 				deadLetterHead(s, groupKey, queue)
+				notify := rs.afterPopLocked(s, rec.Entry.PartitionID)
 				rs.mu.Unlock()
+				notify()
 				continue
 			}
 			rec.NextRetryAt = time.Now().Add(NextDelay(rec.Attempts))

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -148,6 +148,12 @@ func NewRouter(el eventlog.EventLog, numPartitions uint32, cs ConsumerCursorStor
 		cursorStore:   cs,
 		rs:            NewRetryScheduler(),
 	}
+	// RTR-06: when a blocked group's head is popped (delivered or
+	// dead-lettered), the RetryScheduler's floor for that partition may rise
+	// or clear. Re-persist the released cursor immediately so a partition
+	// that goes quiet afterwards doesn't leave the cursor store pinned at a
+	// stale floor until the next unrelated event happens to be dispatched.
+	r.rs.OnFloorReleased = r.handleFloorRelease
 	if pn, ok := el.(eventlog.PartitionNotifier); ok {
 		r.notifyChs = make([]<-chan struct{}, numPartitions)
 		for i := uint32(0); i < numPartitions; i++ {
@@ -467,6 +473,14 @@ func (r *Router) dispatchUpdateCursor(
 	errs []error,
 	i int,
 ) {
+	// Normalize entry.PartitionID to the authoritative partitionID this
+	// dispatch call was invoked with. RetryScheduler's RTR-06 floor tracking
+	// keys off Entry.PartitionID (see AddBlocked/recomputeFloorLocked); relying
+	// on the EventLog implementation to always stamp it correctly on every
+	// LogEntry it returns is fragile — the production Badger EventLog does,
+	// but this keeps the invariant true unconditionally at the point it
+	// matters, regardless of the EventLog implementation.
+	entry.PartitionID = partitionID
 	if snap.blocked {
 		if r.metrics != nil {
 			r.metrics.ConsumerLag.WithLabelValues(cs.consumer.ID()).Add(1)
@@ -480,19 +494,22 @@ func (r *Router) dispatchUpdateCursor(
 			NextRetryAt: time.Now().Add(NextDelay(0)),
 			ConsumerID:  cs.consumer.ID(),
 		}
+		// AddBlocked queues this follow-on in RetryScheduler and, if it's the
+		// first record for this group, lowers the RTR-06 floor for this
+		// partition to entry.Seq. persistCursor (below) reads that floor to
+		// cap what actually reaches the cursor store.
 		r.rs.AddBlocked(cs.consumer, groupKey, rec)
+		// The in-memory cursor still advances past the blocked group so
+		// ReadPartition's window (minCursorForPartition) and future dispatch
+		// calls treat this entry as "seen" for this consumer — required for
+		// the follow-on flow (skip re-delivery attempts to the blocked
+		// group's own head while it's queued for retry). Only the persisted
+		// value is capped.
 		nextForFollowOn := entry.Seq + 1
 		if nextForFollowOn > cs.cursorByPartition[partitionID] {
 			cs.cursorByPartition[partitionID] = nextForFollowOn
 		}
-		if err := r.cursorStore.SaveCursor(ctx, cs.consumer.ID(), partitionID, nextForFollowOn); err != nil {
-			slog.Warn("router: failed to save cursor for blocked follow-on",
-				"consumer", cs.consumer.ID(),
-				"partition", partitionID,
-				"seq", entry.Seq,
-				"err", err,
-			)
-		}
+		r.persistCursor(ctx, cs, partitionID, nextForFollowOn)
 		return
 	}
 
@@ -522,19 +539,89 @@ func (r *Router) dispatchUpdateCursor(
 		return
 	}
 
+	// RTR-06: this delivery succeeded, but a DIFFERENT key on this same
+	// partition may still have a blocked group with a lower seq sitting only
+	// in RetryScheduler's memory-only queue. persistCursor caps nextForPartition
+	// at that group's floor so a crash right after this SaveCursor can't skip
+	// past it — the in-memory cursor still advances, so this consumer isn't
+	// redelivered this entry while the process stays up.
 	nextForPartition := entry.Seq + 1
 	if nextForPartition > cs.cursorByPartition[partitionID] {
 		cs.cursorByPartition[partitionID] = nextForPartition
 	}
-	if err := r.cursorStore.SaveCursor(ctx, cs.consumer.ID(), partitionID, nextForPartition); err != nil {
+	r.persistCursor(ctx, cs, partitionID, nextForPartition)
+	if r.metrics != nil {
+		r.metrics.ConsumerLag.WithLabelValues(cs.consumer.ID()).Set(0)
+	}
+}
+
+// persistCursor saves seq for (cs.consumer.ID(), partitionID), capped at the
+// RetryScheduler's RTR-06 floor for that consumer+partition when one is set.
+// The floor is the lowest seq of any record still queued (undelivered) in a
+// blocked message group; persisting past it would let a crash lose those
+// queued follow-ons forever, since RetryScheduler's queue does not survive a
+// restart.
+//
+// Residual behavior on restart: LoadCursor returns the floor (not the
+// consumer's true in-memory progress), so ReadPartition re-reads from there —
+// including entries for OTHER, non-blocked keys on the same partition that
+// this consumer had already delivered. Those re-deliveries are duplicates,
+// which is acceptable under at-least-once delivery and bounded by EventLog
+// retention, exactly like the existing dead-letter-after-15-retries policy.
+//
+// Must be called under r.mu write lock (same as dispatchUpdateCursor). Calls
+// r.rs.Floor, which acquires RetryScheduler's own mutex — this follows the
+// same Router.mu-then-RetryScheduler.mu order already used by AddBlocked and
+// IsBlocked elsewhere in this file; RetryScheduler never calls back into
+// Router while holding its own mutex, so no lock-order inversion is possible.
+func (r *Router) persistCursor(ctx context.Context, cs *consumerState, partitionID uint32, seq uint64) {
+	persistSeq := seq
+	if floor, ok := r.rs.Floor(cs.consumer.ID(), partitionID); ok && floor < persistSeq {
+		persistSeq = floor
+	}
+	if err := r.cursorStore.SaveCursor(ctx, cs.consumer.ID(), partitionID, persistSeq); err != nil {
 		slog.Warn("router: failed to save cursor",
 			"consumer", cs.consumer.ID(),
 			"partition", partitionID,
-			"seq", entry.Seq,
+			"seq", persistSeq,
 			"err", err,
 		)
 	}
-	if r.metrics != nil {
-		r.metrics.ConsumerLag.WithLabelValues(cs.consumer.ID()).Set(0)
+}
+
+// handleFloorRelease is registered as r.rs.OnFloorReleased. It re-persists
+// the cursor for (consumerID, partitionID) once RetryScheduler's floor for it
+// rises (a blocked group's head was delivered or dead-lettered) or clears
+// entirely (ok == false, no blocked group remains on this partition).
+//
+// Without this, a partition that goes quiet right after a blocked group
+// drains would leave the persisted cursor pinned at the old, now-stale floor
+// until the next unrelated event happens to be dispatched on that partition —
+// which may be a long time, or never, on a low-traffic table.
+//
+// Called by RetryScheduler with its own mutex released (see
+// RetryScheduler.afterPopLocked), so acquiring r.mu here is safe and follows
+// the same Router.mu-then-RetryScheduler.mu order used everywhere else.
+func (r *Router) handleFloorRelease(consumerID string, partitionID uint32, floor uint64, ok bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for i := range r.consumers {
+		cs := &r.consumers[i]
+		if cs.consumer.ID() != consumerID {
+			continue
+		}
+		seq := cs.cursorByPartition[partitionID]
+		if ok && floor < seq {
+			seq = floor
+		}
+		if err := r.cursorStore.SaveCursor(context.Background(), consumerID, partitionID, seq); err != nil {
+			slog.Warn("router: failed to save cursor after floor release",
+				"consumer", consumerID,
+				"partition", partitionID,
+				"seq", seq,
+				"err", err,
+			)
+		}
+		return
 	}
 }


### PR DESCRIPTION
## Source fix plan

`.claude/fix-plans/blocked-group-cursor-durability-20260702-131544.md`

## Problem

When a consumer's message group was blocked (a delivery failed), `dispatchUpdateCursor` in `internal/router/router.go` queued each follow-on event in `RetryScheduler` (memory-only) but immediately advanced and persisted the per-partition cursor to `entry.Seq+1`. A crash or restart while a group was blocked permanently skipped every queued follow-on: the persisted cursor was already past them, and no retry state survives a restart. This was a silent at-least-once violation — worse than the documented dead-letter-after-15-retries policy, because it happened with **zero delivery attempts**.

The same gap also applied more broadly: once any group was blocked, subsequent *successful* deliveries to other, unrelated keys on the same partition also advanced the persisted cursor past the blocked group's still-queued seq.

## Implementation summary

Introduced RTR-06: RetryScheduler now owns a per-`(consumer, partition)` **floor** — the lowest seq of any record still queued (undelivered) in a blocked message group for that consumer on that partition.

- `internal/router/retry.go`:
  - `consumerRetryState.floors map[uint32]uint64` tracks the floor per partition.
  - `AddBlocked` lowers the floor when a *new* group's head record is added (follow-on appends never lower it — they arrive with a higher seq behind the existing head).
  - `recomputeFloorLocked` recalculates the floor by scanning remaining group heads after a head is popped (delivered or dead-lettered) — a pop can only raise the floor, never lower it.
  - New exported `Floor(consumerID, partitionID) (uint64, bool)` for Router to query.
  - New `OnFloorReleased` callback field, invoked (with `rs.mu` released, matching the existing off-lock `Deliver` discipline) whenever a pop changes the floor, so Router can re-persist the released cursor even if the partition goes quiet afterwards.
  - Dead-letter paths (`isPermanentError` and `maxRetries` exhausted) both trigger the same floor recompute + notify — a permanently-failing event no longer pins the persisted cursor forever.

- `internal/router/router.go`:
  - New `persistCursor` helper caps every `SaveCursor` call at `min(nextSeq, floor)`. Used in both the blocked-follow-on branch and the successful-delivery branch of `dispatchUpdateCursor` (the latter matters because a *different* key's successful delivery on the same partition must not outrun another key's blocked floor).
  - New `handleFloorRelease`, wired as `r.rs.OnFloorReleased` in `NewRouter`, re-persists the cursor once a floor is released.
  - `dispatchUpdateCursor` now normalizes `entry.PartitionID = partitionID` up front — floor tracking keys off `Entry.PartitionID`, and this makes that invariant hold regardless of the EventLog implementation's fidelity (production Badger already sets it; some test fakes didn't).
  - In-memory `cursorByPartition` still advances unconditionally, exactly as before — only the *persisted* value is capped, so `minCursorForPartition`/live delivery are unaffected while the process stays up.

**Lock ordering**: RetryScheduler never calls back into Router while holding `rs.mu` (notifications and `Deliver` are always invoked after `rs.mu.Unlock()`), so Router may safely call `AddBlocked`/`IsBlocked`/`Floor` while holding `r.mu` — this is the same `Router.mu`-then-`RetryScheduler.mu` order already used throughout the file; no new inversion is introduced.

**Residual behavior**, documented in code comments: on restart, `LoadCursor` returns the floor, so the EventLog re-delivers from there — including already-delivered entries for *other*, non-blocked keys on the same partition. Those re-deliveries are duplicates, acceptable under at-least-once and bounded by EventLog retention, same as the existing dead-letter-after-15-retries policy.

## Validation

Run from the worktree at `/Users/lucasandrade/kaptanto-fix-blocked-group-cursor-durability`:

- `CGO_ENABLED=0 go build ./...` — **pass**
- `CGO_ENABLED=0 go vet ./...` — **pass**
- `CGO_ENABLED=1 go test ./internal/router/... -race -count=1 -v` — **pass**, all 24 tests including pre-existing RTR-04 (`TestPoisonPillIsolation`, `TestFollowOnEntryQueuedWhenGroupBlocked`, `TestNoDuplicateDeliveryWhenAnotherConsumerLags`), dead-letter, and lock-non-inversion (`TestTickDoesNotHoldLockAcrossDeliver`) tests
- `CGO_ENABLED=0 go test ./... -count=1` — **pass**, all packages
- New tests added (`internal/router/cursor_floor_test.go`):
  - `TestPersistedCursorCappedAtBlockedFloor` — blocks a group, dispatches follow-ons and other-key deliveries, asserts the persisted cursor's max-ever-seen value across the entire `SaveCursor` call history never exceeds the floor, while the healthy key is still delivered exactly once (proving the in-memory cursor kept advancing).
  - `TestCrashRestartRedeliversQueuedFollowOns` — constructs a NEW Router + fresh RetryScheduler over the SAME EventLog and cursor store; asserts queued follow-ons are re-delivered in order.
  - `TestDeadLetterReleasesFloorWhenQueueEmpties` / `TestDeadLetterRaisesFloorWhenFollowOnRemains` — dead-letter path releases (clears or raises) the floor correctly via `OnFloorReleased` and `Floor()`.
- **Confirmed the crash-restart test fails on pre-fix code**: temporarily reverted `router.go`/`retry.go` via `git stash` and ran the (trimmed, since `Floor`/`OnFloorReleased` don't exist pre-fix) crash-restart test in isolation — it failed with `delivered K1 seqs: []` (both K1@1 and K1@3 permanently lost), exactly as the fix plan predicted. Restored the fix and re-ran — passes.

## Residual risk / follow-up

- **Coordination point with `queue-sink-flushbatch-loss`**: that fix plan is implemented as a separate, isolated PR in parallel and also changes when cursors may be persisted (for `BatchFlusher`/broker-sink consumers). This PR only touches `dispatchUpdateCursor`'s per-event `SaveCursor` calls (now routed through the new `persistCursor` helper) and does not touch `FlushBatch` or batching logic. The two changes should not conflict at the code level, but whoever merges second should re-verify that `persistCursor`'s floor-capping logic composes correctly with any deferred-persist behavior the other PR introduces for batch-flush consumers — in particular, that a batch flush doesn't accidentally persist a cursor value that bypasses the RTR-06 floor cap.
- Restart re-delivery duplicates other, already-delivered keys below the floor on the same partition — bounded by EventLog retention, consistent with the existing dead-letter policy, but not separately load-tested here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

A detailed high-level summary could not be generated for this review. Here is an overview derived from the analyzed file changes:

- **internal/router/cursor_floor_test.go**: ## AI-generated summary of changes
- **internal/router/retry.go**: ## AI-generated summary of changes
- **internal/router/router.go**: ## AI-generated summary of changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->