### PR TITLE
fix(ci): clear zizmor cache-poisoning and impostor-commit alerts

### DIFF
--- a/.github/workflows/landing.yml
+++ b/.github/workflows/landing.yml
@@ -2,8 +2,6 @@ name: Landing
 
 on:
   push:
-    tags:
-      - "v*"
     branches:
       - main
     paths:
@@ -39,6 +37,10 @@ jobs:
       # commit ("regenerate package-lock.json to include wrangler
       # dependencies"). CI installs with npm to validate the same dependency
       # graph Cloudflare Pages builds from.
+      #
+      # Tag triggers were removed so this CI-only workflow is not classified as
+      # a release path by zizmor's cache-poisoning audit (deploy is Cloudflare
+      # Pages, not this job). See https://docs.zizmor.sh/audits/#cache-poisoning
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "20"

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -35,7 +35,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable (2026-06-30)
+      # Pin to a commit on dtolnay/rust-toolchain's master history (not a
+      # floating "toolchain: stable" tip). Those tip SHAs diverge from master
+      # and trip zizmor's impostor-commit audit even though they live in-repo.
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master (2026-08-05)
         with:
           toolchain: stable
 
@@ -69,7 +72,7 @@ jobs:
           go-version-file: go.mod
           cache: true
 
-      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable (2026-06-30)
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master (2026-08-05)
         with:
           toolchain: stable
 


### PR DESCRIPTION
## Summary
- Clears code-scanning alerts #33/#34 (`zizmor/impostor-commit` on `dtolnay/rust-toolchain` floating toolchain tips) and #35 (`zizmor/cache-poisoning` on landing `setup-node` cache).
- Pin `dtolnay/rust-toolchain` to a commit on `master` history and pass `toolchain: stable` as input.
- Remove unused `v*` tag triggers from landing CI (deploy is Cloudflare Pages, not this workflow) so npm caching is allowed.

## Test plan
- [x] Local `zizmor` (online) reports no findings on the two workflows
- [ ] CI zizmor workflow green
- [ ] Alerts #33/#34/#35 auto-close after merge to main

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Review findings

No blocking correctness, security, or data-safety issues found.

The changes are limited to CI workflow configuration:

- Removes unused version-tag triggers from `landing.yml`.
- Pins `dtolnay/rust-toolchain` to a commit on the `master` history.
- Passes `toolchain: stable` explicitly.
- Addresses zizmor alerts for impostor commits and cache poisoning.

Residual risk remains until CI validation completes. Confirm that zizmor reports no findings in CI and that the expected alerts close automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->