### PR TITLE
perf(mongodb): batch change-stream appends to the EventLog

### DIFF
--- a/internal/source/mongodb/connector.go
+++ b/internal/source/mongodb/connector.go
@@ -2,8 +2,19 @@
 // MongoDB Change Streams, persists resume tokens, and emits ChangeEvents.
 //
 // Critical invariant (CHK-01): the resume token is NEVER saved to the
-// checkpoint store until after el.Append succeeds. This guarantees that on
-// restart the source re-delivers any event that was not durably committed.
+// checkpoint store until after the corresponding event(s) are durably
+// appended to the EventLog. This guarantees that on restart the source
+// re-delivers any event that was not durably committed.
+//
+// CHK-01 batch granularity: change-stream events are appended to the
+// EventLog in batches (see consumeStream), and the resume token is saved
+// once per batch — the token of the LAST event in the batch — rather than
+// once per event. A crash mid-batch re-opens the stream from the PREVIOUS
+// batch's token and re-sends the whole in-flight batch (up to
+// maxChangeStreamBatchSize events) on restart, instead of just the last
+// event. This is safe: EventLog.Append/AppendBatch dedups by
+// IdempotencyKey (LOG-03), so the re-sent events collapse into no-ops. Only
+// the size of the replay window on restart changes, not durability.
 package mongodb
 
 import (
@@ -13,6 +24,7 @@ import (
 	"log/slog"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"go.mongodb.org/mongo-driver/v2/bson"
@@ -28,6 +40,11 @@ import (
 const (
 	defaultInitialBackoff = 2 * time.Second
 	defaultMaxBackoff     = 60 * time.Second
+
+	// maxChangeStreamBatchSize caps the number of events drained via TryNext
+	// into a single AppendBatch call (see consumeStream). Mirrors the
+	// Postgres WAL path's per-commit batch cap.
+	maxChangeStreamBatchSize = 256
 )
 
 // ChangeStreamIter is the injectable interface for a MongoDB change stream
@@ -35,6 +52,12 @@ const (
 // a fake.
 type ChangeStreamIter interface {
 	Next(ctx context.Context) bool
+	// TryNext is a non-blocking advance: it reports whether a document is
+	// already available in the driver's internal buffer without waiting for
+	// a new one to arrive from the server. Used to greedily drain already
+	// buffered events into a batch (see consumeStream). *mongo.ChangeStream
+	// provides this natively.
+	TryNext(ctx context.Context) bool
 	Decode(v any) error
 	ResumeToken() bson.Raw
 	Err() error
@@ -83,15 +106,17 @@ func (c *Config) validate() error {
 // It persists resume tokens to a CheckpointStore so it can survive restarts.
 //
 // CHK-01 invariant: when an EventLog is configured, the resume token is saved
-// only after el.Append succeeds. A crash between Append and Save means the
-// source will re-deliver the event on restart; the EventLog's idempotency key
-// deduplicates the duplicate delivery.
+// only after the durable write (Append or AppendBatch) succeeds. A crash
+// between the durable write and the token Save means the source will
+// re-deliver the not-yet-checkpointed event(s) on restart; the EventLog's
+// idempotency key deduplicates the duplicate delivery. See the package doc
+// comment for the batch-granularity nuance introduced by consumeStream.
 type MongoDBConnector struct {
-	cfg          Config
-	store        checkpoint.CheckpointStore
-	idGen        *event.IDGenerator
-	eventLog     eventlog.EventLog // nil if no durable log
-	events       chan *event.ChangeEvent
+	cfg           Config
+	store         checkpoint.CheckpointStore
+	idGen         *event.IDGenerator
+	eventLog      eventlog.EventLog // nil if no durable log
+	events        chan *event.ChangeEvent
 	needsSnapshot bool
 	mu            sync.Mutex // guards needsSnapshot
 
@@ -106,6 +131,13 @@ type MongoDBConnector struct {
 	// client is the underlying MongoDB client (nil when watchFn is injected
 	// by tests, so we only connect when a real URI is provided).
 	client *mongo.Client
+
+	// batchStats tracks flush/event counts across all collection goroutines,
+	// exposed via BatchStats for tests/observability that need to confirm
+	// batching is actually occurring (as opposed to always flushing size-1
+	// batches).
+	batchesFlushed atomic.Uint64
+	eventsFlushed  atomic.Uint64
 }
 
 // New creates a MongoDBConnector without a durable EventLog. Delegates to
@@ -185,6 +217,15 @@ func (c *MongoDBConnector) NeedsSnapshot() bool {
 	return c.needsSnapshot
 }
 
+// BatchStats returns the cumulative number of AppendBatch flushes and events
+// flushed across all collection goroutines. Exposed for tests/observability
+// to confirm that batching is actually happening (events > batches implies
+// at least one batch held more than one event) rather than always degrading
+// to size-1 batches.
+func (c *MongoDBConnector) BatchStats() (batches, events uint64) {
+	return c.batchesFlushed.Load(), c.eventsFlushed.Load()
+}
+
 // Events returns the read-only channel on which ChangeEvents are emitted.
 // Callers should range over this channel concurrently with Run.
 func (c *MongoDBConnector) Events() <-chan *event.ChangeEvent {
@@ -197,6 +238,10 @@ func (c *MongoDBConnector) Events() <-chan *event.ChangeEvent {
 //
 // token is the change stream resume token associated with ev and is saved
 // to the checkpoint store after a successful Append.
+//
+// This single-event path remains available for callers that don't batch
+// (e.g. direct unit-test exercise of CHK-01); consumeStream uses
+// AppendAndQueueBatch on the hot path.
 func (c *MongoDBConnector) AppendAndQueue(ctx context.Context, ev *event.ChangeEvent, token bson.Raw) error {
 	if c.eventLog != nil {
 		if _, err := c.eventLog.Append(ev); err != nil {
@@ -216,6 +261,51 @@ func (c *MongoDBConnector) AppendAndQueue(ctx context.Context, ev *event.ChangeE
 	case c.events <- ev:
 	default:
 	}
+
+	c.batchesFlushed.Add(1)
+	c.eventsFlushed.Add(1)
+	return nil
+}
+
+// AppendAndQueueBatch durably appends evs to the EventLog in a single
+// AppendBatch call (if configured) and forwards each event to the events
+// channel individually (drain-or-drop, same semantics as AppendAndQueue —
+// batching only changes how many events share one durable write and one
+// checkpoint save, not the per-event forwarding contract).
+//
+// lastToken must be the resume token of the LAST event in evs. It is the
+// only token saved to the checkpoint store for this batch (CHK-01 batch
+// granularity — see the package doc comment). If AppendBatch fails, none of
+// the events are forwarded and the token is NOT saved.
+func (c *MongoDBConnector) AppendAndQueueBatch(ctx context.Context, evs []*event.ChangeEvent, lastToken bson.Raw) error {
+	if len(evs) == 0 {
+		return nil
+	}
+
+	if c.eventLog != nil {
+		if _, err := c.eventLog.AppendBatch(evs); err != nil {
+			return fmt.Errorf("mongodb: eventlog append batch: %w", err)
+		}
+	}
+
+	// CHK-01: save the LAST event's token only after the durable write
+	// succeeds. Saved once per batch, not once per event.
+	tokenStr := tokenToString(lastToken)
+	if err := c.store.Save(ctx, c.cfg.SourceID, tokenStr); err != nil {
+		return fmt.Errorf("mongodb: save checkpoint: %w", err)
+	}
+
+	// Forward to channel: drain-or-drop per event, looped rather than bulk
+	// sent, preserving the existing per-event drop semantics.
+	for _, ev := range evs {
+		select {
+		case c.events <- ev:
+		default:
+		}
+	}
+
+	c.batchesFlushed.Add(1)
+	c.eventsFlushed.Add(uint64(len(evs)))
 	return nil
 }
 
@@ -342,26 +432,74 @@ func (c *MongoDBConnector) runCollection(ctx context.Context, collName string) (
 	}
 }
 
+// decodeNext decodes the document iter is currently positioned on, captures
+// its resume token, and normalizes it into a ChangeEvent. On decode or
+// normalize failure it logs a warning and returns ok=false so the caller can
+// skip this document without aborting the surrounding batch — the same
+// skip-and-continue behavior as before batching was introduced.
+//
+// The resume token is read via iter.ResumeToken() immediately after Decode,
+// matching the token to the document that was just consumed.
+func (c *MongoDBConnector) decodeNext(collName string, iter ChangeStreamIter) (ev *event.ChangeEvent, token bson.Raw, ok bool) {
+	var rawDoc bson.Raw
+	if decErr := iter.Decode(&rawDoc); decErr != nil {
+		slog.Warn("mongodb: decode change stream doc", "collection", collName, "error", decErr)
+		return nil, nil, false
+	}
+
+	token = iter.ResumeToken()
+
+	ev, normErr := mongoparser.NormalizeChangeEvent(rawDoc, c.cfg.SourceID, c.idGen)
+	if normErr != nil {
+		slog.Warn("mongodb: normalize change event", "collection", collName, "error", normErr)
+		return nil, token, false
+	}
+	return ev, token, true
+}
+
 // consumeStream iterates over events from iter until iter is exhausted, the
 // context is cancelled, or an InvalidResumeToken error occurs.
+//
+// Batching (perf): each outer iteration blocks on Next for the first event,
+// then greedily drains any further ALREADY-buffered events via the
+// non-blocking TryNext (capped at maxChangeStreamBatchSize) before flushing
+// the whole batch through a single AppendAndQueueBatch call. This amortizes
+// the EventLog's per-Append fsync (LOG-01) across many events instead of
+// paying it once per event — the same fix already applied to the Postgres
+// WAL path (see postgres.receiveLoop's flushWALBuf).
+//
+// TryNext still issues a network round-trip ("getMore") when its internal
+// buffer is empty, so the drain loop is only entered after a successful
+// blocking Next, and it flushes immediately on the first empty TryNext
+// rather than waiting or retrying for more. At low event rates this
+// degenerates to exactly today's per-event batches of size 1, with no added
+// latency and no extra getMore traffic.
+//
+// See the package doc comment for the CHK-01 batch-granularity change this
+// introduces (resume token saved once per batch, not once per event).
 func (c *MongoDBConnector) consumeStream(ctx context.Context, collName string, iter ChangeStreamIter) (needsSnapshot bool, err error) {
 	for iter.Next(ctx) {
-		var rawDoc bson.Raw
-		if decErr := iter.Decode(&rawDoc); decErr != nil {
-			slog.Warn("mongodb: decode change stream doc", "collection", collName, "error", decErr)
-			continue
+		batch := make([]*event.ChangeEvent, 0, 1)
+		var lastToken bson.Raw
+
+		if ev, token, ok := c.decodeNext(collName, iter); ok {
+			batch = append(batch, ev)
+			lastToken = token
 		}
 
-		token := iter.ResumeToken()
-
-		ev, normErr := mongoparser.NormalizeChangeEvent(rawDoc, c.cfg.SourceID, c.idGen)
-		if normErr != nil {
-			slog.Warn("mongodb: normalize change event", "collection", collName, "error", normErr)
-			continue
+		for len(batch) < maxChangeStreamBatchSize && iter.TryNext(ctx) {
+			ev, token, ok := c.decodeNext(collName, iter)
+			if !ok {
+				continue
+			}
+			batch = append(batch, ev)
+			lastToken = token
 		}
 
-		if aqErr := c.AppendAndQueue(ctx, ev, token); aqErr != nil {
-			return false, aqErr
+		if len(batch) > 0 {
+			if aqErr := c.AppendAndQueueBatch(ctx, batch, lastToken); aqErr != nil {
+				return false, aqErr
+			}
 		}
 	}
 

--- a/internal/source/mongodb/connector_integration_test.go
+++ b/internal/source/mongodb/connector_integration_test.go
@@ -2,12 +2,16 @@ package mongodb_test
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/olucasandrade/kaptanto/internal/event"
 	mongodb "github.com/olucasandrade/kaptanto/internal/source/mongodb"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo"
@@ -119,4 +123,236 @@ func TestMongoIntegration_ChangeStream_CRUD(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("connector did not stop after context cancellation")
 	}
+}
+
+// TestMongoIntegration_BatchedAppends_UnderLoad drives a burst of inserts
+// against the connector and asserts that batching actually occurs: the
+// number of AppendBatch/AppendAndQueue flushes (BatchStats' batches) must be
+// smaller than the number of events flushed, proving at least one flush
+// combined multiple change-stream events instead of degrading to one flush
+// per event.
+//
+// This can only be asserted against a live server: the effect depends on
+// the driver's internal getMore/buffering behavior under real network and
+// server timing, which the in-process fakeIter used by the unit tests above
+// cannot faithfully reproduce.
+func TestMongoIntegration_BatchedAppends_UnderLoad(t *testing.T) {
+	uri := mongoTestURI(t)
+	cli := connectMongo(t, uri)
+
+	dbName := "kaptanto_it"
+	collName := "batch_load_" + time.Now().Format("150405.000000")
+	coll := cli.Database(dbName).Collection(collName)
+	t.Cleanup(func() {
+		_ = coll.Drop(context.Background())
+	})
+
+	conn, err := mongodb.New(mongodb.Config{
+		URI:         uri,
+		Database:    dbName,
+		Collections: []string{collName},
+		SourceID:    "it_batch_" + collName,
+	}, newFakeStore(), event.NewIDGenerator())
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	runErr := make(chan error, 1)
+	go func() { runErr <- conn.Run(ctx) }()
+
+	// Give the change stream a moment to open before producing writes.
+	time.Sleep(2 * time.Second)
+
+	const n = 500
+	docs := make([]interface{}, n)
+	for i := 0; i < n; i++ {
+		docs[i] = bson.M{"seq": i}
+	}
+	_, err = coll.InsertMany(ctx, docs)
+	require.NoError(t, err, "burst insert of %d documents", n)
+
+	// Poll BatchStats (atomic counters on the connector, safe to read
+	// concurrently with the Run goroutine) until every inserted document has
+	// been flushed, or time out. The events channel has a 1024-entry buffer,
+	// comfortably larger than n, so no concurrent drain is required to avoid
+	// drops here.
+	deadline := time.Now().Add(30 * time.Second)
+	var batches, events uint64
+	for time.Now().Before(deadline) {
+		batches, events = conn.BatchStats()
+		if events >= uint64(n) {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	require.Equal(t, uint64(n), events, "all %d inserted documents must be flushed as change events", n)
+	t.Logf("batch stats: %d batches for %d events (avg batch size %.1f)",
+		batches, events, float64(events)/float64(batches))
+	assert.Less(t, batches, events,
+		"sustained insert load must produce at least one multi-event batch (batches < events); "+
+			"if this fails, batching regressed to one AppendBatch call per event")
+
+	cancel()
+	select {
+	case <-runErr:
+	case <-time.After(5 * time.Second):
+		t.Fatal("connector did not stop after context cancellation")
+	}
+}
+
+// extractSeq pulls the "seq" field out of ev.After. seq is stored as a
+// string (not an int) so it survives the canonical Extended JSON encoding
+// NormalizeChangeEvent applies without needing to unwrap a $numberInt/
+// $numberLong wrapper. Returns ok=false for events with no After (deletes).
+func extractSeq(ev *event.ChangeEvent) (string, bool) {
+	if len(ev.After) == 0 {
+		return "", false
+	}
+	var doc struct {
+		Seq string `json:"seq"`
+	}
+	if err := json.Unmarshal(ev.After, &doc); err != nil || doc.Seq == "" {
+		return "", false
+	}
+	return doc.Seq, true
+}
+
+// TestMongoIntegration_CrashResume_NoGaps simulates a crash mid-stream: it
+// cancels a running connector partway through a burst of inserts (before
+// all of them are necessarily flushed), then starts a second connector
+// instance resuming from the same checkpoint store. It asserts every
+// inserted document is eventually observed by connector A and/or B
+// combined.
+//
+// This is the integration-level proof for the CHK-01 batch-granularity
+// change documented on MongoDBConnector: the resume token is saved once per
+// BATCH (the last event's token), not once per event, so a crash mid-batch
+// re-opens the stream from the PREVIOUS batch's token and connector B may
+// re-observe a few documents connector A already flushed (duplicates,
+// collapsed downstream by EventLog dedup on IdempotencyKey — LOG-03) — but
+// it must never permanently skip one (a gap).
+func TestMongoIntegration_CrashResume_NoGaps(t *testing.T) {
+	uri := mongoTestURI(t)
+	cli := connectMongo(t, uri)
+
+	dbName := "kaptanto_it"
+	collName := "crash_resume_" + time.Now().Format("150405.000000")
+	coll := cli.Database(dbName).Collection(collName)
+	t.Cleanup(func() {
+		_ = coll.Drop(context.Background())
+	})
+
+	store := newFakeStore()
+	sourceID := "it_crash_" + collName
+
+	const total = 200
+	var seenMu sync.Mutex
+	seen := make(map[string]bool, total)
+
+	recordSeen := func(ch <-chan *event.ChangeEvent, stop <-chan struct{}) {
+		for {
+			select {
+			case ev, ok := <-ch:
+				if !ok {
+					return
+				}
+				if seq, ok := extractSeq(ev); ok {
+					seenMu.Lock()
+					seen[seq] = true
+					seenMu.Unlock()
+				}
+			case <-stop:
+				return
+			}
+		}
+	}
+
+	// --- Connector A: consume some (not necessarily all) of a burst of
+	// inserts, then "crash" (context cancel) without draining everything. ---
+	connA, err := mongodb.New(mongodb.Config{
+		URI: uri, Database: dbName, Collections: []string{collName}, SourceID: sourceID,
+	}, store, event.NewIDGenerator())
+	require.NoError(t, err)
+
+	ctxA, cancelA := context.WithCancel(context.Background())
+	runErrA := make(chan error, 1)
+	go func() { runErrA <- connA.Run(ctxA) }()
+	stopA := make(chan struct{})
+	go recordSeen(connA.Events(), stopA)
+
+	// Give the change stream a moment to open before producing writes, so
+	// the resume position starts ahead of our operations.
+	time.Sleep(2 * time.Second)
+
+	docs := make([]interface{}, total)
+	for i := 0; i < total; i++ {
+		docs[i] = bson.M{"seq": fmt.Sprintf("seq-%04d", i)}
+	}
+	_, err = coll.InsertMany(context.Background(), docs)
+	require.NoError(t, err, "burst insert of %d documents", total)
+
+	// Let connector A observe *some* of the burst, then simulate a crash by
+	// cancelling before the full burst is necessarily flushed.
+	time.Sleep(1500 * time.Millisecond)
+	cancelA()
+	close(stopA)
+	select {
+	case <-runErrA:
+	case <-time.After(5 * time.Second):
+		t.Fatal("connector A did not stop after context cancellation")
+	}
+
+	seenMu.Lock()
+	afterA := len(seen)
+	seenMu.Unlock()
+	t.Logf("connector A observed %d/%d documents before simulated crash", afterA, total)
+
+	// --- Connector B: resume from the same store. It must eventually
+	// observe every document connector A had not durably flushed, with no
+	// permanent gaps. ---
+	connB, err := mongodb.New(mongodb.Config{
+		URI: uri, Database: dbName, Collections: []string{collName}, SourceID: sourceID,
+	}, store, event.NewIDGenerator())
+	require.NoError(t, err)
+
+	ctxB, cancelB := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancelB()
+	runErrB := make(chan error, 1)
+	go func() { runErrB <- connB.Run(ctxB) }()
+	stopB := make(chan struct{})
+	go recordSeen(connB.Events(), stopB)
+
+	deadline := time.Now().Add(18 * time.Second)
+	for time.Now().Before(deadline) {
+		seenMu.Lock()
+		n := len(seen)
+		seenMu.Unlock()
+		if n >= total {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	close(stopB)
+	cancelB()
+	select {
+	case <-runErrB:
+	case <-time.After(5 * time.Second):
+		t.Fatal("connector B did not stop after context cancellation")
+	}
+
+	seenMu.Lock()
+	defer seenMu.Unlock()
+	var missing []string
+	for i := 0; i < total; i++ {
+		key := fmt.Sprintf("seq-%04d", i)
+		if !seen[key] {
+			missing = append(missing, key)
+		}
+	}
+	assert.Empty(t, missing,
+		"crash/resume must not permanently lose any document (%d/%d missing after resume); "+
+			"batch-granularity checkpointing must only ever cause re-delivery, never a gap",
+		len(missing), total)
 }

--- a/internal/source/mongodb/connector_test.go
+++ b/internal/source/mongodb/connector_test.go
@@ -18,9 +18,9 @@ import (
 // ---- Fake implementations -----------------------------------------------
 
 type fakeStore struct {
-	saved    map[string]string
-	loadErr  error
-	saveErr  error
+	saved     map[string]string
+	loadErr   error
+	saveErr   error
 	saveCalls int
 }
 
@@ -47,8 +47,17 @@ func (f *fakeStore) Load(_ context.Context, sourceID string) (string, error) {
 func (f *fakeStore) Close() error { return nil }
 
 type fakeEventLog struct {
-	appendErr   error
+	appendErr error
+
+	// appendCalls counts single-event Append invocations.
 	appendCalls int
+
+	// batchCalls counts AppendBatch invocations; batchSizes records the
+	// length of evs on each call, in order. Together these let tests assert
+	// that N buffered events were flushed as ONE AppendBatch call (batching
+	// worked) rather than N separate calls (batching regressed to size 1).
+	batchCalls int
+	batchSizes []int
 }
 
 func (f *fakeEventLog) Append(ev *event.ChangeEvent) (uint64, error) {
@@ -61,12 +70,16 @@ func (f *fakeEventLog) ReadPartition(_ context.Context, _ uint32, _ uint64, _ in
 }
 
 func (f *fakeEventLog) AppendBatch(evs []*event.ChangeEvent) ([]uint64, error) {
-	f.appendCalls += len(evs)
+	f.batchCalls++
+	f.batchSizes = append(f.batchSizes, len(evs))
+	if f.appendErr != nil {
+		return nil, f.appendErr
+	}
 	seqs := make([]uint64, len(evs))
 	for i := range seqs {
 		seqs[i] = 1
 	}
-	return seqs, f.appendErr
+	return seqs, nil
 }
 
 func (f *fakeEventLog) Close() error { return nil }
@@ -77,6 +90,14 @@ type fakeIter struct {
 	idx         int
 	err         error
 	resumeToken bson.Raw
+
+	// noLookahead forces TryNext to always report no buffered events, even
+	// when more events remain — simulating a driver whose internal buffer
+	// never holds more than the document Next just fetched. Used to prove
+	// the low-rate path degenerates to today's per-event (batch-size-1)
+	// behavior.
+	noLookahead  bool
+	tryNextCalls int
 }
 
 func (f *fakeIter) Next(ctx context.Context) bool {
@@ -90,6 +111,23 @@ func (f *fakeIter) Next(ctx context.Context) bool {
 		return true
 	}
 	return false
+}
+
+// TryNext mirrors Next's "is a document available" semantics against the
+// same idx/events backing store, unless noLookahead forces it to report
+// nothing is buffered (see field doc).
+func (f *fakeIter) TryNext(ctx context.Context) bool {
+	f.tryNextCalls++
+	if ctx.Err() != nil {
+		return false
+	}
+	if f.err != nil {
+		return false
+	}
+	if f.noLookahead {
+		return false
+	}
+	return f.idx < len(f.events)
 }
 
 func (f *fakeIter) Decode(v any) error {
@@ -106,8 +144,25 @@ func (f *fakeIter) Decode(v any) error {
 	return bson.Unmarshal(raw, v)
 }
 
-func (f *fakeIter) ResumeToken() bson.Raw { return f.resumeToken }
-func (f *fakeIter) Err() error            { return f.err }
+// ResumeToken mirrors the real driver: it reflects the "_id" field of the
+// LAST document Decode returned, not a fixed value. Tests that don't decode
+// real change-stream documents (e.g. an empty fakeIter{}) can still set the
+// resumeToken field directly, which is used as a fallback before any
+// document has been decoded.
+func (f *fakeIter) ResumeToken() bson.Raw {
+	if f.idx == 0 || f.idx > len(f.events) {
+		return f.resumeToken
+	}
+	var doc struct {
+		ID bson.Raw `bson:"_id"`
+	}
+	if err := bson.Unmarshal(f.events[f.idx-1], &doc); err != nil {
+		return f.resumeToken
+	}
+	return doc.ID
+}
+
+func (f *fakeIter) Err() error                    { return f.err }
 func (f *fakeIter) Close(_ context.Context) error { return nil }
 
 // ---- Tests ---------------------------------------------------------------
@@ -273,4 +328,173 @@ func TestRun_ContextCancel_ReturnsContextCanceled(t *testing.T) {
 
 	runErr := c.Run(ctx)
 	assert.ErrorIs(t, runErr, context.Canceled)
+}
+
+// ---- Batching tests (perf: batch change-stream appends) ------------------
+
+// buildInsertChangeDoc builds a synthetic MongoDB Change Stream "insert"
+// document with a distinct resume token, suitable for driving fakeIter
+// through the real NormalizeChangeEvent path exercised by consumeStream.
+func buildInsertChangeDoc(t *testing.T, tokenData string, oid bson.ObjectID, status string) bson.Raw {
+	t.Helper()
+	resumeToken := bson.D{{Key: "_data", Value: tokenData}}
+	fullDoc := bson.D{{Key: "_id", Value: oid}, {Key: "status", Value: status}}
+	doc := bson.D{
+		{Key: "_id", Value: resumeToken},
+		{Key: "operationType", Value: "insert"},
+		{Key: "clusterTime", Value: bson.Timestamp{T: uint32(time.Now().Unix()), I: 1}},
+		{Key: "ns", Value: bson.D{{Key: "db", Value: "db"}, {Key: "coll", Value: "c1"}}},
+		{Key: "documentKey", Value: bson.D{{Key: "_id", Value: oid}}},
+		{Key: "fullDocument", Value: fullDoc},
+	}
+	b, err := bson.Marshal(doc)
+	require.NoError(t, err)
+	return bson.Raw(b)
+}
+
+// TestConsumeStream_BatchesBufferedEvents_SingleAppendBatchCall verifies the
+// core batching behavior (Test Plan a): when TryNext reports N-1 further
+// buffered events after a successful blocking Next, all N events are
+// flushed through exactly ONE AppendBatch call, the checkpoint token is
+// saved exactly once (the LAST event's token), and event order is preserved
+// on the events channel.
+func TestConsumeStream_BatchesBufferedEvents_SingleAppendBatchCall(t *testing.T) {
+	store := newFakeStore()
+	idGen := event.NewIDGenerator()
+	el := &fakeEventLog{}
+
+	oid1, oid2, oid3 := bson.NewObjectID(), bson.NewObjectID(), bson.NewObjectID()
+	doc1 := buildInsertChangeDoc(t, "82AA01", oid1, "one")
+	doc2 := buildInsertChangeDoc(t, "82AA02", oid2, "two")
+	doc3 := buildInsertChangeDoc(t, "82AA03", oid3, "three")
+
+	iter := &fakeIter{events: []bson.Raw{doc1, doc2, doc3}}
+	watchFn := func(_ context.Context, _ string, _ bson.Raw) (mongodb.ChangeStreamIter, error) {
+		return iter, nil
+	}
+
+	cfg := mongodb.Config{Database: "db", Collections: []string{"c1"}, SourceID: "src"}
+	c, err := mongodb.NewWithWatchFn(cfg, store, idGen, el, watchFn)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	// Run blocks until ctx expires (the change-stream loop retries watchFn
+	// indefinitely once the fake iter is exhausted); by the time it returns,
+	// the single expected batch has already been flushed synchronously in
+	// this same call stack, so reading el/store afterward is race-free.
+	_ = c.Run(ctx)
+
+	// Exactly one AppendBatch call, covering all 3 buffered events.
+	assert.Equal(t, 1, el.batchCalls, "3 buffered events must flush as exactly one AppendBatch call")
+	require.Len(t, el.batchSizes, 1)
+	assert.Equal(t, 3, el.batchSizes[0], "the single AppendBatch call must cover all 3 events")
+	assert.Equal(t, 0, el.appendCalls, "single-event Append must not be used for a multi-event batch")
+
+	// Token saved exactly once, and it is doc3's token (the LAST event), not
+	// doc1's or doc2's.
+	assert.Equal(t, 1, store.saveCalls, "checkpoint token must be saved once per batch, not once per event")
+	assert.Contains(t, store.saved["src"], "82AA03", "saved token must be the LAST event's token")
+	assert.NotContains(t, store.saved["src"], "82AA01", "saved token must not be an earlier event's token")
+	assert.NotContains(t, store.saved["src"], "82AA02", "saved token must not be an earlier event's token")
+
+	// Event order preserved on the channel.
+	ch := c.Events()
+	first := readTestEvent(t, ch)
+	second := readTestEvent(t, ch)
+	third := readTestEvent(t, ch)
+	assert.Contains(t, string(first.After), "one")
+	assert.Contains(t, string(second.After), "two")
+	assert.Contains(t, string(third.After), "three")
+
+	cancel()
+}
+
+// readTestEvent reads the next event off ch, failing the test on timeout.
+func readTestEvent(t *testing.T, ch <-chan *event.ChangeEvent) *event.ChangeEvent {
+	t.Helper()
+	select {
+	case ev := <-ch:
+		require.NotNil(t, ev)
+		return ev
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for event on channel")
+		return nil
+	}
+}
+
+// TestConsumeStream_NoLookahead_BehavesLikePerEventPath verifies the
+// regression safety net (Test Plan c): when TryNext reports nothing
+// buffered immediately after each blocking Next (noLookahead), the
+// connector degenerates to exactly today's per-event path — one AppendBatch
+// call per event, each of size 1, and one token save per event.
+func TestConsumeStream_NoLookahead_BehavesLikePerEventPath(t *testing.T) {
+	store := newFakeStore()
+	idGen := event.NewIDGenerator()
+	el := &fakeEventLog{}
+
+	oid1, oid2 := bson.NewObjectID(), bson.NewObjectID()
+	doc1 := buildInsertChangeDoc(t, "82BB01", oid1, "x")
+	doc2 := buildInsertChangeDoc(t, "82BB02", oid2, "y")
+
+	iter := &fakeIter{events: []bson.Raw{doc1, doc2}, noLookahead: true}
+	watchFn := func(_ context.Context, _ string, _ bson.Raw) (mongodb.ChangeStreamIter, error) {
+		return iter, nil
+	}
+
+	cfg := mongodb.Config{Database: "db", Collections: []string{"c1"}, SourceID: "src"}
+	c, err := mongodb.NewWithWatchFn(cfg, store, idGen, el, watchFn)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	_ = c.Run(ctx)
+
+	assert.Equal(t, 2, el.batchCalls, "with no lookahead, each event must flush its own AppendBatch call")
+	for _, sz := range el.batchSizes {
+		assert.Equal(t, 1, sz, "each batch must contain exactly 1 event when TryNext never reports lookahead")
+	}
+	assert.GreaterOrEqual(t, store.saveCalls, 2, "token must be saved once per event when batches are size 1")
+
+	cancel()
+}
+
+// TestAppendAndQueueBatch_CHK01_AppendBatchFailPreventsTokenSave extends the
+// single-event CHK-01 test (TestAppendAndQueue_CHK01_AppendFailPreventsTokenSave)
+// to the batch path (Test Plan a): if AppendBatch fails, the checkpoint
+// token must NOT be saved, regardless of batch size.
+func TestAppendAndQueueBatch_CHK01_AppendBatchFailPreventsTokenSave(t *testing.T) {
+	store := newFakeStore()
+	idGen := event.NewIDGenerator()
+	el := &fakeEventLog{appendErr: errors.New("disk full")}
+	c, err := mongodb.NewWithEventLog(mongodb.Config{Database: "db", Collections: []string{"c1"}}, store, idGen, el)
+	require.NoError(t, err)
+
+	evs := []*event.ChangeEvent{
+		{ID: idGen.New(), Operation: event.OpInsert, Table: "col", IdempotencyKey: "key1"},
+		{ID: idGen.New(), Operation: event.OpInsert, Table: "col", IdempotencyKey: "key2"},
+	}
+	lastToken := bson.Raw(`{"_data":"last"}`)
+
+	batchErr := c.AppendAndQueueBatch(context.Background(), evs, lastToken)
+	require.Error(t, batchErr)
+	assert.Equal(t, 0, store.saveCalls, "store.Save must NOT be called if AppendBatch fails (CHK-01)")
+}
+
+// TestAppendAndQueueBatch_EmptyBatch_NoOp verifies AppendAndQueueBatch is a
+// safe no-op for an empty batch (defensive: consumeStream already guards
+// this, but the method must not misbehave if called directly).
+func TestAppendAndQueueBatch_EmptyBatch_NoOp(t *testing.T) {
+	store := newFakeStore()
+	idGen := event.NewIDGenerator()
+	el := &fakeEventLog{}
+	c, err := mongodb.NewWithEventLog(mongodb.Config{Database: "db", Collections: []string{"c1"}}, store, idGen, el)
+	require.NoError(t, err)
+
+	err = c.AppendAndQueueBatch(context.Background(), nil, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 0, store.saveCalls)
+	assert.Equal(t, 0, el.batchCalls)
 }


### PR DESCRIPTION
## Source fix plan

`.claude/fix-plans/mongodb-batched-appends-20260702-131544.md`

## Problem

`AppendAndQueue` in `internal/source/mongodb/connector.go` called `EventLog.Append` once per change-stream event, and `Append` fsyncs before returning (LOG-01). Mongo ingest throughput was therefore fsync-bound per event — far below the Postgres WAL path, which was already converted to batched `AppendBatch` calls (`internal/source/postgres/connector.go:267,476`). The gap is an ingest-path artifact, not a source-database limit.

## Implementation

1. Extended `ChangeStreamIter` (`connector.go`) with `TryNext(ctx) bool` — a non-blocking advance that `*mongo.ChangeStream` already provides natively, so the real adapter (`connectReal`) needed no changes. Added `TryNext` to the test fake (`fakeIter` in `connector_test.go`), including a `noLookahead` mode used by the regression test below.
2. Reworked `consumeStream` into a greedy batch loop: after a blocking `Next` succeeds, it drains further already-buffered events via `TryNext` (capped at `maxChangeStreamBatchSize = 256`) into a `[]*event.ChangeEvent`, tracking the resume token of the LAST event. It flushes on the first empty `TryNext` or when the cap is hit, via a new `AppendAndQueueBatch` method that calls `EventLog.AppendBatch` once, saves the last-in-batch token, then forwards each event individually (looped, not bulk-sent — preserves the existing drain-or-drop-per-event semantics).
3. `TryNext` is only entered after a successful blocking `Next`, and the loop flushes immediately on the first empty `TryNext` rather than waiting — at low event rates this degenerates to exactly today's per-event batches of size 1, with no added latency and no extra `getMore` traffic.
4. Documented the CHK-01 granularity change on the package doc comment and `MongoDBConnector`'s doc comment: the resume token is now saved once per batch (the LAST event's token), not once per event. A crash mid-batch re-opens the stream from the previous batch's token and re-sends the whole in-flight batch; this is safe because `EventLog` dedups by `IdempotencyKey` (LOG-03) — only the size of the replay window on restart changes, not durability.
5. The per-collection concurrency model is unchanged — only intra-goroutine batching changes.
6. Added `BatchStats()` (atomic counters) on `MongoDBConnector` so tests/observability can confirm batching is actually occurring rather than silently degrading to size-1 batches.

## Tests added

Unit (`internal/source/mongodb/connector_test.go`, no live Mongo needed):
- `TestConsumeStream_BatchesBufferedEvents_SingleAppendBatchCall` — 3 buffered events (fake `TryNext` true twice then false) flush as exactly one `AppendBatch` call, the token saved once and equal to the LAST event's token, order preserved on the events channel.
- `TestConsumeStream_NoLookahead_BehavesLikePerEventPath` — `TryNext` always reports nothing buffered → each event gets its own `AppendBatch` call of size 1 and its own token save, proving the low-rate path is unchanged (regression safety net).
- `TestAppendAndQueueBatch_CHK01_AppendBatchFailPreventsTokenSave` — extends the existing single-event `TestAppendAndQueue_CHK01_AppendFailPreventsTokenSave` to the batch path: `AppendBatch` failure → token NOT saved.
- `TestAppendAndQueueBatch_EmptyBatch_NoOp` — defensive no-op check.

Integration (`internal/source/mongodb/connector_integration_test.go`, gated on `MONGO_TEST_URI`, skip cleanly without it):
- `TestMongoIntegration_BatchedAppends_UnderLoad` — bursts 500 inserts, polls `BatchStats()`, asserts `batches < events` (proves at least one multi-event flush occurred).
- `TestMongoIntegration_CrashResume_NoGaps` — runs connector A against a burst of 200 inserts, cancels it mid-stream to simulate a crash, then starts connector B resuming from the same checkpoint store, and asserts every document is eventually observed by A and/or B combined (no permanent gaps; duplicates from the batch-granularity replay window are expected and fine).

## Validation run

All from the worktree `/Users/lucasandrade/kaptanto-fix-mongodb-batched-appends`:

- `CGO_ENABLED=0 go build ./...` — **pass**
- `CGO_ENABLED=0 go vet ./...` — **pass**
- `CGO_ENABLED=0 go test ./internal/source/mongodb/... -count=1 -v` — **pass** (all unit tests pass; the 3 `MONGO_TEST_URI`-gated integration tests skip cleanly)
- `go test ./internal/source/mongodb/... -race -count=1` — **pass**, no races
- `CGO_ENABLED=0 go test ./... -count=1` — **pass**, full repo, nothing else broke
- `gofmt -l internal/source/mongodb/*.go` — clean
- `make lint` — golangci-lint is not installed in this sandbox; not run

## Residual risk / follow-up

This is durability-critical code and could not be validated end-to-end here — there is no live MongoDB replica set in this sandbox (Change Streams require a replica set). Specifically **unverified locally**:

- The claimed throughput improvement (fewer fsyncs per event under sustained load) — only provable against a real server's `getMore`/buffering behavior, which `fakeIter` cannot faithfully reproduce.
- Crash/resume gap-freedom under the new batch-granularity checkpointing — the new `TestMongoIntegration_CrashResume_NoGaps` integration test is written to prove this but has only been verified to compile and skip cleanly, not to actually pass against a live server.
- `TryNext`'s real network/round-trip behavior against the pinned `go.mongodb.org/mongo-driver/v2 v2.7.0` — confirmed the method exists with the expected signature (`func (cs *ChangeStream) TryNext(ctx context.Context) bool`) by reading the vendored driver source, but its buffering behavior under load is unverified here.

This is exactly what CI's `integration.yml` job (which provisions a single-node replica set and exports `MONGO_TEST_URI`) is for — it should run both new integration tests on this PR and needs to pass before merge.