### PR TITLE
fix(cmd,router,config): wire DLQ into production pipeline

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -21,6 +21,7 @@ import (
 	"github.com/olucasandrade/kaptanto/internal/checkpoint"
 	"github.com/olucasandrade/kaptanto/internal/cluster"
 	"github.com/olucasandrade/kaptanto/internal/config"
+	"github.com/olucasandrade/kaptanto/internal/dlq"
 	"github.com/olucasandrade/kaptanto/internal/event"
 	"github.com/olucasandrade/kaptanto/internal/eventlog"
 	"github.com/olucasandrade/kaptanto/internal/ha"
@@ -342,6 +343,51 @@ func runPipeline(ctx context.Context, cfg *config.Config) error {
 	}
 
 	metrics := observability.NewKaptantoMetrics()
+
+	// Open the DLQ store. Enabled by default (nil/true); an explicit false
+	// restores pre-DLQ log-and-drop behavior.
+	var dlqStore dlq.Store
+	if cfg.DLQ.Enabled == nil || *cfg.DLQ.Enabled {
+		dlqPath := cfg.DLQ.Path
+		if dlqPath == "" {
+			dlqPath = filepath.Join(cfg.DataDir, "dlq.db")
+		}
+		store, err := dlq.Open(dlqPath)
+		if err != nil {
+			return fmt.Errorf("open dlq store: %w", err)
+		}
+		dlqStore = store
+		defer func() { _ = store.Close() }()
+
+		if cfg.DLQ.Retention != "" {
+			ret, err := time.ParseDuration(cfg.DLQ.Retention)
+			if err != nil {
+				return fmt.Errorf("parse dlq retention %q: %w", cfg.DLQ.Retention, err)
+			}
+			if ret > 0 {
+				retentionCtx, stopRetention := context.WithCancel(ctx)
+				defer stopRetention()
+				go func(ret time.Duration) {
+					ticker := time.NewTicker(ret / 2)
+					defer ticker.Stop()
+					for {
+						select {
+						case <-retentionCtx.Done():
+							return
+						case <-ticker.C:
+							cutoff := time.Now().UTC().Add(-ret)
+							n, err := store.Purge(retentionCtx, dlq.Filter{OlderThan: cutoff})
+							if err != nil {
+								slog.Warn("dlq: retention purge failed", "err", err)
+							} else if n > 0 {
+								slog.Info("dlq: purged old entries", "count", n)
+							}
+						}
+					}
+				}(ret)
+			}
+		}
+	}
 	healthProbes := []observability.HealthProbe{
 		{Name: "eventlog", Check: elPing},
 		{Name: "checkpoint", Check: ckProbe},
@@ -369,7 +415,9 @@ func runPipeline(ctx context.Context, cfg *config.Config) error {
 	healthHandler := observability.NewHealthHandler(healthProbes)
 
 	rtr.SetMetrics(metrics)
+	rtr.RetryScheduler().SetMetrics(metrics)
 	cursorSetMetrics(metrics)
+	rtr.SetDLQ(dlqStore)
 
 	outputServer, err := buildOutputServer(cfg, rtr, cursorStore, metrics, healthHandler, healthProbes, rowFilters, colFilters)
 	if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -111,10 +111,10 @@ type RabbitMQSinkConfig struct {
 // WebhookSinkConfig holds settings for the HTTP webhook sink.
 type WebhookSinkConfig struct {
 	URL             string            `yaml:"url"`
-	URLTemplate     string            `yaml:"url-template"`     // optional; overrides URL per-event
-	Method          string            `yaml:"method"`           // POST (default) | PUT | PATCH
-	Timeout         string            `yaml:"timeout"`          // Go duration; "" = 30s
-	Headers         map[string]string `yaml:"headers"`          // static headers; values support ${VAR}
+	URLTemplate     string            `yaml:"url-template"` // optional; overrides URL per-event
+	Method          string            `yaml:"method"`       // POST (default) | PUT | PATCH
+	Timeout         string            `yaml:"timeout"`      // Go duration; "" = 30s
+	Headers         map[string]string `yaml:"headers"`      // static headers; values support ${VAR}
 	Auth            WebhookAuthConfig `yaml:"auth"`
 	Signing         WebhookSigning    `yaml:"signing"`
 	Batch           WebhookBatch      `yaml:"batch"`
@@ -158,7 +158,7 @@ type TransformConfig struct {
 // from an explicit false (pre-DLQ log-and-drop).
 type DLQConfig struct {
 	Enabled   *bool  `yaml:"enabled"`   // nil/true = on (default); false = pre-DLQ log-and-drop
-	Path      string `yaml:"path"`      // default <data_dir>/dlq.db; fallback = <path minus .db> + "-fallback.ndjson"
+	Path      string `yaml:"path"`      // default <data-dir>/dlq.db
 	Retention string `yaml:"retention"` // Go duration; ""/0 = keep forever
 }
 
@@ -167,15 +167,15 @@ type DLQConfig struct {
 // BuildConsumers function. Each action references a registered Type (e.g.
 // "slack", "pagerduty") and supplies parameters + optional routing match.
 type ActionConfig struct {
-	Name      string            `yaml:"name"`      // unique identifier ([a-z0-9-]+, no ":")
-	Type      string            `yaml:"type"`      // registered action type name
-	Params    map[string]string `yaml:"params"`    // key/value params; secret params must be ${VAR} refs
-	Match     MatchConfig       `yaml:"match"`     // event routing filter (RTG-01)
-	Timeout   string            `yaml:"timeout"`   // override type's default timeout; Go duration
-	Transform *TransformConfig  `yaml:"transform"` // replaces (not merges) the type's default transform
-	Headers   map[string]string `yaml:"headers"`   // merge over type defaults; must not collide with computed auth
-	Batch     *WebhookBatch     `yaml:"batch"`     // override type's batching; rejected if type pins batch
-	Webhook   *WebhookSinkConfig `yaml:"webhook"`  // verbatim webhook config for type "custom" (escape hatch)
+	Name      string             `yaml:"name"`      // unique identifier ([a-z0-9-]+, no ":")
+	Type      string             `yaml:"type"`      // registered action type name
+	Params    map[string]string  `yaml:"params"`    // key/value params; secret params must be ${VAR} refs
+	Match     MatchConfig        `yaml:"match"`     // event routing filter (RTG-01)
+	Timeout   string             `yaml:"timeout"`   // override type's default timeout; Go duration
+	Transform *TransformConfig   `yaml:"transform"` // replaces (not merges) the type's default transform
+	Headers   map[string]string  `yaml:"headers"`   // merge over type defaults; must not collide with computed auth
+	Batch     *WebhookBatch      `yaml:"batch"`     // override type's batching; rejected if type pins batch
+	Webhook   *WebhookSinkConfig `yaml:"webhook"`   // verbatim webhook config for type "custom" (escape hatch)
 }
 
 // MatchConfig declares which events an action should receive.
@@ -208,8 +208,8 @@ type SinksConfig struct {
 //
 // Cert rotation is not supported in v1; restart the process to reload certs.
 type ServerTLSConfig struct {
-	CertFile    string `yaml:"cert-file"`    // path to server certificate PEM; required for TLS
-	KeyFile     string `yaml:"key-file"`     // path to server private key PEM; required for TLS
+	CertFile     string `yaml:"cert-file"`      // path to server certificate PEM; required for TLS
+	KeyFile      string `yaml:"key-file"`       // path to server private key PEM; required for TLS
 	ClientCAFile string `yaml:"client-ca-file"` // path to CA PEM for client cert verification (mTLS); optional
 }
 

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -253,6 +253,12 @@ func (r *Router) SetDLQ(store dlq.Store) {
 	r.dlq = store
 }
 
+// RetryScheduler returns the Router's internal retry scheduler. Exposed so
+// production wiring can inject DLQ and metrics stores before Run.
+func (r *Router) RetryScheduler() *RetryScheduler {
+	return r.rs
+}
+
 // SetOwnedPartitions configures which partitions this Router instance reads.
 // Must be called before Run. Passing nil (default) restores "all partitions"
 // behavior — non-cluster mode is byte-for-byte identical to pre-Phase-16.
@@ -506,7 +512,6 @@ func (r *Router) flushBatchConsumers(ctx context.Context, partitionID uint32, ba
 	return backoffUntil
 }
 
-
 // handlePoisonFlush implements RTR-07 for a PermanentFlushError from FlushBatch.
 // On success it dead-letters the poisoned seq, records it in the skip-set,
 // discards the provisional cursor, and resets flusher backoff. Returns true
@@ -683,7 +688,6 @@ func (r *Router) resetPoisonStreak(idx int, partitionID uint32) {
 		delete(cs.poisonStreakLogged, partitionID)
 	}
 }
-
 
 // promoteProvisional promotes consumer index idx's provisional cursor advance
 // for partitionID into its durable cursor and persists it via cursorStore.


### PR DESCRIPTION
Source: `.agents/fix-plans/pr38-a-dlq-wiring.md`

## Problem
The DLQ package was fully implemented but never wired into `runPipeline`: `dlq.Open` and `SetDLQ` were only called from tests, so `--dlq-enabled`, `--dlq-path`, `--dlq-retention`, the `dlq:` YAML block, and all `kaptanto_dlq_*` metrics were inert in production.

## Fix
- Open the SQLite DLQ store at startup when DLQ is enabled (default true; explicit `false` restores pre-DLQ log-and-drop).
- Inject the store into `Router` and `RetryScheduler`, and wire scheduler metrics.
- Start a retention purge loop when `dlq.retention` is set.
- Remove the stale `fallback.ndjson` comment from `DLQConfig`.
- Expose `Router.RetryScheduler()` so production wiring can inject dependencies without leaking internals.

## Validation
- `gofmt -l internal/cmd internal/config internal/router` — clean
- `go build ./...`
- `go test ./internal/cmd ./internal/router ./internal/dlq ./internal/config -count=1` — all pass

## Residual risk / follow-up
- DLQ-size metric and fallback.ndjson metric still need cleanup; handled in `fix/pr38-g-polish`.
- DLQ stores full row payloads at rest; documentation handled in `fix/pr38-f-docs-accuracy`.