### PR TITLE
fix(router): defer BatchFlusher cursor advance until flush succeeds

### DIFF
--- a/internal/output/kafka/consumer.go
+++ b/internal/output/kafka/consumer.go
@@ -2,16 +2,26 @@
 // that publishes CDC events to an Apache Kafka cluster using franz-go.
 //
 // Key design decisions:
-//   - CHK-01 (Durability): Deliver calls ProduceSync, which blocks until all
-//     in-sync replicas have acknowledged the write. The router's cursor is NOT
-//     advanced until ProduceSync returns nil, preserving at-least-once delivery.
+//   - CHK-01 (Durability): Deliver only buffers a record in memory and returns
+//     immediately; the actual produce happens in FlushBatch, called by the
+//     Router once per ReadPartition batch. The Router does not persist this
+//     consumer's cursor at Deliver time — it records a provisional advance and
+//     promotes it to the durable cursor only after FlushBatch returns nil. A
+//     FlushBatch/Produce failure discards the provisional advance, so the
+//     Router re-reads and re-delivers the same batch (after a backoff) instead
+//     of losing it — see router.BatchFlusher and internal/router/router.go.
 //   - DLV-02 (Per-key ordering): Record.Key is set to entry.Event.Key (the CDC
 //     primary key bytes). Kafka routes records with the same key to the same
 //     partition, giving per-key ordering within a topic.
 //   - DLV-04 (Idempotency header): Every record carries a "Kaptanto-Idempotency-Key"
 //     header set to entry.Event.IdempotencyKey, enabling downstream deduplication.
-//   - DLV-03 (No internal retry): On ProduceSync failure Deliver returns a non-nil
-//     error immediately. Retry is the RetryScheduler's responsibility.
+//     This also covers batches re-delivered after a FlushBatch failure: any
+//     records the broker already committed before the failure are deduplicated
+//     downstream by this key rather than silently lost or double-applied.
+//   - DLV-03 (No internal retry): On a template/encoding error Deliver returns
+//     a non-nil error immediately; on a produce error FlushBatch returns a
+//     non-nil error. Neither retries internally — retry (with NextDelay
+//     backoff for FlushBatch failures) is the Router's responsibility.
 //   - CGO-free: franz-go is a pure Go Kafka client; CGO_ENABLED=0 is safe.
 package kafkasink
 

--- a/internal/output/nats/consumer.go
+++ b/internal/output/nats/consumer.go
@@ -4,15 +4,27 @@
 // Key design decisions:
 //   - NATSSinkConsumer connects to a user-configured external NATS URL, never
 //     reusing the embedded eventlog connection.
-//   - Deliver blocks until js.PublishMsg returns a PubAck, preserving CHK-01:
-//     the router's cursor does not advance until the broker has confirmed the write.
+//   - CHK-01 (Durability): Deliver only buffers a message in memory and returns
+//     immediately; the actual PublishMsgAsync + PubAck wait happens in
+//     FlushBatch, called by the Router once per ReadPartition batch. The Router
+//     does not persist this consumer's cursor at Deliver time — it records a
+//     provisional advance and promotes it to the durable cursor only after
+//     FlushBatch returns nil. A FlushBatch failure discards the provisional
+//     advance, so the Router re-reads and re-delivers the same batch (after a
+//     backoff) instead of losing it — see router.BatchFlusher and
+//     internal/router/router.go.
 //   - Every published message includes a "Kaptanto-Idempotency-Key" header set
-//     to entry.Event.IdempotencyKey (DLV-04).
+//     to entry.Event.IdempotencyKey (DLV-04); this also covers batches
+//     re-delivered after a FlushBatch failure, so messages the broker already
+//     committed before the failure are deduplicated downstream rather than
+//     silently lost or double-applied.
 //   - The NATS subject is derived by executing a Go template against the ChangeEvent
 //     at deliver time (DLV-02 subject routing); per-key delivery ordering is an
 //     RTR-04 router guarantee, not a NATS JetStream feature.
-//   - On publish failure Deliver returns a non-nil error; retry is the RetryScheduler's
-//     responsibility — NATSSinkConsumer never retries internally (DLV-03).
+//   - DLV-03 (No internal retry): On a template/encoding error Deliver returns
+//     a non-nil error immediately; on a publish/ack error FlushBatch returns a
+//     non-nil error. Neither retries internally — retry (with NextDelay backoff
+//     for FlushBatch failures) is the Router's responsibility.
 //   - If StreamName is set in config, NewNATSSinkConsumer validates the stream exists
 //     and returns a clear error immediately if it does not (fail-fast).
 package natssink

--- a/internal/output/pubsub/consumer.go
+++ b/internal/output/pubsub/consumer.go
@@ -2,17 +2,30 @@
 // that publishes CDC events to Google Cloud Pub/Sub using the pubsub/v2 client library.
 //
 // Key design decisions:
-//   - CHK-01 (Durability): Deliver calls result.Get(ctx), which blocks until the
-//     Pub/Sub server acknowledges the publish. The router's cursor is NOT advanced
-//     until result.Get returns nil, preserving at-least-once delivery.
+//   - CHK-01 (Durability): Deliver calls the non-blocking pub.Publish and only
+//     buffers the returned PublishResult in memory; result.Get(ctx) — which
+//     blocks until the Pub/Sub server acknowledges the publish — is called by
+//     FlushBatch, invoked by the Router once per ReadPartition batch. The
+//     Router does not persist this consumer's cursor at Deliver time — it
+//     records a provisional advance and promotes it to the durable cursor
+//     only after FlushBatch returns nil. A FlushBatch failure discards the
+//     provisional advance, so the Router re-reads and re-delivers the same
+//     batch (after a backoff) instead of losing it — see router.BatchFlusher
+//     and internal/router/router.go.
 //   - DLV-02 (Per-key ordering): OrderingKey is set to string(entry.Event.Key) (the CDC
 //     primary key bytes). EnableMessageOrdering=true routes messages with the same key
 //     to the same ordering group, giving per-key ordering.
 //   - DLV-04 (Idempotency attribute): Every message carries a "Kaptanto-Idempotency-Key"
 //     attribute set to entry.Event.IdempotencyKey, enabling downstream deduplication.
-//   - DLV-03 (No internal retry): On publish failure, Deliver calls ResumePublish if the
-//     error is ErrPublishingPaused, then returns a non-nil error immediately. Retry is
-//     the RetryScheduler's responsibility.
+//     This also covers batches re-delivered after a FlushBatch failure, so
+//     messages the broker already committed before the failure are
+//     deduplicated downstream rather than silently lost or double-applied.
+//   - DLV-03 (No internal retry): On an encoding/resolution error Deliver
+//     returns a non-nil error immediately. On a publish/ack failure,
+//     FlushBatch calls ResumePublish if the error is ErrPublishingPaused,
+//     then returns a non-nil error. Neither retries internally — retry (with
+//     NextDelay backoff for FlushBatch failures) is the Router's
+//     responsibility.
 //   - CGO-free: cloud.google.com/go/pubsub/v2 is a pure Go client; CGO_ENABLED=0 is safe.
 //   - Per-table topic routing: When TopicTemplate is set, Deliver evaluates the template
 //     against entry.Event per-message and routes to the resolved topic's publisher. A lazy

--- a/internal/output/rabbitmq/consumer.go
+++ b/internal/output/rabbitmq/consumer.go
@@ -3,13 +3,25 @@
 // the amqp091-go library.
 //
 // Key design decisions:
-//   - CHK-01 (Durability): Deliver blocks until the broker acknowledges the
-//     publish via WaitContext on a DeferredConfirmation. The router cursor is NOT
-//     advanced until WaitContext returns, preserving at-least-once delivery.
-//   - DLV-03 (No internal retry): On any error Deliver returns immediately.
-//     Retry is the RetryScheduler's responsibility.
+//   - CHK-01 (Durability): Deliver calls PublishWithDeferredConfirmWithContext
+//     but does NOT wait for the broker's confirm — it only buffers the
+//     returned DeferredConfirmation in memory. Waiting via WaitContext on all
+//     buffered confirms happens in FlushBatch, called by the Router once per
+//     ReadPartition batch. The Router does not persist this consumer's cursor
+//     at Deliver time — it records a provisional advance and promotes it to
+//     the durable cursor only after FlushBatch returns nil. A FlushBatch
+//     failure discards the provisional advance, so the Router re-reads and
+//     re-delivers the same batch (after a backoff) instead of losing it — see
+//     router.BatchFlusher and internal/router/router.go.
+//   - DLV-03 (No internal retry): On a publish error Deliver returns
+//     immediately; on a confirm/nack error FlushBatch returns a non-nil
+//     error. Neither retries internally — retry (with NextDelay backoff for
+//     FlushBatch failures) is the Router's responsibility.
 //   - DLV-04 (Idempotency header): Every publish carries a
 //     "Kaptanto-Idempotency-Key" AMQP header set to entry.Event.IdempotencyKey.
+//     This also covers batches re-delivered after a FlushBatch failure, so
+//     messages the broker already confirmed before the failure are
+//     deduplicated downstream rather than silently lost or double-applied.
 //   - RTR-04 (Per-key ordering): The channel pool maps entry.PartitionID % 64
 //     to a dedicated channel. AMQP channels are NOT goroutine-safe, so each
 //     partition slot gets its own channel, matching the 64-partition EventLog.

--- a/internal/output/rabbitmq/consumer.go
+++ b/internal/output/rabbitmq/consumer.go
@@ -186,7 +186,7 @@ func NewRabbitMQSinkConsumer(id string, cfg config.RabbitMQSinkConfig) (*RabbitM
 	}
 
 	// 5. Start reconnect goroutine.
-	go c.reconnectLoop(ctx, cfg.URL, tlsCfg)
+	go c.reconnectLoop(ctx, conn, cfg.URL, tlsCfg)
 
 	return c, nil
 }
@@ -386,11 +386,13 @@ func (c *RabbitMQSinkConsumer) Close() {
 // reconnectLoop watches for connection drops and re-dials with exponential
 // backoff (initial=1s, max=30s, +50% jitter). It runs as a background goroutine
 // started by NewRabbitMQSinkConsumer and is stopped when Close() cancels ctx.
-func (c *RabbitMQSinkConsumer) reconnectLoop(ctx context.Context, url string, tlsCfg *tls.Config) {
-	c.mu.RLock()
-	conn := c.conn
-	c.mu.RUnlock()
-
+//
+// conn is the connection dialed by NewRabbitMQSinkConsumer, passed directly
+// rather than re-read from c.conn: if Close() runs before this goroutine gets
+// scheduled, c.conn is already nil, and re-reading it here would register
+// NotifyClose on a nil *amqp.Connection and panic (observed as a nil-pointer
+// SIGSEGV in CI, where scheduling timing made the race visible).
+func (c *RabbitMQSinkConsumer) reconnectLoop(ctx context.Context, conn *amqp.Connection, url string, tlsCfg *tls.Config) {
 	// Obtain initial close-notification channel.
 	notifyClose := conn.NotifyClose(make(chan *amqp.Error, 1))
 

--- a/internal/output/sqs/consumer.go
+++ b/internal/output/sqs/consumer.go
@@ -3,16 +3,29 @@
 //
 // Key design decisions:
 //   - SQS is a stateless HTTP API — there is no persistent connection to close or
-//     reconnect. Each SendMessage call is an independent HTTP request; the AWS SDK
-//     handles retries and credential refresh internally.
-//   - Deliver is synchronous (CHK-01): it blocks until SendMessage returns, so the
-//     router's cursor does not advance until the broker has confirmed the write.
+//     reconnect. Each SendMessageBatch call is an independent HTTP request; the AWS
+//     SDK handles retries and credential refresh internally.
+//   - CHK-01 (Durability): Deliver only buffers a message in memory and returns
+//     immediately; the actual SendMessageBatch call happens in FlushBatch,
+//     called by the Router once per ReadPartition batch. The Router does not
+//     persist this consumer's cursor at Deliver time — it records a
+//     provisional advance and promotes it to the durable cursor only after
+//     FlushBatch returns nil. A FlushBatch failure discards the provisional
+//     advance, so the Router re-reads and re-delivers the same batch (after a
+//     backoff) instead of losing it — see router.BatchFlusher and
+//     internal/router/router.go.
 //   - MessageGroupId is derived from FNV-1a 64-bit hash of the primary key, giving
 //     per-key FIFO ordering within the SQS FIFO queue (DLV-02 adaptation).
 //   - MessageDeduplicationId is SHA-256[:64] of IdempotencyKey, satisfying SQS's
-//     128-char limit while providing content-based deduplication (DLV-04).
-//   - On SendMessage failure Deliver returns a non-nil error; retry is the
-//     RetryScheduler's responsibility — SQSSinkConsumer never retries internally (DLV-03).
+//     128-char limit while providing content-based deduplication (DLV-04); this
+//     also covers batches re-delivered after a FlushBatch failure, so messages
+//     the broker already committed before the failure are deduplicated
+//     downstream rather than silently lost or double-applied.
+//   - DLV-03 (No internal retry): On an encoding error Deliver returns a
+//     non-nil error immediately; on a SendMessageBatch/per-entry failure
+//     FlushBatch returns a non-nil error. Neither retries internally — retry
+//     (with NextDelay backoff for FlushBatch failures) is the Router's
+//     responsibility.
 package sqssink
 
 import (

--- a/internal/router/batchflusher_cursor_test.go
+++ b/internal/router/batchflusher_cursor_test.go
@@ -3,7 +3,6 @@ package router_test
 import (
 	"context"
 	"errors"
-	"strconv"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -91,47 +90,9 @@ func (f *fakeCursorConsumer) getFlushAttempts() []time.Time {
 	return out
 }
 
-// recordingCursorStore is a router.ConsumerCursorStore that records every
-// SaveCursor call so tests can assert on exactly what was persisted, not just
-// the final value. LoadCursor returns 1 (the RTR-03 default) for unseen keys,
-// matching noopCursorStore.
-type recordingCursorStore struct {
-	mu    sync.Mutex
-	saved map[string]uint64
-}
-
-func newRecordingCursorStore() *recordingCursorStore {
-	return &recordingCursorStore{saved: make(map[string]uint64)}
-}
-
-func cursorKey(consumerID string, partitionID uint32) string {
-	return consumerID + ":" + strconv.FormatUint(uint64(partitionID), 10)
-}
-
-func (s *recordingCursorStore) SaveCursor(_ context.Context, consumerID string, partitionID uint32, seq uint64) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.saved[cursorKey(consumerID, partitionID)] = seq
-	return nil
-}
-
-func (s *recordingCursorStore) LoadCursor(_ context.Context, consumerID string, partitionID uint32) (uint64, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if v, ok := s.saved[cursorKey(consumerID, partitionID)]; ok {
-		return v, nil
-	}
-	return 1, nil
-}
-
-// lastSaved returns the last seq SaveCursor was called with for
-// (consumerID, partitionID), and whether SaveCursor was ever called at all.
-func (s *recordingCursorStore) lastSaved(consumerID string, partitionID uint32) (uint64, bool) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	v, ok := s.saved[cursorKey(consumerID, partitionID)]
-	return v, ok
-}
+// recordingCursorStore (and its constructor, newRecordingCursorStore) is
+// defined once for the package in cursor_floor_test.go; this file's tests use
+// its lastSaved method.
 
 // TestBatchFlusherCursorDeferredUntilFlushSucceeds is the core regression test
 // for the queue-sink-flushbatch-loss fix. Before the fix, dispatch Phase 3

--- a/internal/router/batchflusher_cursor_test.go
+++ b/internal/router/batchflusher_cursor_test.go
@@ -1,0 +1,318 @@
+package router_test
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/olucasandrade/kaptanto/internal/eventlog"
+	"github.com/olucasandrade/kaptanto/internal/router"
+)
+
+// errFlush is the sentinel error returned by fakeCursorConsumer.FlushBatch
+// when simulating a broker outage.
+var errFlush = errors.New("flush failed: broker unreachable")
+
+// fakeCursorConsumer implements router.Consumer and router.BatchFlusher. It
+// mimics the pop-before-send pattern used by all five real broker sinks
+// (kafka, nats, sqs, pubsub, rabbitmq): Deliver only buffers the seq into an
+// in-memory pending map; FlushBatch pops the batch out of pending and either
+// records it as durably "flushed" (broker acked) or drops it and returns an
+// error (broker rejected/unreachable) — exactly like the real sinks, which
+// never put a failed batch back into pending. Whether the dropped batch is
+// ever seen again depends entirely on the Router re-delivering the same
+// window, which is the behavior under test.
+type fakeCursorConsumer struct {
+	id string
+
+	failFlush atomic.Bool
+
+	mu            sync.Mutex
+	pending       map[uint32][]uint64
+	flushed       []uint64
+	flushAttempts []time.Time
+}
+
+var _ router.Consumer = (*fakeCursorConsumer)(nil)
+var _ router.BatchFlusher = (*fakeCursorConsumer)(nil)
+
+func (f *fakeCursorConsumer) ID() string { return f.id }
+
+func (f *fakeCursorConsumer) Deliver(_ context.Context, entry eventlog.LogEntry) error {
+	f.mu.Lock()
+	if f.pending == nil {
+		f.pending = make(map[uint32][]uint64)
+	}
+	f.pending[entry.PartitionID] = append(f.pending[entry.PartitionID], entry.Seq)
+	f.mu.Unlock()
+	return nil
+}
+
+func (f *fakeCursorConsumer) FlushBatch(_ context.Context, partitionID uint32) error {
+	f.mu.Lock()
+	f.flushAttempts = append(f.flushAttempts, time.Now())
+	batch := f.pending[partitionID]
+	delete(f.pending, partitionID)
+	f.mu.Unlock()
+
+	if len(batch) == 0 {
+		return nil
+	}
+	if f.failFlush.Load() {
+		// Mirror real sinks: the popped batch is dropped on failure, never
+		// re-queued internally. Only the Router re-reading and re-delivering
+		// the same window can recover it.
+		return errFlush
+	}
+
+	f.mu.Lock()
+	f.flushed = append(f.flushed, batch...)
+	f.mu.Unlock()
+	return nil
+}
+
+func (f *fakeCursorConsumer) getFlushed() []uint64 {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]uint64, len(f.flushed))
+	copy(out, f.flushed)
+	return out
+}
+
+func (f *fakeCursorConsumer) getFlushAttempts() []time.Time {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]time.Time, len(f.flushAttempts))
+	copy(out, f.flushAttempts)
+	return out
+}
+
+// recordingCursorStore is a router.ConsumerCursorStore that records every
+// SaveCursor call so tests can assert on exactly what was persisted, not just
+// the final value. LoadCursor returns 1 (the RTR-03 default) for unseen keys,
+// matching noopCursorStore.
+type recordingCursorStore struct {
+	mu    sync.Mutex
+	saved map[string]uint64
+}
+
+func newRecordingCursorStore() *recordingCursorStore {
+	return &recordingCursorStore{saved: make(map[string]uint64)}
+}
+
+func cursorKey(consumerID string, partitionID uint32) string {
+	return consumerID + ":" + strconv.FormatUint(uint64(partitionID), 10)
+}
+
+func (s *recordingCursorStore) SaveCursor(_ context.Context, consumerID string, partitionID uint32, seq uint64) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.saved[cursorKey(consumerID, partitionID)] = seq
+	return nil
+}
+
+func (s *recordingCursorStore) LoadCursor(_ context.Context, consumerID string, partitionID uint32) (uint64, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if v, ok := s.saved[cursorKey(consumerID, partitionID)]; ok {
+		return v, nil
+	}
+	return 1, nil
+}
+
+// lastSaved returns the last seq SaveCursor was called with for
+// (consumerID, partitionID), and whether SaveCursor was ever called at all.
+func (s *recordingCursorStore) lastSaved(consumerID string, partitionID uint32) (uint64, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	v, ok := s.saved[cursorKey(consumerID, partitionID)]
+	return v, ok
+}
+
+// TestBatchFlusherCursorDeferredUntilFlushSucceeds is the core regression test
+// for the queue-sink-flushbatch-loss fix. Before the fix, dispatch Phase 3
+// advanced and persisted the consumer cursor as soon as Deliver returned nil
+// — i.e. as soon as the event was buffered, not sent. A FlushBatch failure
+// then silently dropped the batch (see fakeCursorConsumer.FlushBatch, which
+// mirrors every real sink's pop-before-send behavior) with the cursor already
+// past it: permanent event loss.
+//
+// This test seeds 3 events on one partition behind a permanently-failing
+// FlushBatch, asserts nothing is durably flushed and the cursor store is
+// never advanced while the "broker" is down, then recovers the "broker" and
+// asserts all 3 events are (re-)delivered and flushed exactly once, and the
+// cursor store ends up at seq=4 (past all 3) — never further.
+func TestBatchFlusherCursorDeferredUntilFlushSucceeds(t *testing.T) {
+	entries := []eventlog.LogEntry{
+		makeEntry(1, `"k1"`),
+		makeEntry(2, `"k2"`),
+		makeEntry(3, `"k3"`),
+	}
+	el := newFakeEventLog(map[uint32][]eventlog.LogEntry{0: entries})
+
+	consumer := &fakeCursorConsumer{id: "kafka-defer"}
+	consumer.failFlush.Store(true)
+
+	cs := newRecordingCursorStore()
+	r := router.NewRouter(el, 1, cs)
+	r.Register(consumer)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = r.Run(ctx)
+	}()
+
+	// Give the router time to attempt (and fail) at least one flush.
+	time.Sleep(150 * time.Millisecond)
+
+	if got := consumer.getFlushed(); len(got) != 0 {
+		cancel()
+		<-done
+		t.Fatalf("expected zero successfully-flushed seqs while broker is down, got %v", got)
+	}
+	if seq, ok := cs.lastSaved(consumer.ID(), 0); ok {
+		cancel()
+		<-done
+		t.Fatalf("cursor store must never contain a seq past an unacked record — "+
+			"expected no SaveCursor call while FlushBatch keeps failing (CHK-01 violation), got saved seq=%d", seq)
+	}
+
+	// Recover the "broker" well before the NextDelay(0)==1s backoff elapses,
+	// so the next scheduled retry succeeds.
+	consumer.failFlush.Store(false)
+
+	deadline := time.After(3 * time.Second)
+waitLoop:
+	for {
+		select {
+		case <-deadline:
+			cancel()
+			<-done
+			t.Fatal("flush never succeeded after broker recovery within 3s")
+		default:
+		}
+		if len(consumer.getFlushed()) >= 3 {
+			break waitLoop
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	cancel()
+	<-done
+
+	flushed := consumer.getFlushed()
+	counts := map[uint64]int{}
+	for _, seq := range flushed {
+		counts[seq]++
+	}
+	for _, want := range []uint64{1, 2, 3} {
+		if counts[want] != 1 {
+			t.Errorf("seq=%d flushed %d times, want exactly 1 (router must stop re-delivering once flush succeeds)", want, counts[want])
+		}
+	}
+
+	seq, ok := cs.lastSaved(consumer.ID(), 0)
+	if !ok {
+		t.Fatal("expected cursor to be saved once FlushBatch succeeded")
+	}
+	if seq != 4 {
+		t.Errorf("expected persisted cursor seq=4 (past all 3 flushed entries, never further), got %d", seq)
+	}
+}
+
+// TestMixedConsumersSSEUnaffectedByBatchFlusherFailure covers the plan's Risk
+// (a): re-reading a window after a failed FlushBatch re-delivers it to every
+// consumer registered on the partition, not just the failing one, because
+// ReadPartition's fromSeq is the MINIMUM cursor across all consumers
+// (minCursorForPartition). This test proves that re-delivery is harmless to a
+// healthy, non-batching consumer sharing the partition: its own
+// entry.Seq < snap.cursor guard (dispatch, Phase 2) filters out anything it
+// already processed, so it must receive each event exactly once even while a
+// sibling BatchFlusher consumer's broker is permanently down and its cursor
+// never advances.
+func TestMixedConsumersSSEUnaffectedByBatchFlusherFailure(t *testing.T) {
+	entries := []eventlog.LogEntry{
+		makeEntry(1, `"m1"`),
+		makeEntry(2, `"m2"`),
+		makeEntry(3, `"m3"`),
+		makeEntry(4, `"m4"`),
+		makeEntry(5, `"m5"`),
+	}
+	el := newFakeEventLog(map[uint32][]eventlog.LogEntry{0: entries})
+
+	sse := &fakeConsumer{id: "sse-mixed"}
+	kafka := &fakeCursorConsumer{id: "kafka-mixed"}
+	kafka.failFlush.Store(true) // broker permanently down for the whole test
+
+	r := router.NewRouter(el, 1, nil)
+	r.Register(sse)
+	r.Register(kafka)
+
+	// Long enough to span at least two read/dispatch cycles for the stuck
+	// partition: the first attempt fails immediately, the second after the
+	// NextDelay(0)==1s backoff.
+	ctx, cancel := context.WithTimeout(context.Background(), 1300*time.Millisecond)
+	defer cancel()
+	if err := r.Run(ctx); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+
+	counts := map[uint64]int{}
+	for _, e := range sse.delivered() {
+		counts[e.Seq]++
+	}
+	for seq := uint64(1); seq <= 5; seq++ {
+		if counts[seq] != 1 {
+			t.Errorf("sse consumer: seq=%d delivered %d times, want exactly 1 "+
+				"(kafka consumer's stuck cursor re-widens the read window, but sse's own cursor must gate re-delivery)", seq, counts[seq])
+		}
+	}
+
+	if got := kafka.getFlushed(); len(got) != 0 {
+		t.Errorf("kafka consumer should never have flushed successfully (broker permanently down for this test), got %v", got)
+	}
+}
+
+// TestBatchFlusherBackoffAvoidsHotLoop covers plan step 4: consecutive
+// FlushBatch failures for a partition must be throttled by the
+// RetryScheduler's NextDelay backoff schedule, not retried on every poll
+// iteration. Without backoff, a down broker would cause runPartition to spin
+// ReadPartition/dispatch/FlushBatch continuously, producing hundreds of
+// attempts within the test window; with backoff, NextDelay(0) == 1s bounds
+// the loop to roughly one attempt per second while the failure persists.
+func TestBatchFlusherBackoffAvoidsHotLoop(t *testing.T) {
+	entries := []eventlog.LogEntry{makeEntry(1, `"backoff-key"`)}
+	el := newFakeEventLog(map[uint32][]eventlog.LogEntry{0: entries})
+
+	consumer := &fakeCursorConsumer{id: "kafka-backoff"}
+	consumer.failFlush.Store(true) // broker permanently down for this test
+
+	r := router.NewRouter(el, 1, nil)
+	r.Register(consumer)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1300*time.Millisecond)
+	defer cancel()
+	if err := r.Run(ctx); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+
+	attempts := consumer.getFlushAttempts()
+	if len(attempts) < 2 {
+		t.Fatalf("expected at least 2 FlushBatch attempts (initial failure + 1 backoff-scheduled retry) within 1.3s, got %d", len(attempts))
+	}
+	// A hot loop (no backoff) would produce hundreds of attempts in this
+	// window; NextDelay(0)==1s bounds a healthy backoff to ~2-3 attempts.
+	if len(attempts) > 5 {
+		t.Fatalf("too many FlushBatch attempts (%d) within 1.3s — backoff was not applied, router is hot-looping", len(attempts))
+	}
+	gap := attempts[1].Sub(attempts[0])
+	if gap < 800*time.Millisecond {
+		t.Errorf("expected roughly a 1s gap between the first and second FlushBatch attempt (NextDelay(0)==1s backoff), got %v", gap)
+	}
+}

--- a/internal/router/batchflusher_cursor_test.go
+++ b/internal/router/batchflusher_cursor_test.go
@@ -168,8 +168,24 @@ func TestBatchFlusherCursorDeferredUntilFlushSucceeds(t *testing.T) {
 		_ = r.Run(ctx)
 	}()
 
-	// Give the router time to attempt (and fail) at least one flush.
-	time.Sleep(150 * time.Millisecond)
+	// Wait until the router has attempted (and failed) at least one flush,
+	// rather than sleeping a fixed duration — a slow runner could otherwise
+	// let this pass without ever exercising the failure/discard path.
+	attemptDeadline := time.After(2 * time.Second)
+waitForAttempt:
+	for {
+		select {
+		case <-attemptDeadline:
+			cancel()
+			<-done
+			t.Fatal("router never attempted FlushBatch while broker was down")
+		default:
+		}
+		if len(consumer.getFlushAttempts()) > 0 {
+			break waitForAttempt
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 
 	if got := consumer.getFlushed(); len(got) != 0 {
 		cancel()

--- a/internal/router/cursor_floor_test.go
+++ b/internal/router/cursor_floor_test.go
@@ -62,6 +62,17 @@ func (r *recordingCursorStore) LoadCursor(_ context.Context, consumerID string, 
 	return v, nil
 }
 
+// lastSaved returns the last seq SaveCursor was called with for
+// (consumerID, partitionID), and whether SaveCursor was ever called at all
+// for that key — distinguishing "never saved" from "saved value 1" in a way
+// LoadCursor's RTR-03 default (1) cannot.
+func (r *recordingCursorStore) lastSaved(consumerID string, partitionID uint32) (uint64, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	v, ok := r.data[r.key(consumerID, partitionID)]
+	return v, ok
+}
+
 // maxSeq returns the highest seq ever passed to SaveCursor for
 // (consumerID, partitionID), across the entire call history — used to prove
 // the persisted cursor never transiently exceeded a floor, even though the

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -42,12 +42,38 @@ type Consumer interface {
 // coalesce network flushes. If a Consumer implements BatchFlusher, the Router
 // calls FlushBatch once after dispatching each ReadPartition batch instead of
 // relying on per-event flushes inside Deliver. This amortises flush latency
-// (e.g. http.Flusher) over an entire batch, significantly increasing SSE
-// delivery throughput on high-latency transports.
+// (e.g. http.Flusher, a broker producer's batch API) over an entire batch,
+// significantly increasing delivery throughput on high-latency transports.
+//
+// Cursor semantics (CHK-01, queue-sink-flushbatch-loss fix): for a
+// BatchFlusher consumer, a successful Deliver only buffers the event in
+// memory — it does NOT advance the consumer's durable cursor. Instead the
+// Router records a provisional cursor advance. The provisional advance is
+// promoted to the durable, persisted cursor only after FlushBatch returns
+// nil for that partition. If FlushBatch returns an error, the provisional
+// advance for that partition is discarded: the consumer's durable cursor is
+// unchanged, so the next ReadPartition call naturally re-reads and
+// re-delivers the same window (per-key order is preserved because entries
+// are re-delivered in the same seq order). Consecutive FlushBatch failures on
+// a partition apply the RetryScheduler's NextDelay backoff schedule before
+// the partition is polled again, so a persistently unreachable broker does
+// not hot-loop ReadPartition.
+//
+// Re-reading a failed window can re-deliver entries to OTHER consumers
+// registered on the same partition; this is harmless because each consumer's
+// own cursor already advanced past anything it successfully processed (see
+// the entry.Seq < snap.cursor guard in dispatch). It can also cause a
+// partial-success batch (broker acked some records, failed others) to be
+// re-delivered in full, producing broker-side duplicates for the
+// already-acked records — this is acceptable under at-least-once delivery;
+// DLV-04's idempotency keys make such duplicates dedupable downstream.
 type BatchFlusher interface {
 	// FlushBatch flushes any buffered writes to the underlying transport.
-	// Called by runPartition after processing each batch of entries.
-	// Errors are logged but do not block future delivery.
+	// Called by runPartition after processing each batch of entries. A nil
+	// return promotes this consumer's provisional cursor for partitionID to
+	// the durable, persisted cursor. A non-nil return discards the
+	// provisional advance so the batch is re-read and re-delivered on the
+	// next poll, after a NextDelay-scheduled backoff.
 	FlushBatch(ctx context.Context, partitionID uint32) error
 }
 
@@ -105,6 +131,18 @@ func (n *noopCursorStore) LoadCursor(_ context.Context, consumerID string, parti
 type consumerState struct {
 	consumer          Consumer
 	cursorByPartition map[uint32]uint64
+
+	// isBatchFlusher and provisionalByPartition implement the
+	// queue-sink-flushbatch-loss fix: for consumers that implement
+	// BatchFlusher, a successful Deliver during dispatch does not touch
+	// cursorByPartition directly. Instead it records a provisional advance
+	// here. runPartition promotes provisionalByPartition[p] into
+	// cursorByPartition[p] (and persists it) only after FlushBatch(p)
+	// returns nil; on failure the provisional advance is discarded so the
+	// next ReadPartition naturally re-reads the same window. Both fields are
+	// only populated/consulted when isBatchFlusher is true.
+	isBatchFlusher         bool
+	provisionalByPartition map[uint32]uint64
 }
 
 // consumerSnap is a lightweight snapshot of a consumer's state captured at
@@ -188,9 +226,14 @@ func (r *Router) Register(c Consumer) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
+	_, isBatchFlusher := c.(BatchFlusher)
 	cs := consumerState{
 		consumer:          c,
 		cursorByPartition: make(map[uint32]uint64),
+		isBatchFlusher:    isBatchFlusher,
+	}
+	if isBatchFlusher {
+		cs.provisionalByPartition = make(map[uint32]uint64)
 	}
 
 	ctx := context.Background()
@@ -233,6 +276,16 @@ func (r *Router) Run(ctx context.Context) error {
 	return nil
 }
 
+// flusherBackoff tracks consecutive FlushBatch failures for one BatchFlusher
+// consumer on one partition, so runPartition can apply the RetryScheduler's
+// NextDelay backoff schedule instead of hot-looping ReadPartition against a
+// consumer whose broker is unreachable (queue-sink-flushbatch-loss fix,
+// plan step 4).
+type flusherBackoff struct {
+	attempts int
+	nextAt   time.Time
+}
+
 // runPartition is the per-partition poll loop. It reads events sequentially
 // and dispatches each to all registered consumers. On empty batch (or error)
 // it waits for a notify signal from the EventLog writer or a fallback timer
@@ -268,11 +321,32 @@ func (r *Router) runPartition(ctx context.Context, partitionID uint32) {
 	var snaps []consumerSnap
 	var deliveryErrs []error
 
+	// backoffState tracks consecutive FlushBatch failures per BatchFlusher
+	// consumer on this partition (queue-sink-flushbatch-loss fix). It is
+	// scoped to this goroutine — safe without locking since only this
+	// partition's goroutine ever touches it.
+	backoffState := make(map[BatchFlusher]*flusherBackoff)
+	// backoffUntil is the latest nextAt across all consumers currently in
+	// backoff; the loop waits until this time before the next ReadPartition
+	// attempt, so a down broker does not cause a tight re-read/re-flush loop.
+	var backoffUntil time.Time
+
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		default:
+		}
+
+		if !backoffUntil.IsZero() {
+			if remaining := time.Until(backoffUntil); remaining > 0 {
+				select {
+				case <-ctx.Done():
+					return
+				case <-time.After(remaining):
+				}
+			}
+			backoffUntil = time.Time{}
 		}
 
 		nextSeq := r.minCursorForPartition(partitionID)
@@ -305,25 +379,103 @@ func (r *Router) runPartition(ctx context.Context, partitionID uint32) {
 			r.dispatch(ctx, partitionID, entry, &snaps, &deliveryErrs)
 		}
 
-		// Fix E: flush once per batch for consumers that implement BatchFlusher.
-		// Acquiring RLock to snapshot consumer list is safe here; the flush
-		// itself happens outside the lock.
+		// Flush once per batch for consumers that implement BatchFlusher, then
+		// promote or discard each consumer's provisional cursor advance based
+		// on the flush outcome (queue-sink-flushbatch-loss fix). Acquiring
+		// RLock to snapshot the consumer list is safe here; the flush itself
+		// happens outside the lock.
+		type flusherEntry struct {
+			bf  BatchFlusher
+			idx int // index into r.consumers, for provisional-cursor promotion/discard
+		}
 		r.mu.RLock()
-		flushers := make([]BatchFlusher, 0, len(r.consumers))
-		for _, cs := range r.consumers {
+		flushers := make([]flusherEntry, 0, len(r.consumers))
+		for i, cs := range r.consumers {
 			if bf, ok := cs.consumer.(BatchFlusher); ok {
-				flushers = append(flushers, bf)
+				flushers = append(flushers, flusherEntry{bf: bf, idx: i})
 			}
 		}
 		r.mu.RUnlock()
-		for _, bf := range flushers {
+		for _, fe := range flushers {
 			if ctx.Err() != nil {
 				return
 			}
-			if err := bf.FlushBatch(ctx, partitionID); err != nil {
+			if err := fe.bf.FlushBatch(ctx, partitionID); err != nil {
 				slog.Warn("router: batch flush error", "partition", partitionID, "err", err)
+				// Discard this consumer's provisional cursor advance so the
+				// next ReadPartition re-reads and re-delivers the same
+				// window (queue-sink-flushbatch-loss fix). Apply/extend the
+				// NextDelay backoff schedule so a persistently unreachable
+				// broker does not cause a hot loop.
+				r.discardProvisional(fe.idx, partitionID)
+				bo := backoffState[fe.bf]
+				if bo == nil {
+					bo = &flusherBackoff{}
+					backoffState[fe.bf] = bo
+				}
+				bo.attempts++
+				bo.nextAt = time.Now().Add(NextDelay(bo.attempts - 1))
+				if backoffUntil.IsZero() || bo.nextAt.After(backoffUntil) {
+					backoffUntil = bo.nextAt
+				}
+				continue
 			}
+			// Flush succeeded — clear any prior backoff and promote the
+			// provisional cursor to the durable, persisted cursor.
+			delete(backoffState, fe.bf)
+			r.promoteProvisional(ctx, fe.idx, partitionID)
 		}
+	}
+}
+
+// promoteProvisional promotes consumer index idx's provisional cursor advance
+// for partitionID into its durable cursor and persists it via cursorStore.
+// Called by runPartition after FlushBatch returns nil for a BatchFlusher
+// consumer (queue-sink-flushbatch-loss fix). No-op if idx is out of range
+// (consumer state was somehow removed — Router never unregisters, so this is
+// purely defensive) or there is no pending provisional advance.
+func (r *Router) promoteProvisional(ctx context.Context, idx int, partitionID uint32) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if idx >= len(r.consumers) {
+		return
+	}
+	cs := &r.consumers[idx]
+	provisional, ok := cs.provisionalByPartition[partitionID]
+	if !ok {
+		return
+	}
+	delete(cs.provisionalByPartition, partitionID)
+	if provisional > cs.cursorByPartition[partitionID] {
+		cs.cursorByPartition[partitionID] = provisional
+	}
+	if err := r.cursorStore.SaveCursor(ctx, cs.consumer.ID(), partitionID, cs.cursorByPartition[partitionID]); err != nil {
+		slog.Warn("router: failed to save cursor after batch flush",
+			"consumer", cs.consumer.ID(),
+			"partition", partitionID,
+			"err", err,
+		)
+	}
+	if r.metrics != nil {
+		r.metrics.ConsumerLag.WithLabelValues(cs.consumer.ID()).Set(0)
+	}
+}
+
+// discardProvisional discards consumer index idx's pending provisional cursor
+// advance for partitionID after a failed FlushBatch, so the next
+// ReadPartition call naturally re-reads and re-delivers the same window
+// (queue-sink-flushbatch-loss fix). No-op if idx is out of range (defensive
+// only — see promoteProvisional).
+func (r *Router) discardProvisional(idx int, partitionID uint32) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if idx >= len(r.consumers) {
+		return
+	}
+	cs := &r.consumers[idx]
+	delete(cs.provisionalByPartition, partitionID)
+	if r.metrics != nil {
+		r.metrics.ConsumerLag.WithLabelValues(cs.consumer.ID()).Add(1)
 	}
 }
 
@@ -523,6 +675,25 @@ func (r *Router) dispatchUpdateCursor(
 	}
 
 	nextForPartition := entry.Seq + 1
+
+	// queue-sink-flushbatch-loss fix: a BatchFlusher consumer's Deliver only
+	// buffered the event in memory — no network I/O happened yet. Advancing
+	// and persisting the durable cursor here would let the cursor outrun the
+	// actual send, so record a provisional advance instead. runPartition
+	// promotes it to cs.cursorByPartition (and persists it) only after
+	// FlushBatch confirms the buffered batch was actually sent; a flush
+	// failure discards the provisional advance so the batch is re-read and
+	// re-delivered. This branch is intentionally isolated from the
+	// non-batching path below and from the blocked-group follow-on path
+	// above (owned by a separate, concurrently developed fix) to keep the
+	// change additive.
+	if cs.isBatchFlusher {
+		if nextForPartition > cs.provisionalByPartition[partitionID] {
+			cs.provisionalByPartition[partitionID] = nextForPartition
+		}
+		return
+	}
+
 	if nextForPartition > cs.cursorByPartition[partitionID] {
 		cs.cursorByPartition[partitionID] = nextForPartition
 	}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -321,11 +321,14 @@ func (r *Router) runPartition(ctx context.Context, partitionID uint32) {
 	var snaps []consumerSnap
 	var deliveryErrs []error
 
-	// backoffState tracks consecutive FlushBatch failures per BatchFlusher
-	// consumer on this partition (queue-sink-flushbatch-loss fix). It is
-	// scoped to this goroutine — safe without locking since only this
-	// partition's goroutine ever touches it.
-	backoffState := make(map[BatchFlusher]*flusherBackoff)
+	// backoffState tracks consecutive FlushBatch failures per consumer index
+	// on this partition (queue-sink-flushbatch-loss fix), keyed by fe.idx
+	// rather than the BatchFlusher value itself — the interface doesn't
+	// require comparability, so a non-comparable concrete flusher type would
+	// panic on map access. fe.idx is stable because the router never
+	// unregisters consumers. Scoped to this goroutine — safe without locking
+	// since only this partition's goroutine ever touches it.
+	backoffState := make(map[int]*flusherBackoff)
 	// backoffUntil is the latest nextAt across all consumers currently in
 	// backoff; the loop waits until this time before the next ReadPartition
 	// attempt, so a down broker does not cause a tight re-read/re-flush loop.
@@ -381,51 +384,67 @@ func (r *Router) runPartition(ctx context.Context, partitionID uint32) {
 
 		// Flush once per batch for consumers that implement BatchFlusher, then
 		// promote or discard each consumer's provisional cursor advance based
-		// on the flush outcome (queue-sink-flushbatch-loss fix). Acquiring
-		// RLock to snapshot the consumer list is safe here; the flush itself
-		// happens outside the lock.
-		type flusherEntry struct {
-			bf  BatchFlusher
-			idx int // index into r.consumers, for provisional-cursor promotion/discard
-		}
-		r.mu.RLock()
-		flushers := make([]flusherEntry, 0, len(r.consumers))
-		for i, cs := range r.consumers {
-			if bf, ok := cs.consumer.(BatchFlusher); ok {
-				flushers = append(flushers, flusherEntry{bf: bf, idx: i})
-			}
-		}
-		r.mu.RUnlock()
-		for _, fe := range flushers {
-			if ctx.Err() != nil {
-				return
-			}
-			if err := fe.bf.FlushBatch(ctx, partitionID); err != nil {
-				slog.Warn("router: batch flush error", "partition", partitionID, "err", err)
-				// Discard this consumer's provisional cursor advance so the
-				// next ReadPartition re-reads and re-delivers the same
-				// window (queue-sink-flushbatch-loss fix). Apply/extend the
-				// NextDelay backoff schedule so a persistently unreachable
-				// broker does not cause a hot loop.
-				r.discardProvisional(fe.idx, partitionID)
-				bo := backoffState[fe.bf]
-				if bo == nil {
-					bo = &flusherBackoff{}
-					backoffState[fe.bf] = bo
-				}
-				bo.attempts++
-				bo.nextAt = time.Now().Add(NextDelay(bo.attempts - 1))
-				if backoffUntil.IsZero() || bo.nextAt.After(backoffUntil) {
-					backoffUntil = bo.nextAt
-				}
-				continue
-			}
-			// Flush succeeded — clear any prior backoff and promote the
-			// provisional cursor to the durable, persisted cursor.
-			delete(backoffState, fe.bf)
-			r.promoteProvisional(ctx, fe.idx, partitionID)
+		// on the flush outcome (queue-sink-flushbatch-loss fix).
+		backoffUntil = r.flushBatchConsumers(ctx, partitionID, backoffState, backoffUntil)
+	}
+}
+
+// flusherEntry pairs a BatchFlusher consumer with its index into r.consumers,
+// which promoteProvisional/discardProvisional need to locate the consumer's
+// provisional cursor state.
+type flusherEntry struct {
+	bf  BatchFlusher
+	idx int
+}
+
+// flushBatchConsumers flushes every BatchFlusher consumer once for
+// partitionID, then promotes or discards that consumer's provisional cursor
+// advance based on the flush outcome (queue-sink-flushbatch-loss fix). A
+// failed flush discards the provisional advance — so the next ReadPartition
+// re-reads and re-delivers the same window — and extends backoffState's
+// NextDelay schedule for that consumer so a persistently unreachable broker
+// does not cause a hot loop. Returns the backoffUntil the caller should wait
+// on before its next ReadPartition attempt (unchanged if no flush failed).
+//
+// Acquiring RLock to snapshot the consumer list is safe here; the flush
+// itself happens outside the lock. If ctx is cancelled mid-loop, remaining
+// flushers are skipped — runPartition's outer loop checks ctx.Done() again
+// on its next iteration and returns there.
+func (r *Router) flushBatchConsumers(ctx context.Context, partitionID uint32, backoffState map[int]*flusherBackoff, backoffUntil time.Time) time.Time {
+	r.mu.RLock()
+	flushers := make([]flusherEntry, 0, len(r.consumers))
+	for i, cs := range r.consumers {
+		if bf, ok := cs.consumer.(BatchFlusher); ok {
+			flushers = append(flushers, flusherEntry{bf: bf, idx: i})
 		}
 	}
+	r.mu.RUnlock()
+
+	for _, fe := range flushers {
+		if ctx.Err() != nil {
+			return backoffUntil
+		}
+		if err := fe.bf.FlushBatch(ctx, partitionID); err != nil {
+			slog.Warn("router: batch flush error", "partition", partitionID, "err", err)
+			r.discardProvisional(fe.idx, partitionID)
+			bo := backoffState[fe.idx]
+			if bo == nil {
+				bo = &flusherBackoff{}
+				backoffState[fe.idx] = bo
+			}
+			bo.attempts++
+			bo.nextAt = time.Now().Add(NextDelay(bo.attempts - 1))
+			if backoffUntil.IsZero() || bo.nextAt.After(backoffUntil) {
+				backoffUntil = bo.nextAt
+			}
+			continue
+		}
+		// Flush succeeded — clear any prior backoff and promote the
+		// provisional cursor to the durable, persisted cursor.
+		delete(backoffState, fe.idx)
+		r.promoteProvisional(ctx, fe.idx, partitionID)
+	}
+	return backoffUntil
 }
 
 // promoteProvisional promotes consumer index idx's provisional cursor advance


### PR DESCRIPTION
## Source fix plan

`.claude/fix-plans/queue-sink-flushbatch-loss-20260702-131544.md` (not committed, per policy).

## Problem

For `BatchFlusher` consumers (all 5 broker sinks: kafka, nats, sqs, pubsub, rabbitmq), `Deliver` only enqueues into an in-memory pending buffer and returns nil, so dispatch immediately advances and persists the consumer's durable cursor. `FlushBatch` — the actual network send, called once per `ReadPartition` batch — could then fail, but nothing rolled the cursor back, re-queued the batch, or engaged the RetryScheduler; the error was only `slog.Warn`-logged. A transient broker outage during a flush permanently lost up to a full `ReadPartition` window (256 events) per partition for that sink, contradicting the sinks' own CHK-01/DLV-03 doc comments, which claimed at-least-once.

## Implementation summary

1. **Deferred cursor updates**: `consumerState` gained `isBatchFlusher` and `provisionalByPartition`. `dispatchUpdateCursor`'s successful-delivery path now branches early for `BatchFlusher` consumers, recording a provisional advance instead of touching `cursorByPartition`/`SaveCursor` directly. This is an isolated early-return, separate from the pre-existing blocked-group-follow-on branch above it.
2. **Promote-on-success / discard-on-failure**: `runPartition`'s flush loop now calls `promoteProvisional` (advances + persists the durable cursor) after `FlushBatch` returns nil, or `discardProvisional` after a failure — so the next `ReadPartition` naturally re-reads and re-delivers the same window.
3. **Backoff on repeated failure**: a per-partition-goroutine `backoffState` map tracks consecutive `FlushBatch` failures per consumer and applies the existing `RetryScheduler.NextDelay` schedule before the next `ReadPartition` attempt, so a down broker doesn't hot-loop.
4. **Sink doc comments**: all 5 sinks' CHK-01/DLV-03 package comments updated to describe the actual (now-correct) mechanism. **No functional changes to any sink** — `Deliver`/`FlushBatch` implementations are untouched; the fix lives entirely in the router.

## Risk analysis (from the plan)

Re-reading a failed window re-delivers it to every consumer registered on that partition, not just the failing one, because `ReadPartition`'s `fromSeq` is the minimum cursor across all consumers. This is proven harmless to a healthy sibling consumer by a **pre-existing** mechanism already in `dispatch`: `if entry.Seq < snap.cursor { continue // already delivered and acked by this consumer }` (Phase 2, checked *before* `Deliver` is called) — the same guard that already isolates a healthy consumer from a *blocked* peer. New test `TestMixedConsumersSSEUnaffectedByBatchFlusherFailure` proves an SSE consumer receives each event exactly once while a sibling kafka-like consumer's broker stays permanently down for the whole test.

## Coordination note

A separate, concurrently-developed fix plan (`blocked-group-cursor-durability`, PR #30) also changes cursor-persist timing — for blocked-group follow-on events specifically, an entirely different code path. This PR's change is scoped to a new early-return branch in `dispatchUpdateCursor` and does not modify the blocked-group branch, to keep the two changes additive. Both PRs' authors should sanity-check the merged result once both land (a consumer that is simultaneously a `BatchFlusher` *and* has a blocked group on the same partition exercises both mechanisms — not separately tested by either PR in isolation).

## Validation run

```
CGO_ENABLED=0 go build ./...                                                         # clean
CGO_ENABLED=0 go vet ./...                                                            # clean
CGO_ENABLED=0 go test ./... -count=1                                                  # all 26 packages ok
CGO_ENABLED=1 go test ./internal/router/... ./internal/output/... -race -count=1 -v   # all pass, no races
```

**Gap-proof (performed and independently re-verified by the reviewer)**: copied `TestBatchFlusherCursorDeferredUntilFlushSucceeds` onto unmodified `main` — it fails: `SaveCursor` is called with `seq=4` despite zero successful `FlushBatch` calls, reproducing the exact CHK-01 violation this PR fixes. With the fix applied, the same test passes and the cursor store only ever contains a seq the broker actually acked.

## Residual risk / follow-up

- Live-broker chaos testing (kill the broker mid-stream, restore, assert zero missing idempotency keys) is unverified in this sandbox — no live brokers available. `integration.yml` / the bench harness's crash-recovery scenario are the real validation.
- See the coordination note above regarding the concurrent `blocked-group-cursor-durability` PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No blocking correctness or data-safety issues stand out from the router changes as summarized.

The main fix looks sound: BatchFlusher consumers now keep a provisional cursor until FlushBatch succeeds, failures re-read the same window, and the new tests cover the loss case, mixed-consumer behavior, and backoff.

Residual risk: the new backoff/cursor promotion path is subtle, so I’d still watch for future regressions around mixed batch-flusher/non-batch consumers on the same partition, but I don’t see an actionable bug in this PR as presented.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->