### PR TITLE
fix(action): inngest api-url, shared event-name validation, After.* in cache-invalidate

### DIFF
--- a/internal/action/event_name_template.go
+++ b/internal/action/event_name_template.go
@@ -1,0 +1,120 @@
+package action
+
+import (
+	"fmt"
+	"strings"
+	"text/template/parse"
+)
+
+// eventNameFieldMap maps Go-template field names used in event-name templates
+// to the corresponding jq paths on a ChangeEvent.
+var eventNameFieldMap = map[string]string{
+	"Table":     ".table",
+	"Operation": ".operation",
+	"Schema":    ".schema",
+}
+
+// validateEventNameTemplate parses a template and rejects any construct other
+// than literal text and the field placeholders {{.Table}}, {{.Operation}}, and
+// {{.Schema}} (with optional whitespace). This prevents pipelines, conditionals,
+// unknown fields, and other Go template features from silently becoming literal
+// event names.
+func validateEventNameTemplate(tmpl string) error {
+	tree, err := parse.New("event-name").Parse(tmpl, "{{", "}}", map[string]*parse.Tree{})
+	if err != nil {
+		return err
+	}
+	return walkEventNameNodes(tree.Root)
+}
+
+func walkEventNameNodes(node parse.Node) error {
+	switch n := node.(type) {
+	case *parse.ListNode:
+		if n == nil {
+			return nil
+		}
+		for _, child := range n.Nodes {
+			if err := walkEventNameNodes(child); err != nil {
+				return err
+			}
+		}
+	case *parse.TextNode:
+		return nil
+	case *parse.ActionNode:
+		return walkEventNameNodes(n.Pipe)
+	case *parse.PipeNode:
+		if n == nil {
+			return nil
+		}
+		// A valid placeholder is a single command with one field argument.
+		if len(n.Cmds) != 1 {
+			return fmt.Errorf("unsupported template construct")
+		}
+		cmd := n.Cmds[0]
+		if len(cmd.Args) != 1 {
+			return fmt.Errorf("unsupported template construct")
+		}
+		return walkEventNameNodes(cmd.Args[0])
+	case *parse.FieldNode:
+		if len(n.Ident) != 1 {
+			return fmt.Errorf("unsupported field %q", strings.Join(n.Ident, "."))
+		}
+		if _, ok := eventNameFieldMap[n.Ident[0]]; !ok {
+			return fmt.Errorf("unsupported field %q", strings.Join(n.Ident, "."))
+		}
+		return nil
+	case *parse.StringNode:
+		return nil
+	default:
+		return fmt.Errorf("unsupported template construct %T", node)
+	}
+	return nil
+}
+
+// renderEventNameExpr converts a Go template string like
+// "kaptanto/{{ .Table }}.{{ .Operation }}" into a jq string expression like
+// `("kaptanto/" + .table + "." + .operation)`. It allows optional whitespace
+// inside the delimiters and rejects unknown fields.
+func renderEventNameExpr(tmpl string) (string, error) {
+	matches := templateFieldRe.FindAllStringSubmatchIndex(tmpl, -1)
+	if len(matches) == 0 {
+		if strings.Contains(tmpl, "{{") || strings.Contains(tmpl, "}}") {
+			return "", fmt.Errorf("unsupported template syntax in %q; only {{.Field}} placeholders are allowed", tmpl)
+		}
+		return jqStringLiteral(tmpl), nil
+	}
+
+	var parts []string
+	lastEnd := 0
+
+	for _, loc := range matches {
+		if loc[0] > lastEnd {
+			literal := tmpl[lastEnd:loc[0]]
+			if strings.Contains(literal, "{{") || strings.Contains(literal, "}}") {
+				return "", fmt.Errorf("unsupported template syntax in %q; only {{.Field}} placeholders are allowed", tmpl)
+			}
+			parts = append(parts, jqStringLiteral(literal))
+		}
+
+		fieldName := tmpl[loc[2]:loc[3]]
+		jqField, ok := eventNameFieldMap[fieldName]
+		if !ok {
+			return "", fmt.Errorf("unsupported field %q; supported: Table, Operation, Schema", fieldName)
+		}
+		parts = append(parts, jqField)
+		lastEnd = loc[1]
+	}
+
+	if lastEnd < len(tmpl) {
+		literal := tmpl[lastEnd:]
+		if strings.Contains(literal, "{{") || strings.Contains(literal, "}}") {
+			return "", fmt.Errorf("unsupported template syntax in %q; only {{.Field}} placeholders are allowed", tmpl)
+		}
+		parts = append(parts, jqStringLiteral(literal))
+	}
+
+	if len(parts) == 1 {
+		return parts[0], nil
+	}
+	return "(" + strings.Join(parts, " + ") + ")", nil
+}

--- a/internal/action/types_cloudflare.go
+++ b/internal/action/types_cloudflare.go
@@ -2,6 +2,7 @@ package action
 
 import (
 	"fmt"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -26,7 +27,7 @@ func (cloudflareType) ParamSpec() map[string]ParamSpec {
 	}
 }
 
-func (cloudflareType) PinsBatch() bool             { return true }
+func (cloudflareType) PinsBatch() bool               { return true }
 func (cloudflareType) ComputedAuthHeaders() []string { return []string{"Authorization"} }
 
 // urlFieldMap maps Go-template field names to jq JSON paths on the ChangeEvent.
@@ -38,6 +39,35 @@ var urlFieldMap = map[string]string{
 	"Source":         ".source",
 	"ID":             ".id",
 	"IdempotencyKey": ".idempotency_key",
+}
+
+// urlTemplateFieldRe matches {{.Field}} and {{.After.col}} / {{.Before.col}}
+// placeholders with optional whitespace inside the delimiters.
+var urlTemplateFieldRe = regexp.MustCompile(`\{\{\s*\.([\w.]+)\s*\}\}`)
+
+// urlTemplateFieldToJQ converts a captured template field name to a jq path.
+// It supports top-level fields from urlFieldMap and row-data prefixes
+// After.<col> / Before.<col>.
+func urlTemplateFieldToJQ(fieldName string) (string, error) {
+	if jq, ok := urlFieldMap[fieldName]; ok {
+		return jq, nil
+	}
+	if strings.HasPrefix(fieldName, "After.") {
+		col := strings.TrimPrefix(fieldName, "After.")
+		if col == "" {
+			return "", fmt.Errorf("empty column in After.* placeholder")
+		}
+		return fmt.Sprintf(`.after[%s]`, jqStringLiteral(col)), nil
+	}
+	if strings.HasPrefix(fieldName, "Before.") {
+		col := strings.TrimPrefix(fieldName, "Before.")
+		if col == "" {
+			return "", fmt.Errorf("empty column in Before.* placeholder")
+		}
+		return fmt.Sprintf(`.before[%s]`, jqStringLiteral(col)), nil
+	}
+	return "", fmt.Errorf("unsupported field %q; supported: %s, After.<col>, Before.<col>",
+		fieldName, strings.Join(sortedKeys(urlFieldMap), ", "))
 }
 
 func (cloudflareType) Build(p ResolvedParams) (config.WebhookSinkConfig, config.TransformConfig, error) {
@@ -84,9 +114,10 @@ func (cloudflareType) Build(p ResolvedParams) (config.WebhookSinkConfig, config.
 // urlTemplateToJQ converts a simple Go-template URL string like
 // "https://cdn.example.com/{{.Table}}" into a jq string expression that safely
 // JSON-encodes the rendered URL. Unsupported Go-template constructs are
-// rejected so they cannot silently produce malformed JSON.
+// rejected so they cannot silently produce malformed JSON. Row-data columns may
+// be referenced as {{.After.<col>}} or {{.Before.<col>}}.
 func urlTemplateToJQ(tmpl string) (string, error) {
-	matches := templateFieldRe.FindAllStringSubmatchIndex(tmpl, -1)
+	matches := urlTemplateFieldRe.FindAllStringSubmatchIndex(tmpl, -1)
 	if len(matches) == 0 {
 		if strings.Contains(tmpl, "{{") || strings.Contains(tmpl, "}}") {
 			return "", fmt.Errorf("unsupported template syntax in %q; only {{.Field}} placeholders are allowed", tmpl)
@@ -107,10 +138,9 @@ func urlTemplateToJQ(tmpl string) (string, error) {
 		}
 
 		fieldName := tmpl[loc[2]:loc[3]]
-		jqField, ok := urlFieldMap[fieldName]
-		if !ok {
-			return "", fmt.Errorf("unsupported field %q; supported: %s",
-				fieldName, strings.Join(sortedKeys(urlFieldMap), ", "))
+		jqField, err := urlTemplateFieldToJQ(fieldName)
+		if err != nil {
+			return "", err
 		}
 		parts = append(parts, fmt.Sprintf("(%s | tostring)", jqField))
 		lastEnd = loc[1]

--- a/internal/action/types_cloudflare_test.go
+++ b/internal/action/types_cloudflare_test.go
@@ -244,6 +244,20 @@ func TestCacheInvalidate_GoldenRequest(t *testing.T) {
 	assert.Equal(t, "https://cdn.example.com/public/products", body["files"][0])
 }
 
+func TestCacheInvalidate_Build_AfterColumn(t *testing.T) {
+	ct := action.DefaultRegistry.Lookup("cache-invalidate")
+	require.NotNil(t, ct)
+
+	_, tc, err := ct.Build(action.ResolvedParams{
+		"api-token":    "tok",
+		"zone-id":      "z1",
+		"url-template": `https://cdn.example.com/products/{{.After.id}}`,
+	})
+	require.NoError(t, err)
+	assert.Contains(t, tc.Expression, `.after["id"]`)
+	assert.Contains(t, tc.Expression, `| tostring`)
+}
+
 func TestCacheInvalidate_GoldenRequest_DatabaseSource(t *testing.T) {
 	var gotBody []byte
 

--- a/internal/action/types_inngest.go
+++ b/internal/action/types_inngest.go
@@ -3,16 +3,16 @@ package action
 import (
 	"fmt"
 	"strings"
-	"text/template/parse"
 
 	"github.com/olucasandrade/kaptanto/internal/config"
 )
 
 // inngestType implements the "inngest" action type (ACT-01).
 //
-// Inngest accepts events via POST https://inn.gs/e/<event-key>.
-// The event-key is embedded in the URL path (not a header), so there are no
-// computed auth headers. Inngest accepts JSON arrays, so batching is allowed.
+// Inngest accepts events via POST <api-url>/e/<event-key> (cloud default:
+// https://inn.gs). The event-key is embedded in the URL path (not a header), so
+// there are no computed auth headers. Inngest accepts JSON arrays, so batching
+// is allowed.
 type inngestType struct{}
 
 func init() { DefaultRegistry.Register(&inngestType{}) }
@@ -26,6 +26,12 @@ func (*inngestType) ParamSpec() map[string]ParamSpec {
 			Secret:      true,
 			Description: "Inngest event key (embedded in URL path)",
 		},
+		"api-url": {
+			Required:    false,
+			Secret:      false,
+			Description: "Inngest API base URL (set to a local dev server for development)",
+			Default:     "https://inn.gs",
+		},
 		"event-name-template": {
 			Required:    false,
 			Secret:      false,
@@ -35,11 +41,15 @@ func (*inngestType) ParamSpec() map[string]ParamSpec {
 	}
 }
 
-func (*inngestType) PinsBatch() bool          { return false }
+func (*inngestType) PinsBatch() bool               { return false }
 func (*inngestType) ComputedAuthHeaders() []string { return nil }
 
 func (*inngestType) Build(p ResolvedParams) (config.WebhookSinkConfig, config.TransformConfig, error) {
 	eventKey := p["event-key"]
+	apiURL := strings.TrimRight(p["api-url"], "/")
+	if apiURL == "" {
+		apiURL = "https://inn.gs"
+	}
 	nameTemplate := p["event-name-template"]
 
 	if err := validateEventNameTemplate(nameTemplate); err != nil {
@@ -47,9 +57,13 @@ func (*inngestType) Build(p ResolvedParams) (config.WebhookSinkConfig, config.Tr
 			fmt.Errorf("inngest: invalid event-name-template: %w", err)
 	}
 
-	nameExpr := renderNameExpr(nameTemplate)
+	nameExpr, err := renderEventNameExpr(nameTemplate)
+	if err != nil {
+		return config.WebhookSinkConfig{}, config.TransformConfig{},
+			fmt.Errorf("inngest: invalid event-name-template: %w", err)
+	}
 
-	url := "https://inn.gs/e/" + eventKey
+	url := apiURL + "/e/" + eventKey
 
 	whCfg := config.WebhookSinkConfig{
 		URL:    url,
@@ -60,7 +74,7 @@ func (*inngestType) Build(p ResolvedParams) (config.WebhookSinkConfig, config.Tr
 	}
 
 	jqExpr := fmt.Sprintf(
-		`{name: %s, id: .idempotency_key, ts: (.ts // now*1000 | floor), data: .}`,
+		`{name: %s, id: .idempotency_key, ts: ((.timestamp | fromdateiso8601) * 1000) // (now*1000 | floor), data: .}`,
 		nameExpr,
 	)
 
@@ -70,103 +84,4 @@ func (*inngestType) Build(p ResolvedParams) (config.WebhookSinkConfig, config.Tr
 	}
 
 	return whCfg, transform, nil
-}
-
-var allowedEventNameFields = map[string]bool{
-	"Table":     true,
-	"Operation": true,
-	"Schema":    true,
-}
-
-// validateEventNameTemplate parses the template and rejects any construct other
-// than literal text and the exact field placeholders {{.Table}}, {{.Operation}},
-// and {{.Schema}}. This prevents pipelines, conditionals, and other Go template
-// features from silently becoming literal event names.
-func validateEventNameTemplate(tmpl string) error {
-	tree, err := parse.New("event-name").Parse(tmpl, "{{", "}}", map[string]*parse.Tree{})
-	if err != nil {
-		return err
-	}
-	return walkEventNameNodes(tree.Root)
-}
-
-func walkEventNameNodes(node parse.Node) error {
-	switch n := node.(type) {
-	case *parse.ListNode:
-		if n == nil {
-			return nil
-		}
-		for _, child := range n.Nodes {
-			if err := walkEventNameNodes(child); err != nil {
-				return err
-			}
-		}
-	case *parse.TextNode:
-		return nil
-	case *parse.ActionNode:
-		return walkEventNameNodes(n.Pipe)
-	case *parse.PipeNode:
-		if n == nil {
-			return nil
-		}
-		// A valid placeholder is a single command with one field argument.
-		if len(n.Cmds) != 1 {
-			return fmt.Errorf("unsupported template construct")
-		}
-		cmd := n.Cmds[0]
-		if len(cmd.Args) != 1 {
-			return fmt.Errorf("unsupported template construct")
-		}
-		return walkEventNameNodes(cmd.Args[0])
-	case *parse.FieldNode:
-		if len(n.Ident) != 1 || !allowedEventNameFields[n.Ident[0]] {
-			return fmt.Errorf("unsupported field %q", strings.Join(n.Ident, "."))
-		}
-		return nil
-	case *parse.StringNode:
-		return nil
-	default:
-		return fmt.Errorf("unsupported template construct %T", node)
-	}
-	return nil
-}
-
-// renderNameExpr converts a Go template string like "kaptanto/{{.Table}}.{{.Operation}}"
-// into a jq string expression like ("kaptanto/" + .table + "." + .operation).
-// The CDC event JSON uses lowercase field names (.table, .operation, .schema).
-func renderNameExpr(tmpl string) string {
-	fieldMap := map[string]string{
-		"{{.Table}}":     ".table",
-		"{{.Operation}}": ".operation",
-		"{{.Schema}}":    ".schema",
-	}
-
-	parts := []string{}
-	remaining := tmpl
-	for len(remaining) > 0 {
-		earliest := -1
-		var earliestKey, earliestField string
-		for key, field := range fieldMap {
-			idx := strings.Index(remaining, key)
-			if idx >= 0 && (earliest < 0 || idx < earliest) {
-				earliest = idx
-				earliestKey = key
-				earliestField = field
-			}
-		}
-		if earliest < 0 {
-			parts = append(parts, fmt.Sprintf("%q", remaining))
-			break
-		}
-		if earliest > 0 {
-			parts = append(parts, fmt.Sprintf("%q", remaining[:earliest]))
-		}
-		parts = append(parts, earliestField)
-		remaining = remaining[earliest+len(earliestKey):]
-	}
-
-	if len(parts) == 1 {
-		return parts[0]
-	}
-	return "(" + strings.Join(parts, " + ") + ")"
 }

--- a/internal/action/types_inngest_test.go
+++ b/internal/action/types_inngest_test.go
@@ -64,7 +64,7 @@ func TestInngest_Build_DefaultTemplate(t *testing.T) {
 	assert.Contains(t, tc.Expression, ".idempotency_key")
 	assert.Contains(t, tc.Expression, ".table")
 	assert.Contains(t, tc.Expression, ".operation")
-	assert.Contains(t, tc.Expression, "now*1000")
+	assert.Contains(t, tc.Expression, "fromdateiso8601")
 
 	// Compile and execute the transform against a real event to catch invalid
 	// jq runtime behavior such as applying floor to a serialized timestamp.
@@ -101,8 +101,11 @@ func TestInngest_Build_DefaultTemplate(t *testing.T) {
 	require.NoError(t, json.Unmarshal(out, &envelope))
 	assert.Equal(t, "kaptanto/orders.insert", envelope.Name)
 	assert.Equal(t, ev.IdempotencyKey, envelope.ID)
-	assert.Greater(t, envelope.TS, float64(0))
 	assert.Equal(t, "orders", envelope.Data["table"])
+
+	// ts must be derived from the event's RFC3339 timestamp, not from "now".
+	wantTS := float64(ev.Timestamp.UnixMilli())
+	assert.InDelta(t, wantTS, envelope.TS, 1.0, "ts should be event time in milliseconds")
 }
 
 func TestInngest_Build_CustomTemplate(t *testing.T) {
@@ -206,6 +209,32 @@ func TestInngest_Build_UnsupportedTemplateSyntax(t *testing.T) {
 		})
 		require.Error(t, err, "template %q must be rejected", tmpl)
 	}
+}
+
+func TestInngest_Build_WhitespaceTemplate(t *testing.T) {
+	it := lookupType(t, "inngest")
+	params := action.ResolvedParams{
+		"event-key":           "key",
+		"event-name-template": "kaptanto/{{ .Table }}.{{ .Operation }}",
+	}
+
+	_, tc, err := it.Build(params)
+	require.NoError(t, err)
+	assert.Contains(t, tc.Expression, ".table")
+	assert.Contains(t, tc.Expression, ".operation")
+	assert.NotContains(t, tc.Expression, "{{")
+}
+
+func TestInngest_Build_APIURLHonored(t *testing.T) {
+	it := lookupType(t, "inngest")
+	params := action.ResolvedParams{
+		"event-key": "key",
+		"api-url":   "http://inngest:8288",
+	}
+
+	whCfg, _, err := it.Build(params)
+	require.NoError(t, err)
+	assert.Equal(t, "http://inngest:8288/e/key", whCfg.URL)
 }
 
 func TestInngest_Golden_BatchMode_Valid(t *testing.T) {

--- a/internal/action/types_triggerdev.go
+++ b/internal/action/types_triggerdev.go
@@ -3,7 +3,6 @@ package action
 import (
 	"fmt"
 	"strings"
-	"text/template"
 
 	"github.com/olucasandrade/kaptanto/internal/config"
 )
@@ -41,7 +40,7 @@ func (*triggerdevType) ParamSpec() map[string]ParamSpec {
 	}
 }
 
-func (*triggerdevType) PinsBatch() bool             { return true }
+func (*triggerdevType) PinsBatch() bool               { return true }
 func (*triggerdevType) ComputedAuthHeaders() []string { return []string{"Authorization"} }
 
 func (*triggerdevType) Build(p ResolvedParams) (config.WebhookSinkConfig, config.TransformConfig, error) {
@@ -49,12 +48,16 @@ func (*triggerdevType) Build(p ResolvedParams) (config.WebhookSinkConfig, config
 	apiURL := strings.TrimRight(p["api-url"], "/")
 	nameTemplate := p["event-name-template"]
 
-	if _, err := template.New("").Parse(nameTemplate); err != nil {
+	if err := validateEventNameTemplate(nameTemplate); err != nil {
 		return config.WebhookSinkConfig{}, config.TransformConfig{},
 			fmt.Errorf("triggerdev: invalid event-name-template: %w", err)
 	}
 
-	nameExpr := renderNameExpr(nameTemplate)
+	nameExpr, err := renderEventNameExpr(nameTemplate)
+	if err != nil {
+		return config.WebhookSinkConfig{}, config.TransformConfig{},
+			fmt.Errorf("triggerdev: invalid event-name-template: %w", err)
+	}
 
 	whCfg := config.WebhookSinkConfig{
 		URL:    apiURL + "/api/v1/events",

--- a/internal/action/types_triggerdev_test.go
+++ b/internal/action/types_triggerdev_test.go
@@ -201,6 +201,40 @@ func TestTriggerdev_Golden_APIURLOverride_Honored(t *testing.T) {
 	require.Len(t, consumers, 1)
 }
 
+func TestTriggerdev_Build_UnsupportedTemplateSyntax(t *testing.T) {
+	td := lookupType(t, "triggerdev")
+
+	unsupported := []string{
+		`myapp/{{.Table | upper}}`,
+		`{{if .Table}}x{{end}}`,
+		`{{.UnknownField}}`,
+	}
+
+	for _, tmpl := range unsupported {
+		_, _, err := td.Build(action.ResolvedParams{
+			"api-key":             "tr_test_key",
+			"api-url":             "https://api.trigger.dev",
+			"event-name-template": tmpl,
+		})
+		require.Error(t, err, "template %q must be rejected", tmpl)
+	}
+}
+
+func TestTriggerdev_Build_WhitespaceTemplate(t *testing.T) {
+	td := lookupType(t, "triggerdev")
+	params := action.ResolvedParams{
+		"api-key":             "tr_test_key",
+		"api-url":             "https://api.trigger.dev",
+		"event-name-template": "kaptanto/{{ .Table }}.{{ .Operation }}",
+	}
+
+	_, tc, err := td.Build(params)
+	require.NoError(t, err)
+	assert.Contains(t, tc.Expression, ".table")
+	assert.Contains(t, tc.Expression, ".operation")
+	assert.NotContains(t, tc.Expression, "{{")
+}
+
 func TestTriggerdev_Golden_AuthHeaderCollision_Rejected(t *testing.T) {
 	t.Setenv("TRIGGER_API_KEY", "tr_test_key")
 


### PR DESCRIPTION
Source: `.agents/fix-plans/pr38-d-action-types.md`

## Problem
- Inngest hardcoded `https://inn.gs/e/`, making local dev servers unreachable.
- `triggerdev` only parsed the event-name template, allowing unsupported constructs to render literally.
- `inngest` accepted whitespace in `{{ .Table }}` but rendered it literally because the renderer string-matched only exact `{{.Table}}`.
- `ts` in the Inngest payload always fell back to send-time; it never used the event timestamp.
- `cache-invalidate` url-template did not support row-data references like `{{.After.id}}`.

## Fix
- Add optional `api-url` param to the inngest type (default `https://inn.gs`).
- Move event-name template AST validation and regex-based jq rendering to `internal/action/event_name_template.go`; use it from both inngest and triggerdev.
- Derive Inngest `ts` from the event's `.timestamp` field with a now-based fallback.
- Extend `cache-invalidate` url-template to support `{{.After.<col>}}` and `{{.Before.<col>}}`.

## Validation
- `gofmt -l internal/action` — clean
- `go build ./...`
- `go test ./internal/action -count=1` — all pass

## Residual risk / follow-up
- The Inngest example smoke test in `fix/pr38-b-examples-repair` currently skips the `api-url` case until this branch merges; after merge that skip can be removed.