### PR TITLE
fix(webhook): redact secret URLs, skip re-expansion, enforce HTTP(S) scheme

### DIFF
--- a/internal/output/webhook/consumer.go
+++ b/internal/output/webhook/consumer.go
@@ -79,6 +79,7 @@ import (
 	"github.com/olucasandrade/kaptanto/internal/event"
 	"github.com/olucasandrade/kaptanto/internal/eventlog"
 	"github.com/olucasandrade/kaptanto/internal/observability"
+	"github.com/olucasandrade/kaptanto/internal/redact"
 	"github.com/olucasandrade/kaptanto/internal/router"
 	"github.com/olucasandrade/kaptanto/internal/transform"
 )
@@ -129,9 +130,24 @@ type pendingReq struct {
 // configuration (fail-fast), and builds a shared http.Client. The caller is
 // responsible for calling Close() when done.
 func NewWebhookSinkConsumer(id string, cfg config.WebhookSinkConfig) (*WebhookSinkConsumer, error) {
-	cfg, err := expandWebhookConfig(cfg)
-	if err != nil {
-		return nil, err
+	return newWebhookSinkConsumer(id, cfg, true)
+}
+
+// NewResolvedWebhookSinkConsumer creates a WebhookSinkConsumer from a config
+// whose values have already been resolved (e.g. by the action engine). It skips
+// env expansion so a resolved secret containing a literal '$' is not corrupted
+// by a second expansion pass.
+func NewResolvedWebhookSinkConsumer(id string, cfg config.WebhookSinkConfig) (*WebhookSinkConsumer, error) {
+	return newWebhookSinkConsumer(id, cfg, false)
+}
+
+func newWebhookSinkConsumer(id string, cfg config.WebhookSinkConfig, expand bool) (*WebhookSinkConsumer, error) {
+	var err error
+	if expand {
+		cfg, err = expandWebhookConfig(cfg)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	norm, err := validateWebhookConfig(cfg)
@@ -253,6 +269,24 @@ func validateWebhookConfig(cfg config.WebhookSinkConfig) (webhookNorm, error) {
 	case http.MethodPost, http.MethodPut, http.MethodPatch:
 	default:
 		return zero, fmt.Errorf("webhook sink: method %q not allowed — must be one of POST, PUT, PATCH", cfg.Method)
+	}
+
+	// 2a. Scheme allowlist. Only http/https are supported; other schemes surface
+	// as transient transport errors and would retry forever (F6).
+	if cfg.URL != "" {
+		if err := requireHTTPScheme(cfg.URL); err != nil {
+			return zero, err
+		}
+	}
+	if cfg.URLTemplate != "" {
+		trimmed := strings.TrimSpace(cfg.URLTemplate)
+		// Templates whose first token is a placeholder cannot be validated until
+		// render time; anything with a literal scheme prefix must be http/https.
+		if trimmed != "" && !strings.HasPrefix(trimmed, "{{") {
+			if err := requireHTTPScheme(trimmed); err != nil {
+				return zero, err
+			}
+		}
 	}
 
 	// 3. Bearer XOR basic.
@@ -439,6 +473,8 @@ func (c *WebhookSinkConsumer) Deliver(ctx context.Context, entry eventlog.LogEnt
 }
 
 // resolveURL returns the request URL for ev: url-template if set, else static url.
+// A rendered URL that does not use http/https is returned as a permanent error
+// so the router dead-letters it instead of retrying forever (F6).
 func (c *WebhookSinkConsumer) resolveURL(ev *event.ChangeEvent) (string, error) {
 	if c.urlT != nil {
 		var buf bytes.Buffer
@@ -448,6 +484,9 @@ func (c *WebhookSinkConsumer) resolveURL(ev *event.ChangeEvent) (string, error) 
 		u := strings.TrimSpace(buf.String())
 		if u == "" {
 			return "", fmt.Errorf("webhook sink: url-template rendered to an empty string — check url-template config")
+		}
+		if err := requireHTTPScheme(u); err != nil {
+			return "", &router.PermanentError{Cause: err.Error()}
 		}
 		return u, nil
 	}
@@ -476,6 +515,9 @@ func (c *WebhookSinkConsumer) buildBody(entry eventlog.LogEntry) ([]byte, bool, 
 	}
 	out, drop, err := c.engine.Apply(raw, entry.Event)
 	if err != nil {
+		if c.m != nil {
+			c.m.TransformErrorsTotal.WithLabelValues(c.id).Inc()
+		}
 		return nil, false, err
 	}
 	if drop {
@@ -540,12 +582,12 @@ func (c *WebhookSinkConsumer) FlushBatch(ctx context.Context, partitionID uint32
 func (c *WebhookSinkConsumer) sendGrouped(ctx context.Context, req httpReq) error {
 	status, snippet, err := c.doRequest(ctx, req)
 	if err != nil {
-		return fmt.Errorf("webhook sink: %s %s: %w", c.method, req.url, err)
+		return fmt.Errorf("webhook sink: %s %s: %w", c.method, redact.URL(req.url), err)
 	}
 	if status >= 200 && status < 300 {
 		return nil
 	}
-	cause := fmt.Errorf("webhook sink: %s %s returned %d: %.256s", c.method, req.url, status, snippet)
+	cause := fmt.Errorf("webhook sink: %s %s returned %d: %.256s", c.method, redact.URL(req.url), status, snippet)
 	if isTransientStatus(status) {
 		return cause
 	}
@@ -576,12 +618,12 @@ func (c *WebhookSinkConsumer) isolatePoisonChunk(ctx context.Context, items []pe
 		status, snippet, err := c.doRequest(ctx, single)
 		if err != nil {
 			// Transient network/timeout — abort isolation; do not resend further.
-			return fmt.Errorf("webhook sink: %s %s: %w", c.method, item.url, err)
+			return fmt.Errorf("webhook sink: %s %s: %w", c.method, redact.URL(item.url), err)
 		}
 		if status >= 200 && status < 300 {
 			continue
 		}
-		cause := fmt.Errorf("webhook sink: %s %s returned %d: %.256s", c.method, item.url, status, snippet)
+		cause := fmt.Errorf("webhook sink: %s %s returned %d: %.256s", c.method, redact.URL(item.url), status, snippet)
 		if isTransientStatus(status) {
 			return cause
 		}
@@ -764,6 +806,21 @@ func (c *WebhookSinkConsumer) Ping() error {
 // Close closes idle HTTP connections. It is safe to call Close multiple times.
 func (c *WebhookSinkConsumer) Close() {
 	c.client.CloseIdleConnections()
+}
+
+// requireHTTPScheme returns an error if s does not start with an http or https
+// scheme. It tolerates leading/trailing whitespace and placeholder templates
+// as long as the scheme prefix is literal http:// or https://.
+func requireHTTPScheme(s string) error {
+	trimmed := strings.TrimSpace(s)
+	if strings.HasPrefix(trimmed, "http://") || strings.HasPrefix(trimmed, "https://") {
+		return nil
+	}
+	u, err := url.Parse(trimmed)
+	if err == nil && (u.Scheme == "http" || u.Scheme == "https") {
+		return nil
+	}
+	return fmt.Errorf("webhook sink: url/url-template must use http or https scheme")
 }
 
 // buildTLSConfig constructs a *tls.Config from cfg:

--- a/internal/output/webhook/consumer_test.go
+++ b/internal/output/webhook/consumer_test.go
@@ -708,3 +708,80 @@ func BenchmarkFlushBatch(b *testing.B) {
 		})
 	}
 }
+
+func TestNewWebhookSinkConsumer_RejectBadScheme(t *testing.T) {
+	_, err := webhooksink.NewWebhookSinkConsumer("w", config.WebhookSinkConfig{
+		URL: "file:///etc/passwd",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "http or https")
+}
+
+func TestNewResolvedWebhookSinkConsumer_SkipsReExpansion(t *testing.T) {
+	// A config whose values are already resolved (no ${...} refs left).
+	cfg := config.WebhookSinkConfig{
+		URL: "http://example.com",
+		Auth: config.WebhookAuthConfig{
+			BearerToken: "abc$def",
+		},
+	}
+
+	c, err := webhooksink.NewResolvedWebhookSinkConsumer("w", cfg)
+	require.NoError(t, err)
+	defer c.Close()
+	_ = c
+}
+
+func TestDeliver_URLTemplateBadScheme_IsPermanent(t *testing.T) {
+	c := newConsumer(t, config.WebhookSinkConfig{
+		URLTemplate: "{{.Table}}",
+	})
+	c.SetMetrics(observability.NewKaptantoMetrics())
+
+	err := c.Deliver(context.Background(), makeEntry(0, "public", "orders", "x", nil))
+	require.Error(t, err)
+	var permanent *router.PermanentError
+	require.ErrorAs(t, err, &permanent)
+}
+
+func TestFlushBatch_URLRedactedInError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte("nope"))
+	}))
+	t.Cleanup(srv.Close)
+
+	secretPath := "/services/T0123/B0456/xXxSecretToken"
+	c, err := webhooksink.NewWebhookSinkConsumer("w", config.WebhookSinkConfig{
+		URL: srv.URL + secretPath,
+	})
+	require.NoError(t, err)
+	t.Cleanup(c.Close)
+
+	err = c.Deliver(context.Background(), makeEntry(0, "public", "orders", "i1", []byte(`{}`)))
+	require.NoError(t, err)
+	err = c.FlushBatch(context.Background(), 0)
+	require.Error(t, err)
+
+	assert.NotContains(t, err.Error(), secretPath, "error must not leak secret URL path")
+	assert.Contains(t, err.Error(), "webhook sink:")
+}
+
+func TestDeliver_TransformError_IncrementsMetric(t *testing.T) {
+	m := observability.NewKaptantoMetrics()
+	c, err := webhooksink.NewWebhookSinkConsumer("w", config.WebhookSinkConfig{
+		URL: "http://example.com",
+		Transform: config.TransformConfig{
+			Language:   "go-template",
+			Expression: "{{.NonExistent}}",
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(c.Close)
+	c.SetMetrics(m)
+
+	err = c.Deliver(context.Background(), makeEntry(0, "public", "orders", "i1", []byte(`{}`)))
+	require.Error(t, err)
+	val := testutil.ToFloat64(m.TransformErrorsTotal.WithLabelValues("w"))
+	assert.Equal(t, 1.0, val)
+}

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -1,0 +1,25 @@
+// Package redact provides helpers for stripping secrets from values before
+// they appear in logs, returned errors, or DLQ reason strings (ACT-02:
+// secrets are never logged).
+package redact
+
+import (
+	"net/url"
+	"strings"
+)
+
+// URL returns raw reduced to scheme://host, dropping userinfo, path, query,
+// and fragment — the parts that typically carry credentials. For webhook URLs
+// such as https://hooks.slack.com/services/T…/B…/xxx or
+// https://inn.gs/e/<event-key>, the path (and sometimes the query) IS the
+// credential, so none of it may survive into an error string.
+//
+// The function fails closed: if raw cannot be parsed, or yields no host,
+// it returns a fixed placeholder instead of any part of raw.
+func URL(raw string) string {
+	u, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil || u.Host == "" {
+		return "<redacted-url>"
+	}
+	return u.Scheme + "://" + u.Host
+}

--- a/internal/redact/redact_test.go
+++ b/internal/redact/redact_test.go
@@ -1,0 +1,93 @@
+package redact
+
+import "testing"
+
+func TestURL(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "slack webhook path is dropped",
+			in:   "https://hooks.slack.com/services/T0123/B0456/xXxSecretToken",
+			want: "https://hooks.slack.com",
+		},
+		{
+			name: "query and fragment dropped",
+			in:   "https://example.com/hook?token=abc123#frag",
+			want: "https://example.com",
+		},
+		{
+			name: "userinfo dropped",
+			in:   "https://user:pass@example.com:8443/path",
+			want: "https://example.com:8443",
+		},
+		{
+			name: "http scheme kept",
+			in:   "http://127.0.0.1:9000/events",
+			want: "http://127.0.0.1:9000",
+		},
+		{
+			name: "non-http scheme keeps scheme and host only",
+			in:   "ftp://files.example.com/etc/passwd",
+			want: "ftp://files.example.com",
+		},
+		{
+			name: "schemeless host-only input fails closed",
+			in:   "example.com/secret-path",
+			want: "<redacted-url>",
+		},
+		{
+			name: "no host fails closed",
+			in:   "file:///etc/passwd",
+			want: "<redacted-url>",
+		},
+		{
+			name: "unparseable fails closed",
+			in:   "http://exa mple.com/path",
+			want: "<redacted-url>",
+		},
+		{
+			name: "empty input fails closed",
+			in:   "",
+			want: "<redacted-url>",
+		},
+		{
+			name: "surrounding whitespace trimmed",
+			in:   "  https://example.com/hook  ",
+			want: "https://example.com",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := URL(tc.in); got != tc.want {
+				t.Fatalf("URL(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestURL_NeverLeaksSecret(t *testing.T) {
+	const secret = "xXxSecretToken"
+	out := URL("https://hooks.slack.com/services/T0123/B0456/" + secret)
+	if out == "" || len(out) == 0 {
+		t.Fatal("expected non-empty redaction")
+	}
+	if contains := containsSubstring(out, secret); contains {
+		t.Fatalf("redacted URL %q leaks secret %q", out, secret)
+	}
+}
+
+func containsSubstring(s, sub string) bool {
+	return len(sub) > 0 && len(s) >= len(sub) && (s == sub || len(s) > 0 && indexOf(s, sub) >= 0)
+}
+
+func indexOf(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}


### PR DESCRIPTION
Source: `.agents/fix-plans/pr38-c-webhook-hardening.md`

## Problem
- Secret webhook URLs (Slack, Discord, Inngest tokens embedded in paths) leaked into logs and DLQ reason strings.
- Resolved action secrets were expanded a second time by the webhook sink, breaking values containing literal `$`.
- Non-HTTP(S) schemes passed startup and then retried forever as transient transport errors.
- `TransformErrorsTotal` was registered but never incremented.

## Fix
- Add `NewResolvedWebhookSinkConsumer` for action-built configs and keep `NewWebhookSinkConsumer` for raw sink configs.
- Use `internal/redact.URL` in all webhook error strings so only scheme+host survive.
- Validate the URL scheme at construction and after rendering `url-template`; bad schemes become permanent errors.
- Increment `TransformErrorsTotal` in `buildBody` when `engine.Apply` returns an error.

## Validation
- `gofmt -l internal/output/webhook internal/redact` — clean
- `go build ./...`
- `go test ./internal/output/webhook ./internal/redact -count=1` — all pass

## Residual risk / follow-up
- `internal/action/action.go` still calls `NewWebhookSinkConsumer`; it should switch to `NewResolvedWebhookSinkConsumer` to fully close the double-expansion bug. That one-line change is handled in `fix/pr38-g-polish`.