### PR TITLE
fix(cmd): implement output: webhook and observability for output: none

### DIFF
--- a/internal/cmd/output.go
+++ b/internal/cmd/output.go
@@ -24,6 +24,7 @@ import (
 	sqssink "github.com/olucasandrade/kaptanto/internal/output/sqs"
 	"github.com/olucasandrade/kaptanto/internal/output/sse"
 	"github.com/olucasandrade/kaptanto/internal/output/stdout"
+	webhooksink "github.com/olucasandrade/kaptanto/internal/output/webhook"
 	"github.com/olucasandrade/kaptanto/internal/router"
 )
 
@@ -132,7 +133,7 @@ func buildOutputServer(
 	// observability endpoints (/metrics, /healthz) would otherwise leak topology
 	// information to unauthenticated callers.
 	networkOutputs := map[string]bool{
-		"sse": true, "grpc": true,
+		"sse": true, "grpc": true, "webhook": true,
 		"nats": true, "sqs": true, "kafka": true, "pubsub": true, "rabbitmq": true,
 	}
 	if networkOutputs[cfg.Output] && cfg.AuthToken == "" {
@@ -149,13 +150,9 @@ func buildOutputServer(
 		)
 	}
 
-	// Short-circuit non-network outputs before generating OpenAPI: stdout and none
-	// do not expose /openapi.json, so a marshal failure should not prevent them
-	// from starting.
-	switch cfg.Output {
-	case "none":
-		return func(ctx context.Context) error { <-ctx.Done(); return nil }, nil
-	case "stdout":
+	// Short-circuit stdout before generating OpenAPI: it exposes no network
+	// endpoints, so a marshal failure should not prevent it from starting.
+	if cfg.Output == "stdout" {
 		w := stdout.NewStdoutWriter(os.Stdout)
 		w.SetMetrics(metrics)
 		rtr.Register(w)
@@ -172,6 +169,8 @@ func buildOutputServer(
 	oaHandler := openapi.NewHandler(oaBytes)
 
 	switch cfg.Output {
+	case "none":
+		return buildObservabilityServer(cfg, metrics, healthHandler, healthProbes, oaHandler)
 	case "sse":
 		return buildSSEServer(cfg, rtr, metrics, healthHandler, oaHandler, rowFilters, colFilters)
 	case "grpc":
@@ -221,8 +220,17 @@ func buildOutputServer(
 			return nil, fmt.Errorf("rabbitmq sink: init: %w", err)
 		}
 		return buildSinkServer(cfg, "rabbitmq", sink, rtr, metrics, healthProbes, oaHandler, nil)
+	case "webhook":
+		if cfg.Sinks.Webhook == nil {
+			return nil, fmt.Errorf("--output webhook requires a sinks.webhook block in config (url)")
+		}
+		sink, err := webhooksink.NewWebhookSinkConsumer("webhook", *cfg.Sinks.Webhook)
+		if err != nil {
+			return nil, fmt.Errorf("webhook sink: init: %w", err)
+		}
+		return buildSinkServer(cfg, "webhook", sink, rtr, metrics, healthProbes, oaHandler, nil)
 	default:
-		return nil, fmt.Errorf("unknown output mode %q: valid modes are none, stdout, sse, grpc, nats, sqs, kafka, pubsub, rabbitmq", cfg.Output)
+		return nil, fmt.Errorf("unknown output mode %q: valid modes are none, stdout, sse, grpc, nats, sqs, kafka, pubsub, rabbitmq, webhook", cfg.Output)
 	}
 }
 
@@ -354,6 +362,61 @@ func buildGRPCServer(
 		}()
 		if err := grpcSrv.Serve(lis); err != nil {
 			return fmt.Errorf("grpc server: %w", err)
+		}
+		return nil
+	}, nil
+}
+
+// buildObservabilityServer runs only the observability endpoints
+// (/metrics, /healthz, /openapi.json) for output modes that have no data-plane
+// server of their own. It applies the same TLS policy as buildSinkServer.
+func buildObservabilityServer(
+	cfg *config.Config,
+	metrics *observability.KaptantoMetrics,
+	healthHandler http.Handler,
+	healthProbes []observability.HealthProbe,
+	oaHandler http.Handler,
+) (func(context.Context) error, error) {
+	tlsCfg, err := buildServerTLSConfig(cfg.ServerTLS)
+	if err != nil {
+		return nil, err
+	}
+	if err := requireServerTLS("none", tlsCfg, cfg.Insecure); err != nil {
+		return nil, err
+	}
+
+	mux := http.NewServeMux()
+	var metricsH, healthH, oaH http.Handler
+	metricsH = metrics.Handler()
+	healthH = observability.NewHealthHandler(healthProbes)
+	oaH = oaHandler
+	if cfg.AuthToken != "" {
+		metricsH = auth.Middleware(cfg.AuthToken, metricsH)
+		healthH = auth.Middleware(cfg.AuthToken, healthH)
+		oaH = auth.Middleware(cfg.AuthToken, oaH)
+	}
+	mux.Handle("/metrics", metricsH)
+	mux.Handle("/healthz", healthH)
+	mux.Handle("/openapi.json", oaH)
+	srv := newHTTPServer(fmt.Sprintf(":%d", cfg.Port), mux)
+	if tlsCfg != nil {
+		srv.TLSConfig = tlsCfg
+	}
+	return func(ctx context.Context) error {
+		go func() {
+			<-ctx.Done()
+			shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			_ = srv.Shutdown(shutdownCtx)
+		}()
+		if tlsCfg != nil {
+			if err := srv.ListenAndServeTLS("", ""); err != nil && err != http.ErrServerClosed {
+				return fmt.Errorf("none obs server: %w", err)
+			}
+		} else {
+			if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+				return fmt.Errorf("none obs server: %w", err)
+			}
 		}
 		return nil
 	}, nil

--- a/internal/cmd/output_sink_tls_test.go
+++ b/internal/cmd/output_sink_tls_test.go
@@ -31,11 +31,11 @@ import (
 // server without bringing up a real broker connection.
 type fakeObsSink struct{}
 
-func (f *fakeObsSink) ID() string                                 { return "fake" }
+func (f *fakeObsSink) ID() string                                           { return "fake" }
 func (f *fakeObsSink) Deliver(_ context.Context, _ eventlog.LogEntry) error { return nil }
-func (f *fakeObsSink) SetMetrics(_ *observability.KaptantoMetrics) {}
-func (f *fakeObsSink) Ping() error                                { return nil }
-func (f *fakeObsSink) Close()                                     {}
+func (f *fakeObsSink) SetMetrics(_ *observability.KaptantoMetrics)          {}
+func (f *fakeObsSink) Ping() error                                          { return nil }
+func (f *fakeObsSink) Close()                                               {}
 
 var _ messageSink = (*fakeObsSink)(nil)
 
@@ -334,6 +334,112 @@ func TestBuildSinkServer_mTLSObservability(t *testing.T) {
 	req2.Header.Set("Authorization", "Bearer "+token)
 	_, err = noCertClient.Do(req2)
 	require.Error(t, err, "client without certificate must fail mTLS handshake")
+
+	cancel()
+}
+
+func TestBuildOutputServer_WebhookRequiresSinkConfig(t *testing.T) {
+	cfg := config.Defaults()
+	cfg.Output = "webhook"
+	cfg.Insecure = true
+
+	metrics := observability.NewKaptantoMetrics()
+	rtr := router.NewRouter(nil, 1, router.NewNoopCursorStore())
+
+	_, err := buildOutputServer(cfg, rtr, router.NewNoopCursorStore(), metrics, http.NotFoundHandler(), nil, nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "sinks.webhook")
+}
+
+func TestBuildOutputServer_WebhookRequiresTLS(t *testing.T) {
+	cfg := config.Defaults()
+	cfg.Output = "webhook"
+	cfg.AuthToken = "token"
+	cfg.Sinks.Webhook = &config.WebhookSinkConfig{
+		URL: "http://localhost:1",
+	}
+
+	metrics := observability.NewKaptantoMetrics()
+	rtr := router.NewRouter(nil, 1, router.NewNoopCursorStore())
+
+	_, err := buildOutputServer(cfg, rtr, router.NewNoopCursorStore(), metrics, http.NotFoundHandler(), nil, nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "requires TLS")
+}
+
+func TestBuildOutputServer_WebhookStarts(t *testing.T) {
+	cfg := config.Defaults()
+	cfg.Output = "webhook"
+	cfg.Insecure = true
+	cfg.Sinks.Webhook = &config.WebhookSinkConfig{
+		URL: "http://localhost:1",
+	}
+
+	metrics := observability.NewKaptantoMetrics()
+	rtr := router.NewRouter(nil, 1, router.NewNoopCursorStore())
+
+	fn, err := buildOutputServer(cfg, rtr, router.NewNoopCursorStore(), metrics, http.NotFoundHandler(), nil, nil, nil)
+	require.NoError(t, err)
+	assert.NotNil(t, fn)
+}
+
+func TestBuildOutputServer_NoneObservabilityRequiresTLS(t *testing.T) {
+	cfg := config.Defaults()
+	cfg.Output = "none"
+
+	metrics := observability.NewKaptantoMetrics()
+	rtr := router.NewRouter(nil, 1, router.NewNoopCursorStore())
+
+	_, err := buildOutputServer(cfg, rtr, router.NewNoopCursorStore(), metrics, http.NotFoundHandler(), nil, nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "requires TLS")
+}
+
+func TestBuildObservabilityServer_ServesEndpoints(t *testing.T) {
+	const token = "obs-none-token"
+	dir := t.TempDir()
+	certFile, keyFile := generateSelfSignedCert(t, dir)
+
+	cfg := config.Defaults()
+	port, lis := newLocalListener(t)
+	cfg.Port = port
+	_ = lis.Close() // release the port so the observability server can bind
+	cfg.AuthToken = token
+	cfg.ServerTLS = config.ServerTLSConfig{CertFile: certFile, KeyFile: keyFile}
+
+	metrics := observability.NewKaptantoMetrics()
+
+	fn, err := buildObservabilityServer(cfg, metrics, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }), nil, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }))
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = fn(ctx) }()
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
+	addr := fmt.Sprintf("https://127.0.0.1:%d", cfg.Port)
+	waitForObsServer(t, addr, client)
+
+	// No token → 401.
+	resp, err := client.Get(addr + "/healthz")
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	_ = resp.Body.Close()
+
+	// Token → 200 on all three observability endpoints.
+	for _, path := range []string{"/healthz", "/metrics", "/openapi.json"} {
+		req, err := http.NewRequest(http.MethodGet, addr+path, nil)
+		require.NoError(t, err)
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, resp.StatusCode, path)
+		_ = resp.Body.Close()
+	}
 
 	cancel()
 }


### PR DESCRIPTION
Source: `.agents/fix-plans/pr38-e-webhook-output-mode.md`

## Problem
- `output: webhook` was referenced by docs and OpenAPI generation but had no case in `buildOutputServer`, so it failed at startup.
- `output: none`, the documented pure action-processor mode, started no HTTP server at all, leaving `/metrics`, `/healthz`, and `/openapi.json` unreachable.

## Fix
- Implement `case "webhook"` in `buildOutputServer`, constructing the existing webhook sink from `cfg.Sinks.Webhook`.
- Add `webhook` to the network-outputs map so it requires TLS/auth like the other sinks.
- Move OpenAPI generation before the non-network short-circuit and serve the observability mux for `output: none`.
- Add focused tests covering webhook startup, TLS enforcement, and none-mode observability endpoints.

## Validation
- `gofmt -l internal/cmd` — clean
- `go build ./...`
- `go test ./internal/cmd ./internal/openapi -count=1` — all pass

## Residual risk / follow-up
- Examples currently use `output: none`; they now get observability endpoints (TLS required unless --insecure). Landing/README docs updates handled in `fix/pr38-f-docs-accuracy`.