### PR TITLE
polish(action,transform,observability,events): misc small fixes

### DIFF
--- a/internal/action/action.go
+++ b/internal/action/action.go
@@ -96,9 +96,18 @@ func BuildConsumersWithRegistry(cfg *config.Config, m *observability.KaptantoMet
 			return nil, err
 		}
 
-		// Step 5: construct webhook consumer
+		// Step 5: construct webhook consumer. Most action types resolve ${VAR}
+		// refs in validateAndResolveParams, so using the resolved-config constructor
+		// avoids a second expansion that corrupts secrets containing '$' (F5).
+		// The "custom" type is the exception: it intentionally passes raw ${VAR}
+		// placeholders through to the sink for late expansion.
 		consumerID := fmt.Sprintf("action:%s:%s", a.Type, a.Name)
-		inner, err := webhooksink.NewWebhookSinkConsumer(consumerID, whCfg)
+		var inner *webhooksink.WebhookSinkConsumer
+		if a.Type == "custom" {
+			inner, err = webhooksink.NewWebhookSinkConsumer(consumerID, whCfg)
+		} else {
+			inner, err = webhooksink.NewResolvedWebhookSinkConsumer(consumerID, whCfg)
+		}
 		if err != nil {
 			return nil, fmt.Errorf("action %q: webhook consumer: %w", a.Name, err)
 		}
@@ -121,9 +130,6 @@ func validateName(name string, seen map[string]struct{}) error {
 	}
 	if !nameRegex.MatchString(name) {
 		return fmt.Errorf("action %q: name must match [a-z0-9-]+ (no uppercase, no ':')", name)
-	}
-	if strings.Contains(name, ":") {
-		return fmt.Errorf("action %q: name must not contain ':'", name)
 	}
 	if _, dup := seen[name]; dup {
 		return fmt.Errorf("action %q: duplicate name", name)
@@ -158,9 +164,10 @@ func validateAndResolveParams(a *config.ActionConfig, t Type) (ResolvedParams, e
 		if ps.Secret {
 			trimmed := strings.TrimSpace(raw)
 			if !envRefRegex.MatchString(trimmed) {
+				example := "${" + strings.ToUpper(strings.ReplaceAll(name, "-", "_")) + "}"
 				return nil, fmt.Errorf(
-					"action %q: param %q is secret and must be an environment variable reference like ${SLACK_WEBHOOK_URL}",
-					a.Name, name)
+					"action %q: param %q is secret and must be an environment variable reference like %s",
+					a.Name, name, example)
 			}
 			// Resolve the env var
 			varName := trimmed[2 : len(trimmed)-1] // extract VAR from ${VAR}
@@ -314,7 +321,9 @@ func (c *matchConsumer) Close() {
 
 // SetMetrics delegates to the inner consumer.
 func (c *matchConsumer) SetMetrics(m *observability.KaptantoMetrics) {
-	type metricsAware interface{ SetMetrics(*observability.KaptantoMetrics) }
+	type metricsAware interface {
+		SetMetrics(*observability.KaptantoMetrics)
+	}
 	if ma, ok := c.inner.(metricsAware); ok {
 		ma.SetMetrics(m)
 	}

--- a/internal/observability/metrics.go
+++ b/internal/observability/metrics.go
@@ -12,23 +12,21 @@ import (
 // Uses a custom registry (not global DefaultRegisterer) to prevent
 // duplicate-registration panics in tests.
 type KaptantoMetrics struct {
-	reg               *prometheus.Registry
-	EventsDelivered   *prometheus.CounterVec   // kaptanto_events_delivered_total{consumer,table,operation}
-	ConsumerLag       *prometheus.GaugeVec     // kaptanto_consumer_lag_events{consumer}
-	ErrorsTotal       *prometheus.CounterVec   // kaptanto_errors_total{consumer,kind}
-	SourceLagBytes    *prometheus.GaugeVec     // kaptanto_source_lag_bytes{source}
-	CheckpointFlushes prometheus.Counter       // kaptanto_checkpoint_flushes_total
-	QueuePublishTotal   *prometheus.CounterVec   // queue_publish_total{sink}
-	QueuePublishErrors  *prometheus.CounterVec   // queue_publish_errors_total{sink}
-	QueuePublishLatency *prometheus.HistogramVec // queue_publish_latency_seconds{sink}
-	DLQEventsTotal         *prometheus.CounterVec // kaptanto_dlq_events_total{consumer}
-	DLQWriteFailuresTotal  *prometheus.CounterVec // kaptanto_dlq_write_failures_total{consumer}
-	DLQFallbackWritesTotal *prometheus.CounterVec // kaptanto_dlq_fallback_writes_total{consumer}
-	DLQSize                prometheus.Gauge       // kaptanto_dlq_size
-	TransformDroppedTotal  *prometheus.CounterVec // kaptanto_transform_dropped_total{consumer}
-	TransformErrorsTotal   *prometheus.CounterVec // kaptanto_transform_errors_total{consumer}
-	ActionEventsMatched    *prometheus.CounterVec // kaptanto_action_events_matched_total{consumer}
-	ActionEventsSkipped    *prometheus.CounterVec // kaptanto_action_events_skipped_total{consumer}
+	reg                   *prometheus.Registry
+	EventsDelivered       *prometheus.CounterVec   // kaptanto_events_delivered_total{consumer,table,operation}
+	ConsumerLag           *prometheus.GaugeVec     // kaptanto_consumer_lag_events{consumer}
+	ErrorsTotal           *prometheus.CounterVec   // kaptanto_errors_total{consumer,kind}
+	SourceLagBytes        *prometheus.GaugeVec     // kaptanto_source_lag_bytes{source}
+	CheckpointFlushes     prometheus.Counter       // kaptanto_checkpoint_flushes_total
+	QueuePublishTotal     *prometheus.CounterVec   // queue_publish_total{sink}
+	QueuePublishErrors    *prometheus.CounterVec   // queue_publish_errors_total{sink}
+	QueuePublishLatency   *prometheus.HistogramVec // queue_publish_latency_seconds{sink}
+	DLQEventsTotal        *prometheus.CounterVec   // kaptanto_dlq_events_total{consumer}
+	DLQWriteFailuresTotal *prometheus.CounterVec   // kaptanto_dlq_write_failures_total{consumer}
+	TransformDroppedTotal *prometheus.CounterVec   // kaptanto_transform_dropped_total{consumer}
+	TransformErrorsTotal  *prometheus.CounterVec   // kaptanto_transform_errors_total{consumer}
+	ActionEventsMatched   *prometheus.CounterVec   // kaptanto_action_events_matched_total{consumer}
+	ActionEventsSkipped   *prometheus.CounterVec   // kaptanto_action_events_skipped_total{consumer}
 }
 
 // NewKaptantoMetrics creates a KaptantoMetrics with a fresh custom Prometheus
@@ -80,14 +78,6 @@ func NewKaptantoMetrics() *KaptantoMetrics {
 			Name: "kaptanto_dlq_write_failures_total",
 			Help: "Total failed writes to the dead-letter queue, labeled by consumer.",
 		}, []string{"consumer"}),
-		DLQFallbackWritesTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: "kaptanto_dlq_fallback_writes_total",
-			Help: "Total DLQ fallback writes (e.g. when primary DLQ storage fails), labeled by consumer.",
-		}, []string{"consumer"}),
-		DLQSize: prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: "kaptanto_dlq_size",
-			Help: "Current number of events in the dead-letter queue.",
-		}),
 		TransformDroppedTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "kaptanto_transform_dropped_total",
 			Help: "Total events dropped by transform filters, labeled by consumer.",
@@ -116,8 +106,6 @@ func NewKaptantoMetrics() *KaptantoMetrics {
 		m.QueuePublishLatency,
 		m.DLQEventsTotal,
 		m.DLQWriteFailuresTotal,
-		m.DLQFallbackWritesTotal,
-		m.DLQSize,
 		m.TransformDroppedTotal,
 		m.TransformErrorsTotal,
 		m.ActionEventsMatched,

--- a/internal/observability/metrics_test.go
+++ b/internal/observability/metrics_test.go
@@ -136,12 +136,6 @@ func TestDLQAndTransformMetrics(t *testing.T) {
 		if m.DLQWriteFailuresTotal == nil {
 			t.Fatal("expected DLQWriteFailuresTotal to be non-nil")
 		}
-		if m.DLQFallbackWritesTotal == nil {
-			t.Fatal("expected DLQFallbackWritesTotal to be non-nil")
-		}
-		if m.DLQSize == nil {
-			t.Fatal("expected DLQSize to be non-nil")
-		}
 		if m.TransformDroppedTotal == nil {
 			t.Fatal("expected TransformDroppedTotal to be non-nil")
 		}
@@ -154,8 +148,6 @@ func TestDLQAndTransformMetrics(t *testing.T) {
 		m := NewKaptantoMetrics()
 		m.DLQEventsTotal.WithLabelValues("consumer-1").Inc()
 		m.DLQWriteFailuresTotal.WithLabelValues("consumer-1").Inc()
-		m.DLQFallbackWritesTotal.WithLabelValues("consumer-1").Inc()
-		m.DLQSize.Set(3)
 		m.TransformDroppedTotal.WithLabelValues("consumer-1").Inc()
 		m.TransformErrorsTotal.WithLabelValues("consumer-1").Inc()
 	})
@@ -164,8 +156,6 @@ func TestDLQAndTransformMetrics(t *testing.T) {
 		m := NewKaptantoMetrics()
 		m.DLQEventsTotal.WithLabelValues("consumer-1").Inc()
 		m.DLQWriteFailuresTotal.WithLabelValues("consumer-1").Inc()
-		m.DLQFallbackWritesTotal.WithLabelValues("consumer-1").Inc()
-		m.DLQSize.Set(7)
 		m.TransformDroppedTotal.WithLabelValues("consumer-1").Inc()
 		m.TransformErrorsTotal.WithLabelValues("consumer-1").Inc()
 
@@ -181,8 +171,6 @@ func TestDLQAndTransformMetrics(t *testing.T) {
 		}{
 			{"kaptanto_dlq_events_total", "Total events written to the dead-letter queue, labeled by consumer."},
 			{"kaptanto_dlq_write_failures_total", "Total failed writes to the dead-letter queue, labeled by consumer."},
-			{"kaptanto_dlq_fallback_writes_total", "Total DLQ fallback writes (e.g. when primary DLQ storage fails), labeled by consumer."},
-			{"kaptanto_dlq_size", "Current number of events in the dead-letter queue."},
 			{"kaptanto_transform_dropped_total", "Total events dropped by transform filters, labeled by consumer."},
 			{"kaptanto_transform_errors_total", "Total transform evaluation errors, labeled by consumer."},
 		}

--- a/internal/transform/jq.go
+++ b/internal/transform/jq.go
@@ -15,7 +15,11 @@ import (
 // defaultJQRuntimeTimeout bounds how long a single jq filter may execute.
 // A context with this timeout is passed to RunWithContext so recursive or
 // non-emitting programs cannot block the router indefinitely.
-const defaultJQRuntimeTimeout = 30 * time.Second
+//
+// NOTE: transforms are trusted code. gojq exposes env/$ENV, so a malicious or
+// careless expression can read process environment (including action secrets).
+// Keep expressions simple and source them from a protected config store.
+const defaultJQRuntimeTimeout = 5 * time.Second
 
 // jqRuntimeTimeoutNs is the mutable runtime bound so tests can exercise
 // cancellation without waiting 30s. Stored as an atomic int64 of nanoseconds

--- a/packages/kaptanto-events/src/client.ts
+++ b/packages/kaptanto-events/src/client.ts
@@ -162,7 +162,6 @@ export class KaptantoStream implements AsyncIterable<ChangeEvent> {
 
       console.warn("KaptantoStream: skipping malformed SSE line", {
         lineLength: line.length,
-        linePrefix: line.slice(0, 20),
       });
     }
 


### PR DESCRIPTION
Source: `.agents/fix-plans/pr38-g-polish.md`

## Problem
- Resolved action secrets were re-expanded by the webhook sink, corrupting values with literal `$` (completes F5 from `fix/pr38-c-webhook-hardening`).
- `DLQFallbackWritesTotal` and `DLQSize` metrics were registered but never updated.
- jq transform timeout defaulted to 30s and lacked a warning that transforms are trusted code with env access.
- The TS SSE client logged the first 20 chars of malformed lines.
- The ACT-02 secret-param error hardcoded ``.
- `validateName\'s `: ` check was redundant after the regex.

## Fix
- Call `NewResolvedWebhookSinkConsumer` for all built-in action types; keep `NewWebhookSinkConsumer` only for the `custom` type.
- Remove dead metrics and their tests.
- Lower default jq timeout to 5s and document env-read risk.
- Log only line length for unrecognized SSE lines.
- Derive the env-ref example from the param name; drop the redundant colon check.

## Validation
- `gofmt -l internal/action internal/observability internal/transform packages/kaptanto-events/src` — clean
- `go build ./...`
- `go test ./internal/action ./internal/transform ./internal/observability -count=1` — all pass (tested with `fix/pr38-c-webhook-hardening` merged locally because this change depends on it)
- `cd packages/kaptanto-events && npm install && npm test` — 30/30 pass

## Residual risk / follow-up
- This branch depends on `fix/pr38-c-webhook-hardening`; merge that PR before this one.