### PR TITLE
perf(backfill): replace O(rows*events) watermark scan with an indexed lookup

### DIFF
--- a/internal/backfill/backfill.go
+++ b/internal/backfill/backfill.go
@@ -167,12 +167,12 @@ type OpenConnFn func(ctx context.Context) (*pgx.Conn, error)
 // dependencies at construction time and implements the full keyset-cursor
 // snapshot loop.
 type BackfillEngineImpl struct {
-	configs        []BackfillConfig
-	store          BackfillStore
-	idGen          *event.IDGenerator
-	appendFn       AppendFn
-	appendBatchFn  AppendBatchFn
-	openConnFn     OpenConnFn
+	configs       []BackfillConfig
+	store         BackfillStore
+	idGen         *event.IDGenerator
+	appendFn      AppendFn
+	appendBatchFn AppendBatchFn
+	openConnFn    OpenConnFn
 	// watermark is optional; nil disables watermark deduplication.
 	watermark *WatermarkChecker
 }
@@ -367,6 +367,21 @@ func (b *BackfillEngineImpl) snapshotTable(ctx context.Context, cfg BackfillConf
 		// Non-fatal: if query or parse fails, SnapshotLSN remains 0 (conservative
 		// path — no rows suppressed incorrectly). pg_current_wal_flush_lsn() returns
 		// NULL on standby; the nil scan error is caught here and handled safely.
+	}
+
+	// Build the O(1) watermark index for this table before scanning any rows
+	// (perf fix: replaces the old per-row full-partition scan). StartTable
+	// registers the index before doing its one-time scan, so it cannot miss
+	// WAL events that land during the build (see StartTable's doc comment).
+	// If it fails, ShouldEmit transparently falls back to the scan-based
+	// path — same correctness, just the pre-fix throughput.
+	if b.watermark != nil {
+		if err := b.watermark.StartTable(ctx, cfg.Table, state.SnapshotLSN); err != nil {
+			slog.Warn("backfill: watermark index build failed, falling back to per-row scan",
+				"error", err, "table", cfg.Table)
+		} else {
+			defer b.watermark.FinishTable(cfg.Table)
+		}
 	}
 
 	// eventBuf accumulates snapshot row events for batched appends (Fix: BKF batch).

--- a/internal/backfill/watermark.go
+++ b/internal/backfill/watermark.go
@@ -4,34 +4,225 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sync"
 
 	"github.com/jackc/pglogrepl"
 	"github.com/olucasandrade/kaptanto/internal/event"
 	"github.com/olucasandrade/kaptanto/internal/eventlog"
 )
 
+// defaultMaxIndexKeys bounds the number of (table, key) entries the indexed
+// watermark path will hold in memory for a single table's active snapshot.
+//
+// Worst-case memory for one table's index is roughly
+// maxIndexKeys * (avg key size + 8 bytes for the uint64 LSN), plus Go map
+// overhead (~50 bytes/entry). At the default of 2,000,000 keys and a
+// generous 128-byte average canonical key, that is ~2M * (128+8+50) ≈ 372MB
+// worst case for a single table with that many keys mutated *during* its
+// snapshot window. If a table's index would exceed this cap, ShouldEmit
+// falls back to the original full-partition scan for that table (see
+// tableIndex.overCap) rather than growing the map unbounded.
+const defaultMaxIndexKeys = 2_000_000
+
+// watermarkPageSize is the number of partition entries fetched per ReadPartition
+// call, used both by the legacy full-scan fallback and by the one-time index
+// build in StartTable. Paging ensures a superseding WAL event is never missed
+// no matter how many events a partition has accumulated.
+const watermarkPageSize = 10000
+
+// tableIndex is the in-memory index for one table's active snapshot: for
+// every (table, key) pair with an event LSN greater than snapshotLSN, it
+// records the maximum such LSN. Only entries with lsn > snapshotLSN can ever
+// change a ShouldEmit decision (see ShouldEmit's doc comment), so entries at
+// or below snapshotLSN are never indexed.
+type tableIndex struct {
+	snapshotLSN uint64
+	keys        map[string]uint64 // canonical key bytes (as string) -> max LSN > snapshotLSN
+	// overCap is set once keys would exceed the checker's maxIndexKeys cap.
+	// keys is nilled out at that point (release memory) and ShouldEmit falls
+	// back to the full-partition scan for this table for the rest of its
+	// snapshot, exactly matching pre-indexed behaviour (correct, just slow).
+	overCap bool
+}
+
 // WatermarkChecker determines whether a snapshot row should be emitted by
 // checking whether a more recent WAL event for the same (table, pk) exists
 // in the Event Log. This enforces the watermark deduplication invariant:
 // a snapshot read is dropped if a WAL event with a higher LSN already exists.
+//
+// Two lookup paths are supported:
+//
+//   - Indexed (preferred): StartTable(table, snapshotLSN) builds an in-memory
+//     map[key]maxLSN once for the whole table by scanning every partition a
+//     single time, then keeps the map current via a synchronous EventLog
+//     append observer (see AppendObserver / AppendObservable in
+//     internal/eventlog). ShouldEmit becomes an O(1) map lookup. Call
+//     FinishTable when the table's snapshot completes to release the memory.
+//   - Scan (fallback): the original implementation, used automatically when
+//     StartTable was never called for a table, when the table's index
+//     exceeded the memory cap, or when the underlying EventLog does not
+//     support AppendObservable (e.g. the NATS cluster-mode EventLog). Pages
+//     through the entire partition for the row's key on every call —
+//     correct but O(partition size) per row.
 type WatermarkChecker struct {
 	eventLog      eventlog.EventLog
 	numPartitions uint32
+	maxIndexKeys  int
+
+	mu     sync.Mutex
+	tables map[string]*tableIndex
+
+	unregister func() // detaches this checker from the EventLog's observer list; nil if unsupported
 }
 
 // NewWatermarkChecker creates a WatermarkChecker backed by the given EventLog.
 // numPartitions must match the EventLog's partition count.
+//
+// If el implements eventlog.AppendObservable (BadgerEventLog does; the NATS
+// cluster EventLog currently does not), the checker registers itself as an
+// AppendObserver immediately — before any table's index is ever built — so
+// the "observer attached before initial scan" ordering required for
+// correctness (see StartTable) holds for every table, from the very first
+// StartTable call onward.
 func NewWatermarkChecker(el eventlog.EventLog, numPartitions uint32) *WatermarkChecker {
-	return &WatermarkChecker{
+	w := &WatermarkChecker{
 		eventLog:      el,
 		numPartitions: numPartitions,
+		maxIndexKeys:  defaultMaxIndexKeys,
+		tables:        make(map[string]*tableIndex),
+	}
+	if obsAble, ok := el.(eventlog.AppendObservable); ok {
+		w.unregister = obsAble.RegisterObserver(w)
+	}
+	return w
+}
+
+// SetMaxIndexKeys overrides the per-table memory cap (default
+// defaultMaxIndexKeys). Values <= 0 are ignored (the current cap is kept) —
+// there is intentionally no "unlimited" setting, since that would defeat the
+// cap's purpose of bounding worst-case memory (see defaultMaxIndexKeys).
+// Must be called before StartTable for the new cap to apply to that table.
+func (w *WatermarkChecker) SetMaxIndexKeys(n int) {
+	if n <= 0 {
+		return
+	}
+	w.mu.Lock()
+	w.maxIndexKeys = n
+	w.mu.Unlock()
+}
+
+// Close detaches this checker from the EventLog's observer list. Safe to
+// call multiple times or when no observer was ever registered.
+func (w *WatermarkChecker) Close() {
+	if w.unregister != nil {
+		w.unregister()
 	}
 }
 
-// watermarkPageSize is the number of partition entries fetched per ReadPartition
-// call. ShouldEmit pages through the entire partition so a superseding WAL event
-// is never missed, no matter how many events the partition has accumulated.
-const watermarkPageSize = 10000
+// StartTable builds (or rebuilds) the in-memory watermark index for table,
+// enabling the O(1) indexed ShouldEmit path for it. Call this once at the
+// start of a table's snapshot, before the first snapshot row is read.
+//
+// Ordering (correctness-critical, BKF-02): this method registers the empty
+// index for table BEFORE scanning the event log. Since NewWatermarkChecker
+// already registered this checker as an AppendObserver ahead of any
+// StartTable call, any event committed after the index is registered here is
+// guaranteed to be captured by ONE OF:
+//
+//  1. ObserveAppend, if the commit's synchronous observer callback (which
+//     always runs after the Badger commit, per AppendObserver's contract)
+//     happens to run after this method's initial map insert, or
+//  2. The scan started immediately below, which reads Badger's then-current
+//     state and therefore sees anything committed before the scan starts
+//     (including anything committed between the map insert and the scan, by
+//     transitivity: commit-before-observer-call and, separately here,
+//     insert-before-scan-start are both single-goroutine program-order facts).
+//
+// An event can be observed by BOTH paths (e.g. committed while the scan is
+// mid-flight); that is harmless because indexing is idempotent — merging the
+// same (key, lsn) twice just re-writes the same max. The only failure mode
+// this ordering rules out is an event being seen by NEITHER path, which
+// would silently let a superseded snapshot row escape suppression.
+//
+// If the resulting index would exceed the configured memory cap, StartTable
+// aborts the build and marks the table as over-cap: ShouldEmit falls back to
+// the scan-based implementation for this table (see tableIndex.overCap).
+//
+// If the scan itself fails or is cancelled partway through (ctx.Err() or a
+// ReadPartition error), StartTable removes the partial index it had
+// registered before returning the error. A partial index is worse than no
+// index: unlike the intentional overCap fallback, ShouldEmit has no way to
+// tell a partial index from a complete one, so leaving it registered would
+// make ShouldEmit silently trust incomplete data — a WAL event in a
+// not-yet-scanned partition would be invisible to it, exactly the "seen by
+// NEITHER path" failure mode the ordering argument above is meant to rule
+// out. Removing it forces every ShouldEmit call for this table back onto the
+// always-correct scan path until a subsequent StartTable call succeeds.
+func (w *WatermarkChecker) StartTable(ctx context.Context, table string, snapshotLSN uint64) (err error) {
+	ti := &tableIndex{
+		snapshotLSN: snapshotLSN,
+		keys:        make(map[string]uint64),
+	}
+
+	// Register the (empty) index BEFORE scanning. From this point on,
+	// ObserveAppend (already live since NewWatermarkChecker) will merge any
+	// matching event into ti.keys as it commits.
+	w.mu.Lock()
+	w.tables[table] = ti
+	w.mu.Unlock()
+
+	defer func() {
+		if err == nil {
+			return
+		}
+		w.mu.Lock()
+		// Only remove it if it's still OUR ti — a concurrent StartTable call
+		// for the same table (or FinishTable) may have already replaced or
+		// removed it, and we must not clobber that newer state.
+		if w.tables[table] == ti {
+			delete(w.tables, table)
+		}
+		w.mu.Unlock()
+	}()
+
+	for partition := uint32(0); partition < w.numPartitions; partition++ {
+		fromSeq := uint64(0)
+		for {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return ctxErr
+			}
+			entries, readErr := w.eventLog.ReadPartition(ctx, partition, fromSeq, watermarkPageSize)
+			if readErr != nil {
+				return fmt.Errorf("watermark: build index for %q, partition %d: %w", table, partition, readErr)
+			}
+
+			w.mergeEntries(table, ti, entries)
+
+			w.mu.Lock()
+			overCap := ti.overCap
+			w.mu.Unlock()
+			if overCap {
+				return nil // cap hit; ShouldEmit will use the scan fallback for this table
+			}
+
+			if len(entries) < watermarkPageSize {
+				break
+			}
+			fromSeq = entries[len(entries)-1].Seq + 1
+		}
+	}
+
+	return nil
+}
+
+// FinishTable releases the in-memory index for table (if any), bounding
+// memory to only the tables currently being backfilled. Safe to call even if
+// StartTable was never called for table, or was already finished.
+func (w *WatermarkChecker) FinishTable(table string) {
+	w.mu.Lock()
+	delete(w.tables, table)
+	w.mu.Unlock()
+}
 
 // ShouldEmit returns true if the snapshot row for (table, pk) should be emitted.
 //
@@ -39,11 +230,107 @@ const watermarkPageSize = 10000
 // an LSN greater than snapshotLSN — meaning a WAL event has already superseded
 // this snapshot row.
 //
-// The partition is computed via eventlog.PartitionOf(pk, numPartitions) to avoid
-// scanning all partitions. The partition is paged through to completion: a single
-// capped read would miss the newest (highest-seq) events, which are exactly the
-// ones most likely to supersede the snapshot row (BKF-02).
+// If StartTable(table, snapshotLSN) was previously called (and the table's
+// index has not exceeded the memory cap), this is an O(1) map lookup.
+// Otherwise it transparently falls back to the O(partition size) full scan —
+// the original implementation — so callers that never adopt StartTable (or
+// whose EventLog does not support AppendObservable) keep working unchanged.
 func (w *WatermarkChecker) ShouldEmit(ctx context.Context, table string, pk json.RawMessage, snapshotLSN uint64) (bool, error) {
+	w.mu.Lock()
+	ti, ok := w.tables[table]
+	if ok && !ti.overCap && ti.snapshotLSN == snapshotLSN {
+		_, superseded := ti.keys[string(pk)]
+		w.mu.Unlock()
+		return !superseded, nil
+	}
+	w.mu.Unlock()
+
+	return w.shouldEmitScan(ctx, table, pk, snapshotLSN)
+}
+
+// ObserveAppend implements eventlog.AppendObserver. It is called synchronously
+// by the EventLog after every successful Append/AppendBatch (see that
+// interface's doc comment for the durability/ordering contract this relies
+// on). Events for tables with no active index (StartTable never called, or
+// already over-cap) are skipped cheaply.
+func (w *WatermarkChecker) ObserveAppend(evs []*event.ChangeEvent, _ []uint64) {
+	if len(evs) == 0 {
+		return
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	for _, ev := range evs {
+		ti, ok := w.tables[ev.Table]
+		if !ok || ti.overCap {
+			continue
+		}
+		w.mergeEventLocked(ti, ev)
+	}
+}
+
+// mergeEntries merges a page of LogEntry results into ti.keys, filtering to
+// entries for table with lsn > ti.snapshotLSN, and enforces the cap.
+// Acquires w.mu itself (safe to call without holding the lock).
+func (w *WatermarkChecker) mergeEntries(table string, ti *tableIndex, entries []eventlog.LogEntry) {
+	if len(entries) == 0 {
+		return
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	// The index may have already been replaced (e.g. a concurrent StartTable
+	// for the same table) or hit its cap while we were reading this page;
+	// re-check under the lock before mutating.
+	if current := w.tables[table]; current != ti || ti.overCap {
+		return
+	}
+	for _, entry := range entries {
+		ev := entry.Event
+		if ev.Table != table {
+			continue
+		}
+		w.mergeEventLocked(ti, ev)
+		if ti.overCap {
+			return
+		}
+	}
+}
+
+// mergeEventLocked merges a single event into ti.keys if its LSN supersedes
+// ti.snapshotLSN, tracking the maximum LSN seen per key. Enforces
+// w.maxIndexKeys, setting ti.overCap and releasing ti.keys if exceeded.
+// Callers must hold w.mu.
+func (w *WatermarkChecker) mergeEventLocked(ti *tableIndex, ev *event.ChangeEvent) {
+	lsn, err := lsnFromMetadata(ev)
+	if err != nil {
+		// Conservative: an unparsable LSN is skipped, matching the scan
+		// path's behaviour of skipping entries it can't parse.
+		return
+	}
+	if lsn <= ti.snapshotLSN {
+		return
+	}
+	key := string(ev.Key)
+	if existing, found := ti.keys[key]; !found || lsn > existing {
+		if !found && len(ti.keys) >= w.maxIndexKeys {
+			ti.overCap = true
+			ti.keys = nil
+			return
+		}
+		ti.keys[key] = lsn
+	}
+}
+
+// shouldEmitScan is the original scan-based implementation, kept as the
+// fallback path for tables with no active index (StartTable not called),
+// tables that exceeded the memory cap, and EventLog backends that do not
+// support AppendObservable.
+//
+// The partition is computed via eventlog.PartitionOf(pk, numPartitions) to
+// avoid scanning all partitions. The partition is paged through to
+// completion: a single capped read would miss the newest (highest-seq)
+// events, which are exactly the ones most likely to supersede the snapshot
+// row (BKF-02).
+func (w *WatermarkChecker) shouldEmitScan(ctx context.Context, table string, pk json.RawMessage, snapshotLSN uint64) (bool, error) {
 	partition := eventlog.PartitionOf(pk, w.numPartitions)
 
 	fromSeq := uint64(0)

--- a/internal/backfill/watermark_test.go
+++ b/internal/backfill/watermark_test.go
@@ -1,0 +1,491 @@
+// Package backfill_test covers the indexed watermark path added to replace
+// the O(rows*events) per-row full-partition scan (see watermark.go). All
+// tests use the external test package to exercise only exported symbols.
+package backfill_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/olucasandrade/kaptanto/internal/backfill"
+	"github.com/olucasandrade/kaptanto/internal/event"
+	"github.com/olucasandrade/kaptanto/internal/eventlog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- partitionedEventLog: a real, partition-respecting, observable EventLog fake ---
+//
+// mockEventLog (backfill_test.go) ignores the requested partition entirely,
+// which is fine for the pre-existing scan tests but doesn't exercise
+// per-partition routing or the AppendObserver contract. partitionedEventLog
+// does both: events are bucketed by eventlog.PartitionOf exactly as
+// BadgerEventLog does, and it implements eventlog.AppendObservable so
+// WatermarkChecker's indexed path (and its observer-ordering guarantee) can
+// be tested against something structurally faithful to production, not just
+// against itself.
+type partitionedEventLog struct {
+	mu            sync.Mutex
+	numPartitions uint32
+	partitions    map[uint32][]eventlog.LogEntry
+	seqCounters   map[uint32]uint64
+	observers     map[int]eventlog.AppendObserver
+	nextObsID     int
+
+	// readHook, if set, is invoked synchronously at the start of every
+	// ReadPartition call (before taking the lock), letting tests inject a
+	// concurrent append at a precise point in a StartTable scan.
+	readHook func(partition uint32, fromSeq uint64)
+}
+
+var (
+	_ eventlog.EventLog         = (*partitionedEventLog)(nil)
+	_ eventlog.AppendObservable = (*partitionedEventLog)(nil)
+	_ eventlog.AppendObserver   = (*backfill.WatermarkChecker)(nil)
+)
+
+func newPartitionedEventLog(numPartitions uint32) *partitionedEventLog {
+	return &partitionedEventLog{
+		numPartitions: numPartitions,
+		partitions:    make(map[uint32][]eventlog.LogEntry),
+		seqCounters:   make(map[uint32]uint64),
+		observers:     make(map[int]eventlog.AppendObserver),
+	}
+}
+
+func (p *partitionedEventLog) Append(ev *event.ChangeEvent) (uint64, error) {
+	seqs, err := p.AppendBatch([]*event.ChangeEvent{ev})
+	if err != nil {
+		return 0, err
+	}
+	return seqs[0], nil
+}
+
+func (p *partitionedEventLog) AppendBatch(evs []*event.ChangeEvent) ([]uint64, error) {
+	if len(evs) == 0 {
+		return nil, nil
+	}
+	p.mu.Lock()
+	seqs := make([]uint64, len(evs))
+	for i, ev := range evs {
+		partition := eventlog.PartitionOf(ev.Key, p.numPartitions)
+		p.seqCounters[partition]++
+		seq := p.seqCounters[partition]
+		seqs[i] = seq
+		p.partitions[partition] = append(p.partitions[partition], eventlog.LogEntry{
+			Seq: seq, PartitionID: partition, Event: ev,
+		})
+	}
+	observers := make([]eventlog.AppendObserver, 0, len(p.observers))
+	for _, obs := range p.observers {
+		observers = append(observers, obs)
+	}
+	p.mu.Unlock()
+
+	// Notify observers synchronously, after the "durable" write and before
+	// AppendBatch returns — mirroring BadgerEventLog's contract exactly, since
+	// WatermarkChecker's correctness depends on that ordering, not on this
+	// fake's internals.
+	for _, obs := range observers {
+		obs.ObserveAppend(evs, seqs)
+	}
+	return seqs, nil
+}
+
+func (p *partitionedEventLog) ReadPartition(_ context.Context, partition uint32, fromSeq uint64, limit int) ([]eventlog.LogEntry, error) {
+	if p.readHook != nil {
+		p.readHook(partition, fromSeq)
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	var page []eventlog.LogEntry
+	for _, e := range p.partitions[partition] {
+		if e.Seq < fromSeq {
+			continue
+		}
+		page = append(page, e)
+		if len(page) >= limit {
+			break
+		}
+	}
+	return page, nil
+}
+
+func (p *partitionedEventLog) Close() error { return nil }
+
+func (p *partitionedEventLog) RegisterObserver(obs eventlog.AppendObserver) func() {
+	p.mu.Lock()
+	id := p.nextObsID
+	p.nextObsID++
+	p.observers[id] = obs
+	p.mu.Unlock()
+
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			p.mu.Lock()
+			delete(p.observers, id)
+			p.mu.Unlock()
+		})
+	}
+}
+
+func mkEvent(table, keyJSON string, lsn uint64) *event.ChangeEvent {
+	return &event.ChangeEvent{
+		Table:    table,
+		Key:      json.RawMessage(keyJSON),
+		Metadata: map[string]any{"lsn": fmt.Sprintf("0/%X", lsn)},
+	}
+}
+
+// --- (a) Property test: indexed path agrees with the scan path ---
+//
+// The "old" scan implementation is still live in watermark.go as
+// shouldEmitScan — ShouldEmit falls back to it automatically whenever
+// StartTable was never called. That means the pre-existing behaviour is
+// reachable through the very same exported ShouldEmit method, just via a
+// different call sequence, so this test can compare "old" vs "new" without
+// needing access to unexported symbols: for each seeded fixture, a checker
+// that never calls StartTable exercises the original scan; a checker that
+// does call StartTable exercises the new index. Both operate over the same
+// partition-respecting fake event log.
+func TestWatermarkChecker_IndexedMatchesScan_Property(t *testing.T) {
+	ctx := context.Background()
+	const numPartitions = 8
+	tables := []string{"orders", "customers", "invoices"}
+
+	rng := rand.New(rand.NewSource(42))
+
+	for run := 0; run < 200; run++ {
+		el := newPartitionedEventLog(numPartitions)
+
+		// Seed a random assortment of events across a handful of keys and
+		// tables, with LSNs randomly above/below the snapshot cutoff.
+		const snapshotLSN = uint64(1000)
+		numKeys := 1 + rng.Intn(12)
+		keys := make([]string, numKeys)
+		for i := range keys {
+			keys[i] = fmt.Sprintf(`{"id":%d}`, i)
+		}
+
+		numEvents := rng.Intn(60)
+		for i := 0; i < numEvents; i++ {
+			table := tables[rng.Intn(len(tables))]
+			key := keys[rng.Intn(len(keys))]
+			// LSNs spread both sides of snapshotLSN.
+			lsn := uint64(rng.Intn(2000))
+			_, err := el.Append(mkEvent(table, key, lsn))
+			require.NoError(t, err)
+		}
+
+		targetTable := tables[rng.Intn(len(tables))]
+		targetKey := json.RawMessage(keys[rng.Intn(len(keys))])
+
+		// Old path: no StartTable call, forces the scan fallback.
+		scanChecker := backfill.NewWatermarkChecker(el, numPartitions)
+		wantEmit, err := scanChecker.ShouldEmit(ctx, targetTable, targetKey, snapshotLSN)
+		require.NoError(t, err)
+
+		// New path: StartTable builds the index first.
+		idxChecker := backfill.NewWatermarkChecker(el, numPartitions)
+		require.NoError(t, idxChecker.StartTable(ctx, targetTable, snapshotLSN))
+		gotEmit, err := idxChecker.ShouldEmit(ctx, targetTable, targetKey, snapshotLSN)
+		require.NoError(t, err)
+		idxChecker.FinishTable(targetTable)
+
+		assert.Equalf(t, wantEmit, gotEmit,
+			"run %d: indexed and scan paths disagree for table=%s key=%s (numEvents=%d)",
+			run, targetTable, string(targetKey), numEvents)
+	}
+}
+
+// --- (b) Race test: concurrent AppendBatch + ShouldEmit ---
+func TestWatermarkChecker_ConcurrentAppendAndShouldEmit_Race(t *testing.T) {
+	ctx := context.Background()
+	const numPartitions = 16
+	const table = "orders"
+	el := newPartitionedEventLog(numPartitions)
+
+	checker := backfill.NewWatermarkChecker(el, numPartitions)
+	require.NoError(t, checker.StartTable(ctx, table, 0))
+	defer checker.FinishTable(table)
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	// Writer: keeps appending new events for a rotating set of keys.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		i := 0
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			key := fmt.Sprintf(`{"id":%d}`, i%50)
+			_, err := el.AppendBatch([]*event.ChangeEvent{mkEvent(table, key, uint64(1000+i))})
+			assert.NoError(t, err)
+			i++
+		}
+	}()
+
+	// Readers: hammer ShouldEmit concurrently with the writer.
+	for r := 0; r < 4; r++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for i := 0; i < 2000; i++ {
+				key := json.RawMessage(fmt.Sprintf(`{"id":%d}`, (i+id)%50))
+				_, err := checker.ShouldEmit(ctx, table, key, 0)
+				assert.NoError(t, err)
+			}
+		}(r)
+	}
+
+	time.Sleep(50 * time.Millisecond)
+	close(stop)
+	wg.Wait()
+}
+
+// --- (c) Benchmark: O(1) indexed vs O(W) scan, 100k-entry partition ---
+//
+// Both benchmarks share the same 100k-event fixture (a single partition,
+// since numPartitions=1 forces every key into partition 0, matching the
+// "100k-entry partition" framing used by the pre-existing scan test). The
+// scan benchmark repeats the pre-fix behaviour; the indexed benchmark builds
+// the index once outside the timed loop, then times only ShouldEmit calls.
+func setupBenchFixture(b *testing.B, n int) (*partitionedEventLog, string, json.RawMessage, uint64) {
+	b.Helper()
+	const table = "orders"
+	el := newPartitionedEventLog(1) // single partition holds everything
+	for i := 0; i < n-1; i++ {
+		// Filler events for a different key than the one we'll query, all
+		// with a low LSN so they never match — this is the worst case for
+		// the scan path (it must walk every one of them).
+		_, err := el.Append(mkEvent(table, `{"id":999999}`, 1))
+		require.NoError(b, err)
+	}
+	// One superseding event for the target key at the very end (highest
+	// seq) — the worst case: the scan can't stop early.
+	targetKey := json.RawMessage(`{"id":1}`)
+	_, err := el.Append(mkEvent(table, string(targetKey), 200))
+	require.NoError(b, err)
+	return el, table, targetKey, 100 // snapshotLSN = 100 < 200, so the target key is suppressed
+}
+
+func BenchmarkShouldEmit_ScanPath_100kPartition(b *testing.B) {
+	el, table, targetKey, snapshotLSN := setupBenchFixture(b, 100_000)
+	checker := backfill.NewWatermarkChecker(el, 1)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		emit, err := checker.ShouldEmit(context.Background(), table, targetKey, snapshotLSN)
+		if err != nil || emit {
+			b.Fatalf("unexpected result: emit=%v err=%v", emit, err)
+		}
+	}
+}
+
+func BenchmarkShouldEmit_IndexedPath_100kPartition(b *testing.B) {
+	el, table, targetKey, snapshotLSN := setupBenchFixture(b, 100_000)
+	checker := backfill.NewWatermarkChecker(el, 1)
+	if err := checker.StartTable(context.Background(), table, snapshotLSN); err != nil {
+		b.Fatalf("StartTable: %v", err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		emit, err := checker.ShouldEmit(context.Background(), table, targetKey, snapshotLSN)
+		if err != nil || emit {
+			b.Fatalf("unexpected result: emit=%v err=%v", emit, err)
+		}
+	}
+}
+
+// --- (d) Integration-style test: snapshot with concurrent updates ---
+//
+// Simulates the exact scenario watermarks exist for: a snapshot is running
+// (StartTable already active) and a WAL event lands for a row that hasn't
+// been read yet. The stale snapshot read for that row must still be
+// suppressed.
+func TestWatermarkChecker_ConcurrentUpdateDuringSnapshot_StaleReadSuppressed(t *testing.T) {
+	ctx := context.Background()
+	const numPartitions = 8
+	const table = "orders"
+	const snapshotLSN = uint64(100)
+
+	el := newPartitionedEventLog(numPartitions)
+	// Some pre-existing, non-superseding history so the index build has real
+	// work to do.
+	for i := 0; i < 10; i++ {
+		_, err := el.Append(mkEvent(table, fmt.Sprintf(`{"id":%d}`, i), 10))
+		require.NoError(t, err)
+	}
+
+	checker := backfill.NewWatermarkChecker(el, numPartitions)
+	require.NoError(t, checker.StartTable(ctx, table, snapshotLSN))
+	defer checker.FinishTable(table)
+
+	targetKey := json.RawMessage(`{"id":42}`)
+
+	// Before the concurrent update, nothing supersedes this row.
+	emit, err := checker.ShouldEmit(ctx, table, targetKey, snapshotLSN)
+	require.NoError(t, err)
+	assert.True(t, emit, "no WAL event yet — snapshot row should be emitted")
+
+	// A WAL event lands for this exact row while the snapshot is "still
+	// running" (StartTable is still active), with an LSN beyond the
+	// snapshot's watermark.
+	_, err = el.Append(mkEvent(table, string(targetKey), snapshotLSN+100))
+	require.NoError(t, err)
+
+	// The now-stale snapshot read for this row must be suppressed.
+	emit, err = checker.ShouldEmit(ctx, table, targetKey, snapshotLSN)
+	require.NoError(t, err)
+	assert.False(t, emit, "WAL event superseding the row must suppress the stale snapshot read")
+}
+
+// TestWatermarkChecker_ObserverAttachedBeforeScan_NoMissedAppend is the
+// regression test for the ordering fix described in StartTable's doc
+// comment: the observer must be attached before the index scan begins, so an
+// append landing in an already-scanned partition, mid-build, is still
+// captured (via the observer) instead of silently escaping suppression.
+//
+// readHook fires the "concurrent" append the moment the scan moves on to the
+// partition after the target key's partition — guaranteeing that partition
+// has already been fully read by the scan and the ONLY way the event can end
+// up in the index is via the observer registered ahead of the scan.
+func TestWatermarkChecker_ObserverAttachedBeforeScan_NoMissedAppend(t *testing.T) {
+	ctx := context.Background()
+	const numPartitions = 8
+	const table = "orders"
+	const snapshotLSN = uint64(100)
+
+	targetKey := json.RawMessage(`{"id":7}`)
+	targetPartition := eventlog.PartitionOf(targetKey, numPartitions)
+	require.Less(t, targetPartition, uint32(numPartitions-1),
+		"test fixture assumption: target key must not be in the last partition")
+
+	el := newPartitionedEventLog(numPartitions)
+
+	var fired sync.Once
+	el.readHook = func(partition uint32, fromSeq uint64) {
+		if partition == targetPartition+1 && fromSeq == 0 {
+			fired.Do(func() {
+				// This must land in targetPartition, which the scan has
+				// already fully read by this point.
+				_, err := el.Append(mkEvent(table, string(targetKey), snapshotLSN+50))
+				require.NoError(t, err)
+			})
+		}
+	}
+
+	checker := backfill.NewWatermarkChecker(el, numPartitions)
+	require.NoError(t, checker.StartTable(ctx, table, snapshotLSN))
+	defer checker.FinishTable(table)
+
+	emit, err := checker.ShouldEmit(ctx, table, targetKey, snapshotLSN)
+	require.NoError(t, err)
+	assert.False(t, emit,
+		"append injected into an already-scanned partition mid-build must still be "+
+			"captured by the pre-attached observer, and must suppress the stale row")
+}
+
+// --- Memory cap fallback ---
+
+func TestWatermarkChecker_OverCap_FallsBackToScan(t *testing.T) {
+	ctx := context.Background()
+	const numPartitions = 4
+	const table = "orders"
+	const snapshotLSN = uint64(0)
+
+	el := newPartitionedEventLog(numPartitions)
+	// Three distinct superseding keys — cap of 2 forces overCap.
+	for i := 0; i < 3; i++ {
+		_, err := el.Append(mkEvent(table, fmt.Sprintf(`{"id":%d}`, i), snapshotLSN+1))
+		require.NoError(t, err)
+	}
+
+	checker := backfill.NewWatermarkChecker(el, numPartitions)
+	checker.SetMaxIndexKeys(2)
+	require.NoError(t, checker.StartTable(ctx, table, snapshotLSN))
+	defer checker.FinishTable(table)
+
+	// Regardless of which keys made it into the index before the cap was
+	// hit, every one of the three superseded keys must still be correctly
+	// suppressed via the scan fallback.
+	for i := 0; i < 3; i++ {
+		key := json.RawMessage(fmt.Sprintf(`{"id":%d}`, i))
+		emit, err := checker.ShouldEmit(ctx, table, key, snapshotLSN)
+		require.NoError(t, err)
+		assert.False(t, emit, "key %d should be suppressed via cap fallback", i)
+	}
+}
+
+// failingReadEventLog fails ReadPartition on failOnPartition, simulating a
+// mid-scan error (or, by the same code path, a cancelled context) partway
+// through StartTable's one-time index build. A superseding event sits on
+// failOnPartition+1 — a partition StartTable never reaches before the error.
+type failingReadEventLog struct {
+	failOnPartition        uint32
+	supersedingKey         json.RawMessage
+	supersedingTable       string
+	supersedingLSNOnFailP1 string
+}
+
+func (f *failingReadEventLog) Append(ev *event.ChangeEvent) (uint64, error) { return 1, nil }
+func (f *failingReadEventLog) AppendBatch(evs []*event.ChangeEvent) ([]uint64, error) {
+	return make([]uint64, len(evs)), nil
+}
+func (f *failingReadEventLog) Close() error { return nil }
+func (f *failingReadEventLog) ReadPartition(_ context.Context, partition uint32, _ uint64, _ int) ([]eventlog.LogEntry, error) {
+	if partition == f.failOnPartition {
+		return nil, fmt.Errorf("simulated read failure on partition %d", partition)
+	}
+	if partition == f.failOnPartition+1 {
+		return []eventlog.LogEntry{
+			{Seq: 1, Event: &event.ChangeEvent{
+				Table:    f.supersedingTable,
+				Key:      f.supersedingKey,
+				Metadata: map[string]any{"lsn": f.supersedingLSNOnFailP1},
+			}},
+		}, nil
+	}
+	return nil, nil
+}
+
+// TestWatermarkChecker_StartTableError_DoesNotLeaveTrustedPartialIndex
+// verifies that when StartTable's scan fails partway through, it does not
+// leave the partial (incomplete) index registered for ShouldEmit to
+// silently trust. A partial index is strictly worse than the intentional
+// overCap fallback: ShouldEmit cannot distinguish "index is complete" from
+// "index stopped halfway due to an error" by inspecting the index alone, so
+// an unremoved partial index would make a WAL event in an unscanned
+// partition invisible — exactly the "seen by neither path" failure mode
+// StartTable's ordering guarantee is supposed to rule out.
+func TestWatermarkChecker_StartTableError_DoesNotLeaveTrustedPartialIndex(t *testing.T) {
+	el := &failingReadEventLog{
+		failOnPartition:        0,
+		supersedingTable:       "orders",
+		supersedingKey:         json.RawMessage(`{"id":"1"}`),
+		supersedingLSNOnFailP1: "0/C8", // 200, supersedes snapshotLSN=100
+	}
+	w := backfill.NewWatermarkChecker(el, 4)
+
+	err := w.StartTable(context.Background(), "orders", 100)
+	require.Error(t, err, "expected StartTable to surface the simulated read failure")
+
+	emit, err := w.ShouldEmit(context.Background(), "orders", json.RawMessage(`{"id":"1"}`), 100)
+	require.NoError(t, err)
+	assert.False(t, emit,
+		"a row superseded by a WAL event in a partition StartTable never reached "+
+			"before failing must still be suppressed via the scan fallback — the "+
+			"failed StartTable must not leave a partial index for ShouldEmit to trust")
+}

--- a/internal/eventlog/badger.go
+++ b/internal/eventlog/badger.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"hash/fnv"
+	"sync"
 	"time"
 
 	badger "github.com/dgraph-io/badger/v4"
@@ -25,6 +26,10 @@ type BadgerEventLog struct {
 	numPartitions uint32
 	retention     time.Duration
 	notifyChs     []chan struct{} // one depth-1 buffered channel per partition
+
+	obsMu     sync.RWMutex
+	observers map[int]AppendObserver // keyed by monotonically increasing id for stable unregister
+	nextObsID int
 }
 
 // Open creates or reopens a BadgerEventLog at dir.
@@ -76,7 +81,46 @@ func Open(dir string, numPartitions uint32, retention time.Duration) (*BadgerEve
 		numPartitions: numPartitions,
 		retention:     retention,
 		notifyChs:     notifyChs,
+		observers:     make(map[int]AppendObserver),
 	}, nil
+}
+
+// RegisterObserver implements AppendObservable. obs is called synchronously,
+// after the durable write commits, on every future Append/AppendBatch that
+// writes at least one non-duplicate event — including calls already in
+// flight when RegisterObserver is invoked, since registration and the
+// observer dispatch loop both hold obsMu (see notifyObservers).
+func (b *BadgerEventLog) RegisterObserver(obs AppendObserver) (unregister func()) {
+	b.obsMu.Lock()
+	id := b.nextObsID
+	b.nextObsID++
+	b.observers[id] = obs
+	b.obsMu.Unlock()
+
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			b.obsMu.Lock()
+			delete(b.observers, id)
+			b.obsMu.Unlock()
+		})
+	}
+}
+
+// notifyObservers dispatches evs/seqs (already filtered to non-duplicates by
+// the caller) to every registered observer, synchronously and in the calling
+// goroutine — this is what makes RegisterObserver's "sees every future
+// commit" guarantee hold: the write is durable in Badger before this runs,
+// and this runs before Append/AppendBatch returns.
+func (b *BadgerEventLog) notifyObservers(evs []*event.ChangeEvent, seqs []uint64) {
+	if len(evs) == 0 {
+		return
+	}
+	b.obsMu.RLock()
+	defer b.obsMu.RUnlock()
+	for _, obs := range b.observers {
+		obs.ObserveAppend(evs, seqs)
+	}
 }
 
 // NotifyCh returns the read-only notify channel for the given partition.
@@ -172,6 +216,11 @@ func (b *BadgerEventLog) Append(ev *event.ChangeEvent) (uint64, error) {
 	// slow reader never stalls the writer (CHK-01 preserved).
 	b.notify(partition)
 
+	// Notify observers (e.g. WatermarkChecker's index) synchronously, after
+	// the durable commit and before returning, so registered observers never
+	// miss an event (see AppendObserver's documented contract).
+	b.notifyObservers([]*event.ChangeEvent{ev}, []uint64{seq})
+
 	return seq, nil
 }
 
@@ -252,13 +301,25 @@ func (b *BadgerEventLog) AppendBatch(evs []*event.ChangeEvent) ([]uint64, error)
 	// Pulse notify channels for every partition that received at least one new
 	// (non-duplicate) event. Coalescing via the depth-1 buffer means we call
 	// notify at most once per partition regardless of how many events landed there.
+	// Also collect the non-duplicate subset to hand to observers (LOG-03: seq==0
+	// marks a duplicate that was silently skipped and must not be observed).
 	notified := make(map[uint32]bool, len(items))
+	writtenEvs := make([]*event.ChangeEvent, 0, len(evs))
+	writtenSeqs := make([]uint64, 0, len(evs))
 	for i, item := range items {
-		if seqs[i] != 0 && !notified[item.partition] {
-			b.notify(item.partition)
-			notified[item.partition] = true
+		if seqs[i] != 0 {
+			if !notified[item.partition] {
+				b.notify(item.partition)
+				notified[item.partition] = true
+			}
+			writtenEvs = append(writtenEvs, evs[i])
+			writtenSeqs = append(writtenSeqs, seqs[i])
 		}
 	}
+
+	// Notify observers synchronously, after the durable commit and before
+	// returning (see AppendObserver's documented contract).
+	b.notifyObservers(writtenEvs, writtenSeqs)
 
 	return seqs, nil
 }

--- a/internal/eventlog/badger_test.go
+++ b/internal/eventlog/badger_test.go
@@ -5,6 +5,8 @@ package eventlog_test
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -299,4 +301,127 @@ func TestReadPartition_RawPopulated(t *testing.T) {
 	rawKeyJSON, err := json.Marshal(rawKey)
 	require.NoError(t, err)
 	assert.JSONEq(t, string(ev.Key), string(rawKeyJSON), "Raw JSON must contain the correct key")
+}
+
+// recordingObserver implements eventlog.AppendObserver and records every call
+// it receives, guarded by a mutex so it is safe to inspect from the test
+// goroutine after concurrent Append/AppendBatch calls.
+type recordingObserver struct {
+	mu    sync.Mutex
+	calls [][]string // one entry per ObserveAppend call: the idempotency keys observed
+}
+
+func (r *recordingObserver) ObserveAppend(evs []*event.ChangeEvent, seqs []uint64) {
+	if len(evs) != len(seqs) {
+		panic("ObserveAppend: evs/seqs length mismatch")
+	}
+	keys := make([]string, len(evs))
+	for i, ev := range evs {
+		if seqs[i] == 0 {
+			panic("ObserveAppend must never be called with the duplicate sentinel seq=0")
+		}
+		keys[i] = ev.IdempotencyKey
+	}
+	r.mu.Lock()
+	r.calls = append(r.calls, keys)
+	r.mu.Unlock()
+}
+
+func (r *recordingObserver) allKeys() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var out []string
+	for _, c := range r.calls {
+		out = append(out, c...)
+	}
+	return out
+}
+
+// TestBadgerEventLog_RegisterObserver_SyncBeforeReturn verifies the
+// AppendObserver contract that WatermarkChecker's indexed watermark path
+// depends on: a registered observer is called synchronously — with the
+// non-duplicate event(s) — before Append/AppendBatch returns, and duplicates
+// (seq==0) are never handed to the observer (LOG-03).
+func TestBadgerEventLog_RegisterObserver_SyncBeforeReturn(t *testing.T) {
+	el, err := eventlog.Open(t.TempDir(), 64, time.Hour)
+	require.NoError(t, err)
+	defer func() { _ = el.Close() }()
+
+	obs := &recordingObserver{}
+	unregister := el.RegisterObserver(obs)
+
+	ev1 := makeEvent("src:public.t:1:insert:0/1", `{"id": 1}`)
+	_, err = el.Append(ev1)
+	require.NoError(t, err)
+
+	evs := []*event.ChangeEvent{
+		makeEvent("src:public.t:2:insert:0/2", `{"id": 2}`),
+		makeEvent("src:public.t:3:insert:0/3", `{"id": 3}`),
+	}
+	_, err = el.AppendBatch(evs)
+	require.NoError(t, err)
+
+	assert.ElementsMatch(t, []string{ev1.IdempotencyKey, evs[0].IdempotencyKey, evs[1].IdempotencyKey}, obs.allKeys(),
+		"observer must see every non-duplicate event from Append and AppendBatch")
+
+	// A duplicate Append/AppendBatch must not be observed (seq==0 events are
+	// filtered before notifyObservers).
+	_, err = el.Append(ev1)
+	require.NoError(t, err)
+	_, err = el.AppendBatch(evs)
+	require.NoError(t, err)
+	assert.Len(t, obs.allKeys(), 3, "duplicate appends must not generate additional observer calls")
+
+	// After unregistering, further appends must not reach the observer.
+	unregister()
+	ev4 := makeEvent("src:public.t:4:insert:0/4", `{"id": 4}`)
+	_, err = el.Append(ev4)
+	require.NoError(t, err)
+	assert.Len(t, obs.allKeys(), 3, "unregistered observer must not receive further calls")
+
+	// Calling unregister a second time must be a safe no-op.
+	unregister()
+}
+
+// TestBadgerEventLog_RegisterObserver_ConcurrentAppendAndUnregister exercises
+// RegisterObserver's synchronization under -race: concurrent Append/AppendBatch
+// calls notifying observers while another goroutine registers/unregisters.
+func TestBadgerEventLog_RegisterObserver_ConcurrentAppendAndUnregister(t *testing.T) {
+	el, err := eventlog.Open(t.TempDir(), 64, time.Hour)
+	require.NoError(t, err)
+	defer func() { _ = el.Close() }()
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		i := 0
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			ev := makeEvent(fmt.Sprintf("src:public.t:%d:insert:0/%d", i, i), fmt.Sprintf(`{"id": %d}`, i))
+			_, err := el.Append(ev)
+			assert.NoError(t, err)
+			i++
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 200; i++ {
+			obs := &recordingObserver{}
+			unregister := el.RegisterObserver(obs)
+			unregister()
+		}
+	}()
+
+	time.Sleep(30 * time.Millisecond)
+	close(stop)
+	wg.Wait()
 }

--- a/internal/eventlog/eventlog.go
+++ b/internal/eventlog/eventlog.go
@@ -72,6 +72,42 @@ type EventLog interface {
 	Close() error
 }
 
+// AppendObserver receives every successfully appended (non-duplicate) event,
+// synchronously, immediately after the durable write commits and BEFORE
+// Append/AppendBatch returns to its caller.
+//
+// This synchronous-before-return contract is load-bearing: WatermarkChecker
+// (internal/backfill) uses it to build an incrementally-updated index instead
+// of re-scanning the whole partition on every ShouldEmit call. For the index
+// to be correct, an observer registered before a table's initial index scan
+// begins must see every event committed after registration — a callback that
+// fires only "eventually" (e.g. via an async queue) would let a snapshot row
+// race ahead of the index and be wrongly emitted. See AppendObservable.
+//
+// Implementations must return quickly and must not block: this runs on the
+// hot append path shared with the router and, transitively, source WAL/CDC
+// ingestion (CHK-01). Do not perform I/O or acquire locks that could be held
+// by a slow consumer.
+type AppendObserver interface {
+	// ObserveAppend is called once per Append/AppendBatch call with every
+	// event that was actually written (duplicates are excluded). seqs[i]
+	// corresponds to evs[i]; seqs are never 0 here (0 is the "duplicate"
+	// sentinel used by Append/AppendBatch, and duplicates are filtered out
+	// before observers are notified).
+	ObserveAppend(evs []*event.ChangeEvent, seqs []uint64)
+}
+
+// AppendObservable is implemented by EventLog backends that support
+// synchronous append observers (currently BadgerEventLog). Callers must type-
+// assert an EventLog to this interface — it is optional so fakes used in
+// tests need not implement it.
+type AppendObservable interface {
+	// RegisterObserver registers obs to be called synchronously on every
+	// future successful Append/AppendBatch. It returns an unregister function
+	// that removes obs; calling unregister more than once is a no-op.
+	RegisterObserver(obs AppendObserver) (unregister func())
+}
+
 // LogEntry is a single event retrieved from ReadPartition.
 type LogEntry struct {
 	// Seq is the partition-local monotonically increasing sequence number.

--- a/internal/source/mongodb/snapshot.go
+++ b/internal/source/mongodb/snapshot.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"go.mongodb.org/mongo-driver/v2/bson"
@@ -25,6 +26,22 @@ import (
 // *backfill.WatermarkChecker satisfies this interface.
 type WatermarkChecker interface {
 	ShouldEmit(ctx context.Context, table string, pk json.RawMessage, snapshotLSN uint64) (bool, error)
+}
+
+// IndexedWatermarkChecker is an optional extension of WatermarkChecker that
+// supports building a per-table in-memory index for O(1) ShouldEmit lookups
+// (perf fix: replaces a full-partition scan per row). *backfill.WatermarkChecker
+// satisfies this interface. MongoSnapshot type-asserts wc against it so a
+// WatermarkChecker that only implements ShouldEmit (e.g. a minimal test
+// fake) keeps working via the plain scan/fallback behaviour.
+type IndexedWatermarkChecker interface {
+	WatermarkChecker
+	// StartTable builds the in-memory index for table/collection so
+	// subsequent ShouldEmit calls for it are O(1). See
+	// backfill.WatermarkChecker.StartTable for the correctness ordering.
+	StartTable(ctx context.Context, table string, snapshotLSN uint64) error
+	// FinishTable releases the in-memory index for table/collection.
+	FinishTable(table string)
 }
 
 // SnapshotConfig holds all parameters for a MongoDB snapshot.
@@ -123,6 +140,18 @@ func (s *MongoSnapshot) Run(ctx context.Context) error {
 
 // snapshotCollection snapshots a single collection.
 func (s *MongoSnapshot) snapshotCollection(ctx context.Context, collName string) error {
+	// Build the O(1) watermark index for this collection before scanning any
+	// documents, if the checker supports it. Non-fatal on error: ShouldEmit
+	// transparently falls back to the per-row scan path.
+	if idx, ok := s.wc.(IndexedWatermarkChecker); ok {
+		if startErr := idx.StartTable(ctx, collName, s.snapshotLSN); startErr != nil {
+			slog.Warn("mongodb snapshot: watermark index build failed, falling back to per-row scan",
+				"error", startErr, "collection", collName)
+		} else {
+			defer idx.FinishTable(collName)
+		}
+	}
+
 	docs, err := s.fetchDocs(ctx, collName)
 	if err != nil {
 		return fmt.Errorf("mongodb snapshot: fetch %s: %w", collName, err)


### PR DESCRIPTION
## Source fix plan

`.claude/fix-plans/watermark-scan-index-20260702-131544.md` (not committed, per policy).

## Problem

`WatermarkChecker.ShouldEmit` paged through an entire partition's event-log contents (10k-entry pages, from seq 0) for **every** snapshot row, comparing keys byte-for-byte. Backfill cost was O(N_rows × W_partition_events) Badger reads + JSON decodes. Large tables snapshotted under live WAL traffic — exactly the scenario watermarks exist for — collapsed to unusable throughput and competed with WAL append fsyncs for I/O.

## Implementation summary

1. **In-memory per-table max-LSN index**: `map[canonicalKey]maxLSN`, populated only with keys whose LSN exceeds the snapshot's `snapshotLSN` (the only entries that can ever suppress a row). `ShouldEmit` becomes an O(1) map lookup once `StartTable(table, snapshotLSN)` has been called for that table.
2. **New `eventlog.AppendObserver`/`AppendObservable`**: `BadgerEventLog` now calls registered observers **synchronously, after the durable commit and before `Append`/`AppendBatch` returns**. `WatermarkChecker` registers itself once, at construction — strictly before any table's `StartTable` call.
3. **Correctness ordering**: `StartTable` inserts the table's (initially empty) index map **before** its one-time scan begins. Combined with observer-registration-at-construction, every commit is captured by either `ObserveAppend` or the scan (or both — harmless, since merging is idempotent), never by neither. Full reasoning is in the `StartTable` doc comment.
4. **Bounded memory + fallback**: a per-table key cap (default 2M) reverts that table to the original full-scan implementation if exceeded, rather than growing unbounded. Same fallback applies when the EventLog backend doesn't implement `AppendObservable` (e.g. the NATS cluster EventLog) or `StartTable` was never called.
5. **Wired into both snapshot engines**: `internal/backfill` (Postgres) and `internal/source/mongodb` (via a new `IndexedWatermarkChecker` interface `MongoSnapshot` type-asserts against), each calling `StartTable`/`FinishTable` around a table's/collection's row-scan loop.

## Correctness bug found and fixed during review

`StartTable`'s error paths (`ctx.Err()`, a `ReadPartition` failure) left the **partially-built** index registered in `w.tables[table]` instead of removing it. This is a real BKF-02 gap: unlike the intentional `overCap` fallback (which explicitly marks the table as "don't trust the index"), `ShouldEmit` has no way to distinguish a partial index from a complete one — a WAL event sitting in a partition `StartTable` never reached before failing would be invisible to the partial index, and `ShouldEmit` would wrongly emit a superseded row.

Reproduced with a standalone test (a fake `EventLog` that fails `ReadPartition` on partition 0 while a superseding event sits on partition 1, never reached): confirmed `ShouldEmit` returned `emit=true` for the superseded row before the fix. Fixed with a deferred cleanup in `StartTable` that removes the partial index on any error return (guarded so it doesn't clobber a newer index from a concurrent `StartTable`/`FinishTable` call). The reproduction is now `TestWatermarkChecker_StartTableError_DoesNotLeaveTrustedPartialIndex` in `watermark_test.go` — fails without the fix, passes with it.

## Dependency note

Per the plan: correctness for non-`"id"` primary keys is bounded by whatever `BackfillConfig.PKCols` the caller supplies — same constraint the scan it replaces already had. This pays off fully once the separate `backfill-pk-discovery` fix (PR #29) lands. `pk.Canonical` byte-parity (commit `92526b6`) is already on `main` and required either way for the indexed and WAL-derived keys to agree.

## Validation run

```
CGO_ENABLED=0 go build ./...                                                          # clean
CGO_ENABLED=0 go vet ./...                                                             # clean
CGO_ENABLED=0 go test ./... -count=1                                                   # all 26 packages ok
CGO_ENABLED=1 go test ./internal/backfill/... -race -count=1 -v                        # all pass, no races
CGO_ENABLED=1 go test ./internal/eventlog/... ./internal/source/mongodb/... -race      # all pass, no races
CGO_ENABLED=0 go test ./internal/backfill/... -bench BenchmarkShouldEmit -run '^$'
#   BenchmarkShouldEmit_ScanPath_100kPartition-8      4,736,611 ns/op
#   BenchmarkShouldEmit_IndexedPath_100kPartition-8          278 ns/op   (~17,000x faster)
```

Tests include: a property test asserting the indexed path returns identical suppress/emit decisions to the original scan implementation (kept as `shouldEmitScan`, the fallback) across seeded fixtures; a `-race` test with concurrent `AppendBatch` + `ShouldEmit`; observer synchronous-before-return and concurrent-register/unregister races; a memory-cap fallback test; and the `StartTable`-error regression test above.

## Residual risk / follow-up

- Full correctness for composite/non-`id` primary keys depends on `backfill-pk-discovery` (PR #29) landing, as noted above.
- Not verified against a live Postgres/MongoDB with a genuinely large table under concurrent write load — the benchmark and race tests are synthetic/in-memory. `bench/`'s crash-recovery-style scenarios would be the natural place to add a real-world large-table watermark benchmark as a follow-up.