### PR TITLE
fix: parse quoted Postgres identifiers for backfill

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -52,6 +52,29 @@ linters:
             - pkg: github.com/olucasandrade/kaptanto/internal/cmd
               desc: "internal/event is a leaf; it must not depend on other internal packages"
 
+        # internal/pgident is a leaf like event: pure Postgres identifier
+        # parsing/quoting; it must not import any other internal package.
+        pgident-leaf:
+          files:
+            - "**/internal/pgident/**"
+          deny:
+            - pkg: github.com/olucasandrade/kaptanto/internal/eventlog
+              desc: "internal/pgident is a leaf; it must not depend on other internal packages"
+            - pkg: github.com/olucasandrade/kaptanto/internal/parser
+              desc: "internal/pgident is a leaf; it must not depend on other internal packages"
+            - pkg: github.com/olucasandrade/kaptanto/internal/backfill
+              desc: "internal/pgident is a leaf; it must not depend on other internal packages"
+            - pkg: github.com/olucasandrade/kaptanto/internal/checkpoint
+              desc: "internal/pgident is a leaf; it must not depend on other internal packages"
+            - pkg: github.com/olucasandrade/kaptanto/internal/source
+              desc: "internal/pgident is a leaf; it must not depend on other internal packages"
+            - pkg: github.com/olucasandrade/kaptanto/internal/output
+              desc: "internal/pgident is a leaf; it must not depend on other internal packages"
+            - pkg: github.com/olucasandrade/kaptanto/internal/router
+              desc: "internal/pgident is a leaf; it must not depend on other internal packages"
+            - pkg: github.com/olucasandrade/kaptanto/internal/cmd
+              desc: "internal/pgident is a leaf; it must not depend on other internal packages"
+
         # eventlog and parser sit just above event: they may use event (and
         # observability) but must not reach into higher layers.
         low-layer:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,51 +29,17 @@ linters:
       # by the offending upper-layer package prefixes (prefix match covers
       # sub-packages, e.g. internal/source also matches internal/source/postgres).
       rules:
-        # internal/event is a pure domain leaf: it must not import any other
-        # internal package.
-        event-leaf:
+        # internal/event and internal/pgident are pure domain leaves: they must
+        # not import any other internal package (including each other). A single
+        # deny on the module-internal prefix keeps both lists synchronized and
+        # covers future internal packages.
+        leaf-packages:
           files:
             - "**/internal/event/**"
-          deny:
-            - pkg: github.com/olucasandrade/kaptanto/internal/eventlog
-              desc: "internal/event is a leaf; it must not depend on other internal packages"
-            - pkg: github.com/olucasandrade/kaptanto/internal/parser
-              desc: "internal/event is a leaf; it must not depend on other internal packages"
-            - pkg: github.com/olucasandrade/kaptanto/internal/backfill
-              desc: "internal/event is a leaf; it must not depend on other internal packages"
-            - pkg: github.com/olucasandrade/kaptanto/internal/checkpoint
-              desc: "internal/event is a leaf; it must not depend on other internal packages"
-            - pkg: github.com/olucasandrade/kaptanto/internal/source
-              desc: "internal/event is a leaf; it must not depend on other internal packages"
-            - pkg: github.com/olucasandrade/kaptanto/internal/output
-              desc: "internal/event is a leaf; it must not depend on other internal packages"
-            - pkg: github.com/olucasandrade/kaptanto/internal/router
-              desc: "internal/event is a leaf; it must not depend on other internal packages"
-            - pkg: github.com/olucasandrade/kaptanto/internal/cmd
-              desc: "internal/event is a leaf; it must not depend on other internal packages"
-
-        # internal/pgident is a leaf like event: pure Postgres identifier
-        # parsing/quoting; it must not import any other internal package.
-        pgident-leaf:
-          files:
             - "**/internal/pgident/**"
           deny:
-            - pkg: github.com/olucasandrade/kaptanto/internal/eventlog
-              desc: "internal/pgident is a leaf; it must not depend on other internal packages"
-            - pkg: github.com/olucasandrade/kaptanto/internal/parser
-              desc: "internal/pgident is a leaf; it must not depend on other internal packages"
-            - pkg: github.com/olucasandrade/kaptanto/internal/backfill
-              desc: "internal/pgident is a leaf; it must not depend on other internal packages"
-            - pkg: github.com/olucasandrade/kaptanto/internal/checkpoint
-              desc: "internal/pgident is a leaf; it must not depend on other internal packages"
-            - pkg: github.com/olucasandrade/kaptanto/internal/source
-              desc: "internal/pgident is a leaf; it must not depend on other internal packages"
-            - pkg: github.com/olucasandrade/kaptanto/internal/output
-              desc: "internal/pgident is a leaf; it must not depend on other internal packages"
-            - pkg: github.com/olucasandrade/kaptanto/internal/router
-              desc: "internal/pgident is a leaf; it must not depend on other internal packages"
-            - pkg: github.com/olucasandrade/kaptanto/internal/cmd
-              desc: "internal/pgident is a leaf; it must not depend on other internal packages"
+            - pkg: github.com/olucasandrade/kaptanto/internal
+              desc: "leaf packages must not import any other internal package"
 
         # eventlog and parser sit just above event: they may use event (and
         # observability) but must not reach into higher layers.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,7 @@ The repository is a monorepo that also contains:
 │   ├── parser/
 │   │   ├── mongodb/       # MongoDB change stream normalizer
 │   │   └── pgoutput/      # Postgres pgoutput parser (+ optional Rust FFI)
+│   ├── pgident/           # Postgres schema/table identifier parsing + safe quoting (leaf)
 │   ├── pk/                # Primary-key extraction utilities
 │   ├── redact/            # Secret redaction helpers
 │   ├── router/            # Fan-out, per-key ordering, retries, cursor advance
@@ -240,10 +241,10 @@ The codebase uses three-letter invariant codes (`CHK-01`, `RTR-04`, `BKF-02`, et
 ### Dependency layers (enforced by `depguard` in `.golangci.yml`)
 
 ```
-event  <  eventlog / parser  <  backfill / checkpoint  <  source / output / router  <  cmd
+event / pgident  <  eventlog / parser  <  backfill / checkpoint  <  source / output / router  <  cmd
 ```
 
-Lower layers must never import upper layers. `internal/event` is a pure domain leaf and must not import any other `internal/` package.
+Lower layers must never import upper layers. `internal/event` is a pure domain leaf and must not import any other `internal/` package. `internal/pgident` is also a leaf (Postgres identifier parsing/quoting) and likewise must not import any other `internal/` package.
 
 ### Complexity
 

--- a/internal/cmd/filters.go
+++ b/internal/cmd/filters.go
@@ -2,11 +2,11 @@ package cmd
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/olucasandrade/kaptanto/internal/backfill"
 	"github.com/olucasandrade/kaptanto/internal/config"
 	"github.com/olucasandrade/kaptanto/internal/output"
+	"github.com/olucasandrade/kaptanto/internal/pgident"
 )
 
 func buildTableFilters(tables map[string]config.TableConfig) (
@@ -37,16 +37,20 @@ func buildTableFilters(tables map[string]config.TableConfig) (
 // (see discoverPrimaryKeys) — this function does no discovery itself and
 // trusts the caller; production wiring in runPipeline fails fast before
 // calling this if discovery found a table with no primary key.
+//
+// Table keys are parsed with pgident so quoted mixed-case names
+// (e.g. public."CamelCaseTable") become raw catalog components before
+// KeysetCursor re-quotes them for SQL.
 func buildBackfillConfigs(
 	tables map[string]config.TableConfig,
 	sourceID string,
 	pkCols map[string][]string,
-) []backfill.BackfillConfig {
+) ([]backfill.BackfillConfig, error) {
 	configs := make([]backfill.BackfillConfig, 0, len(tables))
 	for tableKey := range tables {
-		schema, table := "", tableKey
-		if parts := strings.SplitN(tableKey, ".", 2); len(parts) == 2 {
-			schema, table = parts[0], parts[1]
+		schema, table, err := pgident.Parse(tableKey)
+		if err != nil {
+			return nil, fmt.Errorf("table %q: %w", tableKey, err)
 		}
 		configs = append(configs, backfill.BackfillConfig{
 			SourceID:      sourceID,
@@ -57,5 +61,5 @@ func buildBackfillConfigs(
 			NumPartitions: numEventLogPartitions,
 		})
 	}
-	return configs
+	return configs, nil
 }

--- a/internal/cmd/pk_discovery.go
+++ b/internal/cmd/pk_discovery.go
@@ -75,15 +75,23 @@ func discoverPrimaryKey(ctx context.Context, q pkQuerier, tableIdentity string) 
 //
 // Every key is validated with pgident.Parse before any catalog query runs, so
 // a malformed reference surfaces the identifier error here instead of an
-// opaque ::regclass failure inside Postgres. The query itself still binds the
-// raw key as $1::regclass, preserving schema qualification and search_path
-// resolution for both quoted and unqualified names.
+// opaque ::regclass failure inside Postgres. Validation is done in a first
+// pass so no query is issued while any configured key is malformed. The
+// discovery query itself still binds the raw key as $1::regclass, preserving
+// schema qualification and search_path resolution for both quoted and
+// unqualified names.
 func discoverPrimaryKeys(ctx context.Context, q pkQuerier, tables map[string]config.TableConfig) (map[string][]string, error) {
-	result := make(map[string][]string, len(tables))
+	// First pass: validate every configured identifier. Map iteration order is
+	// random; this guarantees we never run a catalog query before we know all
+	// keys are well-formed.
 	for tableKey := range tables {
 		if _, _, err := pgident.Parse(tableKey); err != nil {
 			return nil, fmt.Errorf("table %q: %w", tableKey, err)
 		}
+	}
+
+	result := make(map[string][]string, len(tables))
+	for tableKey := range tables {
 		cols, err := discoverPrimaryKey(ctx, q, tableKey)
 		if err != nil {
 			return nil, fmt.Errorf("discover primary key for table %q: %w", tableKey, err)

--- a/internal/cmd/pk_discovery.go
+++ b/internal/cmd/pk_discovery.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 	"github.com/olucasandrade/kaptanto/internal/config"
+	"github.com/olucasandrade/kaptanto/internal/pgident"
 )
 
 // pkDiscoveryQuery returns the ordered primary-key column names for a table.
@@ -71,9 +72,18 @@ func discoverPrimaryKey(ctx context.Context, q pkQuerier, tableIdentity string) 
 // WAL-derived key without one, so a table silently falling back to a guessed
 // key would double-deliver or drop rows without any visible symptom. A
 // clear startup error is safer than that.
+//
+// Every key is validated with pgident.Parse before any catalog query runs, so
+// a malformed reference surfaces the identifier error here instead of an
+// opaque ::regclass failure inside Postgres. The query itself still binds the
+// raw key as $1::regclass, preserving schema qualification and search_path
+// resolution for both quoted and unqualified names.
 func discoverPrimaryKeys(ctx context.Context, q pkQuerier, tables map[string]config.TableConfig) (map[string][]string, error) {
 	result := make(map[string][]string, len(tables))
 	for tableKey := range tables {
+		if _, _, err := pgident.Parse(tableKey); err != nil {
+			return nil, fmt.Errorf("table %q: %w", tableKey, err)
+		}
 		cols, err := discoverPrimaryKey(ctx, q, tableKey)
 		if err != nil {
 			return nil, fmt.Errorf("discover primary key for table %q: %w", tableKey, err)

--- a/internal/cmd/pk_discovery_test.go
+++ b/internal/cmd/pk_discovery_test.go
@@ -181,4 +181,15 @@ func TestDiscoverPrimaryKeys(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "public.ghost")
 	})
+
+	t.Run("malformed identifier errors before any catalog query", func(t *testing.T) {
+		q := &fakeQuerier{}
+		tables := map[string]config.TableConfig{
+			`public."unclosed`: {},
+		}
+		_, err := discoverPrimaryKeys(context.Background(), q, tables)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unclosed quote")
+		assert.Empty(t, q.calls, "no ::regclass query must run for a malformed key")
+	})
 }

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -542,7 +542,10 @@ func runPipeline(ctx context.Context, cfg *config.Config) error {
 		}
 	}
 
-	bkConfigs := buildBackfillConfigs(cfg.Tables, connCfg.SourceID, bkPKCols)
+	bkConfigs, err := buildBackfillConfigs(cfg.Tables, connCfg.SourceID, bkPKCols)
+	if err != nil {
+		return fmt.Errorf("backfill: %w", err)
+	}
 	openConnFn := func(ctx context.Context) (backfill.SnapshotConn, error) {
 		return pgx.Connect(ctx, cfg.Source)
 	}

--- a/internal/cmd/root_backfill_test.go
+++ b/internal/cmd/root_backfill_test.go
@@ -100,7 +100,7 @@ func TestBuildBackfillConfigs(t *testing.T) {
 	})
 
 	t.Run("quoted mixed-case table strips quotes for raw catalog names", func(t *testing.T) {
-		// Issue #56: config keys like public."CamelCaseTable" must become
+		// Quoted config keys like public."CamelCaseTable" must become
 		// Schema=public, Table=CamelCaseTable (no quote characters) so
 		// KeysetCursor.Sanitize produces "public"."CamelCaseTable".
 		tables := map[string]config.TableConfig{

--- a/internal/cmd/root_backfill_test.go
+++ b/internal/cmd/root_backfill_test.go
@@ -24,7 +24,8 @@ import (
 // called by runPipeline before this); it just trusts the pkCols map passed in.
 func TestBuildBackfillConfigs(t *testing.T) {
 	t.Run("nil tables returns empty slice without panic", func(t *testing.T) {
-		result := buildBackfillConfigs(nil, "default", nil)
+		result, err := buildBackfillConfigs(nil, "default", nil)
+		require.NoError(t, err)
 		require.NotNil(t, result)
 		assert.Empty(t, result)
 	})
@@ -34,7 +35,8 @@ func TestBuildBackfillConfigs(t *testing.T) {
 			"public.orders": {},
 		}
 		pkCols := map[string][]string{"public.orders": {"order_id"}}
-		result := buildBackfillConfigs(tables, "default", pkCols)
+		result, err := buildBackfillConfigs(tables, "default", pkCols)
+		require.NoError(t, err)
 		require.Len(t, result, 1)
 		cfg := result[0]
 		assert.Equal(t, "default", cfg.SourceID)
@@ -50,7 +52,8 @@ func TestBuildBackfillConfigs(t *testing.T) {
 			"public.order_items": {},
 		}
 		pkCols := map[string][]string{"public.order_items": {"order_id", "line_no"}}
-		result := buildBackfillConfigs(tables, "default", pkCols)
+		result, err := buildBackfillConfigs(tables, "default", pkCols)
+		require.NoError(t, err)
 		require.Len(t, result, 1)
 		assert.Equal(t, []string{"order_id", "line_no"}, result[0].PKCols)
 	})
@@ -60,7 +63,8 @@ func TestBuildBackfillConfigs(t *testing.T) {
 			"orders": {},
 		}
 		pkCols := map[string][]string{"orders": {"id"}}
-		result := buildBackfillConfigs(tables, "default", pkCols)
+		result, err := buildBackfillConfigs(tables, "default", pkCols)
+		require.NoError(t, err)
 		require.Len(t, result, 1)
 		cfg := result[0]
 		assert.Equal(t, "", cfg.Schema)
@@ -75,7 +79,8 @@ func TestBuildBackfillConfigs(t *testing.T) {
 		tables := map[string]config.TableConfig{
 			"public.orders": {},
 		}
-		result := buildBackfillConfigs(tables, "default", nil)
+		result, err := buildBackfillConfigs(tables, "default", nil)
+		require.NoError(t, err)
 		require.Len(t, result, 1)
 		assert.Nil(t, result[0].PKCols)
 	})
@@ -89,8 +94,35 @@ func TestBuildBackfillConfigs(t *testing.T) {
 			"public.orders": {"id"},
 			"public.users":  {"id"},
 		}
-		result := buildBackfillConfigs(tables, "default", pkCols)
+		result, err := buildBackfillConfigs(tables, "default", pkCols)
+		require.NoError(t, err)
 		assert.Len(t, result, 2)
+	})
+
+	t.Run("quoted mixed-case table strips quotes for raw catalog names", func(t *testing.T) {
+		// Issue #56: config keys like public."CamelCaseTable" must become
+		// Schema=public, Table=CamelCaseTable (no quote characters) so
+		// KeysetCursor.Sanitize produces "public"."CamelCaseTable".
+		tables := map[string]config.TableConfig{
+			`public."CamelCaseTable"`: {},
+		}
+		pkCols := map[string][]string{`public."CamelCaseTable"`: {"id"}}
+		result, err := buildBackfillConfigs(tables, "default", pkCols)
+		require.NoError(t, err)
+		require.Len(t, result, 1)
+		assert.Equal(t, "public", result[0].Schema)
+		assert.Equal(t, "CamelCaseTable", result[0].Table)
+		assert.NotContains(t, result[0].Table, `"`)
+		assert.Equal(t, []string{"id"}, result[0].PKCols)
+	})
+
+	t.Run("malformed quoted table returns error", func(t *testing.T) {
+		tables := map[string]config.TableConfig{
+			`public."unclosed`: {},
+		}
+		_, err := buildBackfillConfigs(tables, "default", nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unclosed quote")
 	})
 }
 

--- a/internal/pgident/ident.go
+++ b/internal/pgident/ident.go
@@ -31,6 +31,9 @@ func Parse(ref string) (schema, table string, err error) {
 	}
 	switch len(parts) {
 	case 1:
+		if parts[0] == "" {
+			return "", "", fmt.Errorf("pgident: empty identifier in %q", ref)
+		}
 		return "", parts[0], nil
 	case 2:
 		if parts[0] == "" || parts[1] == "" {

--- a/internal/pgident/ident.go
+++ b/internal/pgident/ident.go
@@ -1,0 +1,121 @@
+// Package pgident parses and safely quotes PostgreSQL schema/table identifiers.
+//
+// Config keys may be written in SQL form (e.g. public."CamelCaseTable"). Callers
+// that need raw catalog names must Parse first; callers that build SQL must
+// Qualify raw names with pgx.Identifier.Sanitize — never Sanitize a string that
+// already contains quote characters.
+package pgident
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// Parse splits a Postgres table reference into raw schema and table names.
+// It understands unquoted identifiers, double-quoted identifiers (including
+// "" escapes and dots inside quotes), and schema.table qualification.
+//
+// Unqualified references return an empty schema; callers apply their own
+// default (e.g. "public" for catalog lookups).
+func Parse(ref string) (schema, table string, err error) {
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		return "", "", fmt.Errorf("pgident: empty table reference")
+	}
+
+	parts, err := splitQualified(ref)
+	if err != nil {
+		return "", "", err
+	}
+	switch len(parts) {
+	case 1:
+		return "", parts[0], nil
+	case 2:
+		if parts[0] == "" || parts[1] == "" {
+			return "", "", fmt.Errorf("pgident: empty identifier in %q", ref)
+		}
+		return parts[0], parts[1], nil
+	default:
+		return "", "", fmt.Errorf("pgident: too many dotted components in %q (use quotes for names containing dots)", ref)
+	}
+}
+
+// Qualify returns a safely quoted schema.table (or just table when schema is
+// empty) suitable for interpolating into SQL.
+func Qualify(schema, table string) string {
+	if schema != "" {
+		return pgx.Identifier{schema, table}.Sanitize()
+	}
+	return pgx.Identifier{table}.Sanitize()
+}
+
+// splitQualified tokenizes a Postgres-style dotted identifier list, respecting
+// double-quoted segments so dots inside quotes do not split components.
+func splitQualified(ref string) ([]string, error) {
+	var parts []string
+	i := 0
+	for i < len(ref) {
+		part, next, err := readIdent(ref, i)
+		if err != nil {
+			return nil, err
+		}
+		parts = append(parts, part)
+		i = next
+		if i >= len(ref) {
+			break
+		}
+		if ref[i] != '.' {
+			return nil, fmt.Errorf("pgident: unexpected character %q in %q", ref[i], ref)
+		}
+		i++ // skip dot
+		if i >= len(ref) {
+			return nil, fmt.Errorf("pgident: trailing dot in %q", ref)
+		}
+	}
+	return parts, nil
+}
+
+// readIdent reads one identifier starting at i. Quoted identifiers keep their
+// exact contents (with "" → "); unquoted identifiers are taken literally up to
+// the next dot (Postgres folds unquoted names to lowercase at parse time in
+// SQL, but config keys are already the intended catalog spelling).
+func readIdent(ref string, i int) (name string, next int, err error) {
+	if ref[i] == '"' {
+		return readQuoted(ref, i)
+	}
+	start := i
+	for i < len(ref) && ref[i] != '.' {
+		if ref[i] == '"' {
+			return "", 0, fmt.Errorf("pgident: quote mid-identifier in %q", ref)
+		}
+		i++
+	}
+	name = ref[start:i]
+	if name == "" {
+		return "", 0, fmt.Errorf("pgident: empty identifier in %q", ref)
+	}
+	return name, i, nil
+}
+
+func readQuoted(ref string, i int) (name string, next int, err error) {
+	// Opening quote at i.
+	i++
+	var b strings.Builder
+	for i < len(ref) {
+		if ref[i] != '"' {
+			b.WriteByte(ref[i])
+			i++
+			continue
+		}
+		// Closing quote, or "" escape.
+		if i+1 < len(ref) && ref[i+1] == '"' {
+			b.WriteByte('"')
+			i += 2
+			continue
+		}
+		return b.String(), i + 1, nil
+	}
+	return "", 0, fmt.Errorf("pgident: unclosed quote in %q", ref)
+}

--- a/internal/pgident/ident_test.go
+++ b/internal/pgident/ident_test.go
@@ -69,6 +69,21 @@ func TestParse(t *testing.T) {
 			wantErr: "empty table reference",
 		},
 		{
+			name:    "empty quoted identifier",
+			ref:     `""`,
+			wantErr: "empty identifier",
+		},
+		{
+			name:    "empty quoted schema component",
+			ref:     `"".orders`,
+			wantErr: "empty identifier",
+		},
+		{
+			name:    "empty quoted table component",
+			ref:     `public.""`,
+			wantErr: "empty identifier",
+		},
+		{
 			name:    "unclosed quote",
 			ref:     `public."CamelCase`,
 			wantErr: "unclosed quote",

--- a/internal/pgident/ident_test.go
+++ b/internal/pgident/ident_test.go
@@ -1,0 +1,118 @@
+package pgident
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParse(t *testing.T) {
+	tests := []struct {
+		name       string
+		ref        string
+		wantSchema string
+		wantTable  string
+		wantErr    string
+	}{
+		{
+			name:       "lowercase schema-qualified",
+			ref:        "public.orders",
+			wantSchema: "public",
+			wantTable:  "orders",
+		},
+		{
+			name:       "unqualified",
+			ref:        "orders",
+			wantSchema: "",
+			wantTable:  "orders",
+		},
+		{
+			name:       "mixed-case quoted table",
+			ref:        `public."CamelCaseTable"`,
+			wantSchema: "public",
+			wantTable:  "CamelCaseTable",
+		},
+		{
+			name:       "quoted unqualified",
+			ref:        `"CamelCaseTable"`,
+			wantSchema: "",
+			wantTable:  "CamelCaseTable",
+		},
+		{
+			name:       "both quoted mixed-case",
+			ref:        `"Sales"."Orders"`,
+			wantSchema: "Sales",
+			wantTable:  "Orders",
+		},
+		{
+			name:       "dot inside quoted table",
+			ref:        `public."weird.table"`,
+			wantSchema: "public",
+			wantTable:  "weird.table",
+		},
+		{
+			name:       "escaped quote inside identifier",
+			ref:        `public."say""hello"`,
+			wantSchema: "public",
+			wantTable:  `say"hello`,
+		},
+		{
+			name:       "whitespace trimmed",
+			ref:        `  public."CamelCaseTable"  `,
+			wantSchema: "public",
+			wantTable:  "CamelCaseTable",
+		},
+		{
+			name:    "empty",
+			ref:     "",
+			wantErr: "empty table reference",
+		},
+		{
+			name:    "unclosed quote",
+			ref:     `public."CamelCase`,
+			wantErr: "unclosed quote",
+		},
+		{
+			name:    "trailing dot",
+			ref:     "public.",
+			wantErr: "trailing dot",
+		},
+		{
+			name:    "too many components without quotes",
+			ref:     "a.b.c",
+			wantErr: "too many dotted components",
+		},
+		{
+			name:    "quote mid unquoted ident",
+			ref:     `pub"lic.orders`,
+			wantErr: "quote mid-identifier",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			schema, table, err := Parse(tt.ref)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantSchema, schema)
+			assert.Equal(t, tt.wantTable, table)
+		})
+	}
+}
+
+func TestQualify(t *testing.T) {
+	assert.Equal(t, `"public"."CamelCaseTable"`, Qualify("public", "CamelCaseTable"))
+	assert.Equal(t, `"Orders"`, Qualify("", "Orders"))
+	assert.Equal(t, `"Sales"."Orders"`, Qualify("Sales", "Orders"))
+
+	// Round-trip: Parse then Qualify must not triple-quote.
+	schema, table, err := Parse(`public."CamelCaseTable"`)
+	require.NoError(t, err)
+	assert.Equal(t, `"public"."CamelCaseTable"`, Qualify(schema, table))
+	assert.NotContains(t, Qualify(schema, table), `"""`)
+}

--- a/internal/source/postgres/connector.go
+++ b/internal/source/postgres/connector.go
@@ -352,7 +352,10 @@ func (c *PostgresConnector) connectAndStream(ctx context.Context, wasEverConnect
 
 	// 4. Check REPLICA IDENTITY for each configured table (SRC-08).
 	for _, t := range c.cfg.Tables {
-		schema, table := splitSchemaTable(t)
+		schema, table, splitErr := splitSchemaTable(t)
+		if splitErr != nil {
+			return fmt.Errorf("postgres: invalid table %q: %w", t, splitErr)
+		}
 		if err := checkReplicaIdentity(ctx, queryConn, schema, table); err != nil {
 			return err
 		}

--- a/internal/source/postgres/publication.go
+++ b/internal/source/postgres/publication.go
@@ -11,6 +11,7 @@ import (
 	"github.com/jackc/pglogrepl"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/olucasandrade/kaptanto/internal/pgident"
 )
 
 // pubQuerier is the minimal surface ensurePublication needs from a Postgres
@@ -56,9 +57,20 @@ func ensurePublication(ctx context.Context, conn pubQuerier, pubName string, tab
 		}
 		createSQL = fmt.Sprintf("CREATE PUBLICATION %s FOR ALL TABLES", pgx.Identifier{pubName}.Sanitize())
 	} else {
+		qualified := make([]string, 0, len(tables))
+		for _, t := range tables {
+			schema, table, parseErr := pgident.Parse(t)
+			if parseErr != nil {
+				return fmt.Errorf("postgres: invalid table %q for publication: %w", t, parseErr)
+			}
+			if schema == "" {
+				schema = "public"
+			}
+			qualified = append(qualified, pgident.Qualify(schema, table))
+		}
 		createSQL = fmt.Sprintf("CREATE PUBLICATION %s FOR TABLE %s",
 			pgx.Identifier{pubName}.Sanitize(),
-			strings.Join(tables, ", "),
+			strings.Join(qualified, ", "),
 		)
 	}
 

--- a/internal/source/postgres/publication_test.go
+++ b/internal/source/postgres/publication_test.go
@@ -99,7 +99,7 @@ func TestEnsurePublication_WithTables_CreatesForTable(t *testing.T) {
 	assert.Contains(t, conn.execSQL, `"public"."users"`)
 }
 
-// TestEnsurePublication_QuotedMixedCaseTable verifies issue #56: a config key
+// TestEnsurePublication_QuotedMixedCaseTable verifies that a quoted config key
 // like public."CamelCaseTable" must produce a single-quoted identifier pair,
 // never the triple-quoted "public"."""CamelCaseTable""".
 func TestEnsurePublication_QuotedMixedCaseTable(t *testing.T) {

--- a/internal/source/postgres/publication_test.go
+++ b/internal/source/postgres/publication_test.go
@@ -86,7 +86,7 @@ func TestEnsurePublication_EmptyTablesAllowAllTablesFalse(t *testing.T) {
 
 // TestEnsurePublication_WithTables_CreatesForTable verifies that a non-empty
 // tables slice produces "CREATE PUBLICATION ... FOR TABLE t1, t2" with the
-// publication name sanitized as a quoted identifier.
+// publication name and table identifiers sanitized as quoted identifiers.
 func TestEnsurePublication_WithTables_CreatesForTable(t *testing.T) {
 	conn := &fakePubConn{existCount: 0}
 
@@ -95,8 +95,22 @@ func TestEnsurePublication_WithTables_CreatesForTable(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, conn.execCalled, "Exec must be called to create the publication")
 	assert.Contains(t, conn.execSQL, `CREATE PUBLICATION "kaptanto_pub" FOR TABLE`)
-	assert.Contains(t, conn.execSQL, "public.orders")
-	assert.Contains(t, conn.execSQL, "public.users")
+	assert.Contains(t, conn.execSQL, `"public"."orders"`)
+	assert.Contains(t, conn.execSQL, `"public"."users"`)
+}
+
+// TestEnsurePublication_QuotedMixedCaseTable verifies issue #56: a config key
+// like public."CamelCaseTable" must produce a single-quoted identifier pair,
+// never the triple-quoted "public"."""CamelCaseTable""".
+func TestEnsurePublication_QuotedMixedCaseTable(t *testing.T) {
+	conn := &fakePubConn{existCount: 0}
+
+	err := ensurePublication(context.Background(), conn, "kaptanto_pub", []string{`public."CamelCaseTable"`}, false)
+
+	require.NoError(t, err)
+	require.True(t, conn.execCalled)
+	assert.Contains(t, conn.execSQL, `"public"."CamelCaseTable"`)
+	assert.NotContains(t, conn.execSQL, `"""`)
 }
 
 // TestEnsurePublication_AllowAllTablesTrue_CreatesForAllTables verifies the

--- a/internal/source/postgres/validation.go
+++ b/internal/source/postgres/validation.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 	"github.com/olucasandrade/kaptanto/internal/observability"
+	"github.com/olucasandrade/kaptanto/internal/pgident"
 )
 
 // checkReplicaIdentity queries pg_class to find the REPLICA IDENTITY setting
@@ -70,14 +71,17 @@ func checkWALLag(ctx context.Context, conn *pgx.Conn, thresholdBytes int64, sour
 }
 
 // splitSchemaTable splits a "schema.table" string into its two parts.
-// If no dot is present, schema defaults to "public".
-func splitSchemaTable(schemaTable string) (schema, table string) {
-	for i := 0; i < len(schemaTable); i++ {
-		if schemaTable[i] == '.' {
-			return schemaTable[:i], schemaTable[i+1:]
-		}
+// Quoted identifiers (e.g. public."CamelCaseTable") are parsed into raw
+// catalog names. If no schema is present, schema defaults to "public".
+func splitSchemaTable(schemaTable string) (schema, table string, err error) {
+	schema, table, err = pgident.Parse(schemaTable)
+	if err != nil {
+		return "", "", err
 	}
-	return "public", schemaTable
+	if schema == "" {
+		schema = "public"
+	}
+	return schema, table, nil
 }
 
 // checkPrimary runs SELECT pg_is_in_recovery() and returns an error if the

--- a/internal/source/postgres/validation_test.go
+++ b/internal/source/postgres/validation_test.go
@@ -1,0 +1,63 @@
+package postgres
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSplitSchemaTable(t *testing.T) {
+	tests := []struct {
+		name       string
+		in         string
+		wantSchema string
+		wantTable  string
+		wantErr    string
+	}{
+		{
+			name:       "schema-qualified lowercase",
+			in:         "public.orders",
+			wantSchema: "public",
+			wantTable:  "orders",
+		},
+		{
+			name:       "unqualified defaults to public",
+			in:         "orders",
+			wantSchema: "public",
+			wantTable:  "orders",
+		},
+		{
+			name:       "quoted mixed-case strips quotes",
+			in:         `public."CamelCaseTable"`,
+			wantSchema: "public",
+			wantTable:  "CamelCaseTable",
+		},
+		{
+			name:       "quoted unqualified defaults to public",
+			in:         `"CamelCaseTable"`,
+			wantSchema: "public",
+			wantTable:  "CamelCaseTable",
+		},
+		{
+			name:    "unclosed quote",
+			in:      `public."Camel`,
+			wantErr: "unclosed quote",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			schema, table, err := splitSchemaTable(tt.in)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantSchema, schema)
+			assert.Equal(t, tt.wantTable, table)
+			assert.NotContains(t, table, `"`)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Quoted mixed-case Postgres table keys (e.g. Prisma `public."CamelCaseTable"`) were split with `SplitN` and then re-quoted by `pgx.Identifier.Sanitize`, producing `"public"."""CamelCaseTable"""` and breaking initial backfill while publication/WAL still worked.
- Adds leaf package `internal/pgident` (`Parse` / `Qualify`) and wires it into `buildBackfillConfigs`, `splitSchemaTable`, and `ensurePublication` so SQL is built from raw catalog names.
- Malformed quoted identifiers now fail at startup instead of silently targeting the wrong relation.

Closes #56

## Test plan
- [x] `go test ./internal/pgident ./internal/cmd ./internal/source/postgres ./internal/backfill -count=1`
- [x] Manual: create `public."CamelCaseTable"`, configure `tables: {'public."CamelCaseTable"': {}}`, start with empty `data-dir`, confirm snapshot succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Review findings

No blocking correctness or security issues are evident from the supplied changes.

The shared `pgident.Parse` and `pgident.Qualify` flow addresses double-quoting and malformed identifier handling across backfill configuration, publication setup, and schema/table validation. The focused tests cover quoted mixed-case names, escaped quotes, embedded dots, qualification, and malformed input.

Residual risk: the supplied summary does not show integration coverage for primary-key discovery, replica-identity validation, WAL relation handling, or the complete initial snapshot/live-WAL handoff. Verify those paths with quoted mixed-case tables before merge.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->