### PR TITLE
chore: harden lint rules to catch dead code and redundant guards

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,7 +2,10 @@
 #
 # This umbrella owns the deeper CI gates:
 #   - Standard suite (errcheck, govet, ineffassign, staticcheck, unused)
-#   - Cyclomatic complexity (#6)         -> gocyclo
+#   - Dead-code / redundant-guard cleanup  -> govet(nilness,unreachable),
+#                                             wastedassign, unparam, gocritic
+#   - Standard-library constants           -> usestdlibvars
+#   - Cyclomatic complexity (#6)           -> gocyclo
 #   - Dependency-structure validation (#4) -> depguard (layered import rules)
 version: "2"
 
@@ -14,8 +17,19 @@ linters:
   enable:
     - gocyclo
     - depguard
+    - wastedassign
+    - unparam
+    - gocritic
+    - usestdlibvars
 
   settings:
+    govet:
+      # Standard govet already covers many suspicious constructs; these passes
+      # catch the dead nil re-checks and unreachable code we recently removed.
+      enable:
+        - nilness
+        - unreachable
+
     gocyclo:
       # runPipeline (48) and tokenize (36) are //nolint:gocyclo-exempted with a
       # refactor note; receiveLoop and snapshotTable (30) are too. The gate is
@@ -105,11 +119,16 @@ linters:
   exclusions:
     generated: lax
     rules:
-      # Tests are allowed to be long/branchy and to cross layers freely.
+      # Tests are allowed to be long/branchy and to cross layers freely. They are
+    # also excluded from style / parameter / constant linters whose findings are
+    # overwhelmingly test-idiomatic rather than production slop.
       - path: _test\.go
         linters:
           - gocyclo
           - depguard
+          - unparam
+          - gocritic
+          - usestdlibvars
 
 # Surface every finding (defaults cap duplicates at 3, which can hide real
 # regressions in the log even though they still fail the build).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -251,8 +251,8 @@ Lower layers must never import upper layers. `internal/event` is a pure domain l
 - New functions must stay at or below cyclomatic complexity **25** (`gocyclo` gate).
 - Existing functions that exceed this are annotated `//nolint:gocyclo` with a refactor note.
 - Additional gates catch dead nil checks (`govet nilness/unreachable`), wasted
-  assignments (`wastedassign`), unused params (`unparam`), and stdlib constants
-  (`usestdlibvars`).
+  assignments (`wastedassign`), unused params (`unparam`), suspicious constructs
+  and duplicate branches (`gocritic`), and stdlib constants (`usestdlibvars`).
 
 ### TypeScript / Qwik (landing/)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,7 +91,7 @@ The repository is a monorepo that also contains:
 ├── get/                   # Cloudflare Worker install redirect
 ├── test/e2e/              # Black-box binary tests (build tag `e2e`)
 ├── scripts/coverage-gate.sh   # Coverage thresholds (CI + local)
-├── .golangci.yml          # Linting (complexity + dependency rules)
+├── .golangci.yml          # Linting (complexity + dependency + dead-code rules)
 ├── .gremlins.yaml         # Mutation-testing configuration
 ├── .goreleaser.yaml       # Release artifact builds
 └── Dockerfile             # Distroless static-binary image
@@ -250,6 +250,9 @@ Lower layers must never import upper layers. `internal/event` is a pure domain l
 
 - New functions must stay at or below cyclomatic complexity **25** (`gocyclo` gate).
 - Existing functions that exceed this are annotated `//nolint:gocyclo` with a refactor note.
+- Additional gates catch dead nil checks (`govet nilness/unreachable`), wasted
+  assignments (`wastedassign`), unused params (`unparam`), and stdlib constants
+  (`usestdlibvars`).
 
 ### TypeScript / Qwik (landing/)
 

--- a/internal/backfill/backfill.go
+++ b/internal/backfill/backfill.go
@@ -434,37 +434,22 @@ func (b *BackfillEngineImpl) snapshotTable(ctx context.Context, cfg BackfillConf
 			bufLastPKValues = nil
 		}
 
-		// Advance cursor and persist state (BKF-03 crash-resumable).
-		// When appendBatchFn is set, flushEventBuf already persisted the cursor
-		// for rows that were flushed mid-page; this call covers the final state
-		// (ProcessedRows, status) after the page is fully processed.
-		if b.appendBatchFn == nil {
-			if lastPKValues != nil {
-				cursor.LastPK = lastPKValues
-				cursorJSON, marshalErr := json.Marshal(lastPKValues)
-				if marshalErr == nil {
-					state.CursorKey = cursorJSON
-				}
+		// Advance cursor to the last SCANNED PK (including watermark-skipped
+		// rows) so the next page query does not re-scan rows that were already
+		// evaluated and skipped. When appendBatchFn is set, flushEventBuf only
+		// advances to bufLastPKValues (last emitted PK), which can lag behind
+		// when trailing rows are skipped; this call covers the final state
+		// (ProcessedRows, status) after the page is fully processed (BKF-03).
+		if lastPKValues != nil {
+			cursor.LastPK = lastPKValues
+			cursorJSON, marshalErr := json.Marshal(lastPKValues)
+			if marshalErr == nil {
+				state.CursorKey = cursorJSON
 			}
-			if saveErr := b.store.SaveState(ctx, state); saveErr != nil {
-				return fmt.Errorf("save state after batch: %w", saveErr)
-			}
-		} else {
-			// Advance cursor to the last SCANNED PK (including watermark-skipped
-			// rows) so the next page query does not re-scan rows that were already
-			// evaluated and skipped. flushEventBuf only advances to bufLastPKValues
-			// (last emitted PK), which can lag behind when trailing rows are skipped.
-			if lastPKValues != nil {
-				cursor.LastPK = lastPKValues
-				cursorJSON, marshalErr := json.Marshal(lastPKValues)
-				if marshalErr == nil {
-					state.CursorKey = cursorJSON
-				}
-			}
-			// Persist end-of-page state (status + ProcessedRows).
-			if saveErr := b.store.SaveState(ctx, state); saveErr != nil {
-				return fmt.Errorf("save state after batch: %w", saveErr)
-			}
+		}
+		// Persist end-of-page state (status + ProcessedRows).
+		if saveErr := b.store.SaveState(ctx, state); saveErr != nil {
+			return fmt.Errorf("save state after batch: %w", saveErr)
 		}
 
 		optimizer.Adjust(time.Since(batchStart))

--- a/internal/cmd/mongo.go
+++ b/internal/cmd/mongo.go
@@ -27,7 +27,6 @@ func runMongoPipeline(
 	ckStore checkpoint.CheckpointStore,
 	el eventlog.EventLog,
 	rtr *router.Router,
-	cursorStore router.ConsumerCursorStore,
 	cursorRun func(ctx context.Context),
 	heartbeater *cluster.NodeHeartbeater,
 	pm *cluster.PartitionManager,

--- a/internal/cmd/output.go
+++ b/internal/cmd/output.go
@@ -173,7 +173,7 @@ func buildOutputServer(
 
 	switch cfg.Output {
 	case "none":
-		return buildObservabilityServer(cfg, metrics, healthHandler, healthProbes, oaHandler)
+		return buildObservabilityServer(cfg, metrics, healthProbes, oaHandler)
 	case "sse":
 		return buildSSEServer(cfg, rtr, metrics, healthHandler, oaHandler, rowFilters, colFilters)
 	case "grpc":
@@ -410,7 +410,6 @@ func buildGRPCServer(
 func buildObservabilityServer(
 	cfg *config.Config,
 	metrics *observability.KaptantoMetrics,
-	healthHandler http.Handler,
 	healthProbes []observability.HealthProbe,
 	oaHandler http.Handler,
 ) (func(context.Context) error, error) {
@@ -483,7 +482,8 @@ func buildSinkServer(
 
 	sink.SetMetrics(metrics)
 	rtr.Register(sink)
-	probes := append(healthProbes, observability.HealthProbe{Name: name, Check: sink.Ping})
+	probes := append([]observability.HealthProbe(nil), healthProbes...)
+	probes = append(probes, observability.HealthProbe{Name: name, Check: sink.Ping})
 	mux := http.NewServeMux()
 	var metricsH, healthH, oaH http.Handler
 	metricsH = metrics.Handler()

--- a/internal/cmd/output_auth_test.go
+++ b/internal/cmd/output_auth_test.go
@@ -140,9 +140,9 @@ func TestBuildOutputServer_NoneWithMCPMetricsRequireBearer(t *testing.T) {
 	oaBytes, err := openapi.MarshalDocument(oaDoc)
 	require.NoError(t, err)
 
-	fn, err := buildObservabilityServer(cfg, metrics, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}), nil, openapi.NewHandler(oaBytes))
+	fn, err := buildObservabilityServer(cfg, metrics, []observability.HealthProbe{
+		{Name: "test", Check: func() error { return nil }},
+	}, openapi.NewHandler(oaBytes))
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/internal/cmd/output_sink_tls_test.go
+++ b/internal/cmd/output_sink_tls_test.go
@@ -409,7 +409,9 @@ func TestBuildObservabilityServer_ServesEndpoints(t *testing.T) {
 
 	metrics := observability.NewKaptantoMetrics()
 
-	fn, err := buildObservabilityServer(cfg, metrics, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }), nil, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }))
+	fn, err := buildObservabilityServer(cfg, metrics, []observability.HealthProbe{
+		{Name: "test", Check: func() error { return nil }},
+	}, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }))
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -469,7 +469,7 @@ func runPipeline(ctx context.Context, cfg *config.Config) error {
 	}
 
 	if cfg.SourceType() == "mongodb" {
-		return runMongoPipeline(ctx, cfg, ckStore, el, rtr, cursorStore, cursorRun, heartbeater, pm, outputServer, metrics, mcpServer)
+		return runMongoPipeline(ctx, cfg, ckStore, el, rtr, cursorRun, heartbeater, pm, outputServer, metrics, mcpServer)
 	}
 
 	tables := make([]string, 0, len(cfg.Tables))

--- a/internal/output/rabbitmq/consumer.go
+++ b/internal/output/rabbitmq/consumer.go
@@ -323,17 +323,18 @@ func (c *RabbitMQSinkConsumer) FlushBatch(ctx context.Context, partitionID uint3
 
 	for _, pm := range batch {
 		acked, waitErr := pm.dc.WaitContext(ctx)
-		if waitErr != nil {
+		switch {
+		case waitErr != nil:
 			if firstErr == nil {
 				firstErr = fmt.Errorf("rabbitmq sink: wait confirm for exchange %q routing-key %q: %w",
 					pm.exchange, pm.routingKey, waitErr)
 			}
-		} else if !acked {
+		case !acked:
 			if firstErr == nil {
 				firstErr = fmt.Errorf("rabbitmq sink: broker nacked message on exchange %q routing-key %q",
 					pm.exchange, pm.routingKey)
 			}
-		} else {
+		default:
 			successCount++
 		}
 	}

--- a/internal/output/row_filter_test.go
+++ b/internal/output/row_filter_test.go
@@ -604,9 +604,6 @@ func TestRowFilter_PrefixedColumns(t *testing.T) {
 			}
 			ev := makeEvent(tt.op, tt.before, tt.after)
 			got := mustMatch(t, f, ev)
-			if err != nil {
-				t.Fatalf("Match error: %v", err)
-			}
 			if got != tt.want {
 				t.Errorf("Match() = %v, want %v", got, tt.want)
 			}

--- a/internal/output/vector/pinecone.go
+++ b/internal/output/vector/pinecone.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"strings"
 	"time"
+	"unicode/utf8"
 )
 
 // Pinecone API version frozen against docs.pinecone.io (2025-10 data plane).
@@ -150,5 +151,11 @@ func truncate(s string) string {
 	if len(s) <= max {
 		return s
 	}
-	return s[:max] + "…"
+	suffix := "…"
+	limit := max - len(suffix)
+	cut := s[:limit]
+	for !utf8.ValidString(cut) && len(cut) > 0 {
+		cut = cut[:len(cut)-1]
+	}
+	return cut + suffix
 }

--- a/internal/output/vector/pinecone.go
+++ b/internal/output/vector/pinecone.go
@@ -128,7 +128,7 @@ func (s *PineconeStore) doJSON(ctx context.Context, method, url string, payload 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return &StatusError{
 			Status: resp.StatusCode,
-			Msg:    fmt.Sprintf("pinecone: %s %s: %s", method, url, truncate(string(body), 512)),
+			Msg:    fmt.Sprintf("pinecone: %s %s: %s", method, url, truncate(string(body))),
 		}
 	}
 	return nil
@@ -145,9 +145,10 @@ func cloneMetadata(m map[string]any) map[string]any {
 	return out
 }
 
-func truncate(s string, n int) string {
-	if len(s) <= n {
+func truncate(s string) string {
+	const max = 512
+	if len(s) <= max {
 		return s
 	}
-	return s[:n] + "…"
+	return s[:max] + "…"
 }

--- a/internal/output/vector/qdrant.go
+++ b/internal/output/vector/qdrant.go
@@ -70,7 +70,7 @@ func (s *QdrantStore) ensureCollection(ctx context.Context) error {
 		return nil
 	}
 	if status != http.StatusNotFound {
-		return fmt.Errorf("vector: qdrant: get collection: status %d: %s", status, truncate(string(body), 512))
+		return fmt.Errorf("vector: qdrant: get collection: status %d: %s", status, truncate(string(body)))
 	}
 	create := map[string]any{
 		"vectors": map[string]any{
@@ -90,7 +90,7 @@ func (s *QdrantStore) ensureCollection(ctx context.Context) error {
 	if status == http.StatusBadRequest && strings.Contains(strings.ToLower(string(body)), "already") {
 		return nil
 	}
-	return fmt.Errorf("vector: qdrant: create collection: status %d: %s", status, truncate(string(body), 512))
+	return fmt.Errorf("vector: qdrant: create collection: status %d: %s", status, truncate(string(body)))
 }
 
 type qdrantPoint struct {
@@ -153,7 +153,7 @@ func (s *QdrantStore) Ping(ctx context.Context) error {
 		return fmt.Errorf("vector: qdrant: ping: %w", err)
 	}
 	if status < 200 || status >= 300 {
-		return &StatusError{Status: status, Msg: "qdrant: ping: " + truncate(string(body), 512)}
+		return &StatusError{Status: status, Msg: "qdrant: ping: " + truncate(string(body))}
 	}
 	return nil
 }
@@ -174,7 +174,7 @@ func (s *QdrantStore) doJSON(ctx context.Context, method, rawURL string, payload
 	if status < 200 || status >= 300 {
 		return &StatusError{
 			Status: status,
-			Msg:    fmt.Sprintf("qdrant: %s %s: %s", method, rawURL, truncate(string(body), 512)),
+			Msg:    fmt.Sprintf("qdrant: %s %s: %s", method, rawURL, truncate(string(body))),
 		}
 	}
 	return nil

--- a/internal/output/vector/truncate_test.go
+++ b/internal/output/vector/truncate_test.go
@@ -1,0 +1,34 @@
+package vector
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTruncate_Boundary(t *testing.T) {
+	cases := []struct {
+		name       string
+		input      string
+		wantMax    int
+		wantSuffix string
+	}{
+		{"short ASCII unchanged", "hello", 512, ""},
+		{"exactly max ASCII", strings.Repeat("a", 512), 512, ""},
+		{"over max ASCII", strings.Repeat("a", 513), 512, "…"},
+		{"over max multibyte", strings.Repeat("é", 300), 512, "…"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := truncate(tc.input)
+			assert.LessOrEqual(t, len(got), tc.wantMax, "result exceeds byte limit")
+			assert.True(t, utf8.ValidString(got), "result must be valid UTF-8")
+			if tc.wantSuffix != "" {
+				assert.True(t, strings.HasSuffix(got, tc.wantSuffix), "expected suffix %q", tc.wantSuffix)
+			}
+		})
+	}
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -1017,7 +1017,7 @@ func (r *Router) applyDispatchCursors(ctx context.Context, partitionID uint32, e
 			r.advanceCursorLocked(cs, partitionID, entry.Seq+1, &saves)
 			continue
 		}
-		r.dispatchUpdateCursor(ctx, cs, snap, entry, partitionID, groupKey, errs, i, &saves)
+		r.dispatchUpdateCursor(cs, snap, entry, partitionID, groupKey, errs, i, &saves)
 	}
 	r.mu.Unlock()
 	for _, save := range saves {
@@ -1037,7 +1037,6 @@ func (r *Router) advanceCursorLocked(cs *consumerState, partitionID uint32, seq 
 // dispatchUpdateCursor handles Phase 3 per-consumer cursor logic.
 // Must be called under r.mu write lock.
 func (r *Router) dispatchUpdateCursor(
-	ctx context.Context,
 	cs *consumerState,
 	snap consumerSnap,
 	entry eventlog.LogEntry,

--- a/internal/source/postgres/connector.go
+++ b/internal/source/postgres/connector.go
@@ -319,7 +319,7 @@ func (c *PostgresConnector) Run(ctx context.Context) error {
 			return ctx.Err()
 		}
 		if backoff < c.cfg.MaxBackoff {
-			backoff = backoff * 2
+			backoff *= 2
 			if backoff > c.cfg.MaxBackoff {
 				backoff = c.cfg.MaxBackoff
 			}
@@ -356,9 +356,7 @@ func (c *PostgresConnector) connectAndStream(ctx context.Context, wasEverConnect
 		if splitErr != nil {
 			return fmt.Errorf("postgres: invalid table %q: %w", t, splitErr)
 		}
-		if err := checkReplicaIdentity(ctx, queryConn, schema, table); err != nil {
-			return err
-		}
+		checkReplicaIdentity(ctx, queryConn, schema, table)
 	}
 
 	// 5. Ensure publication exists (SRC-02).
@@ -440,7 +438,7 @@ func (c *PostgresConnector) connectAndStream(ctx context.Context, wasEverConnect
 			case <-lagCtx.Done():
 				return
 			case <-ticker.C:
-				_ = checkWALLag(lagCtx, queryConn, c.cfg.WALLagThreshold, c.cfg.SourceID, c.metrics)
+				checkWALLag(lagCtx, queryConn, c.cfg.WALLagThreshold, c.cfg.SourceID, c.metrics)
 			}
 		}
 	}()

--- a/internal/source/postgres/validation.go
+++ b/internal/source/postgres/validation.go
@@ -15,8 +15,8 @@ import (
 // columns are logged in old-row data), it emits a slog.Warn so operators
 // know they may get incomplete before-images for UPDATE/DELETE events.
 //
-// This function never returns an error for a DEFAULT identity; it only logs.
-func checkReplicaIdentity(ctx context.Context, conn *pgx.Conn, schema, table string) error {
+// This function only logs; it never returns an error.
+func checkReplicaIdentity(ctx context.Context, conn *pgx.Conn, schema, table string) {
 	var relreplident string
 	err := conn.QueryRow(ctx,
 		`SELECT relreplident::text FROM pg_class
@@ -28,7 +28,7 @@ func checkReplicaIdentity(ctx context.Context, conn *pgx.Conn, schema, table str
 		// Table might not exist yet — log but don't fail.
 		slog.Warn("postgres: could not check REPLICA IDENTITY",
 			"schema", schema, "table", table, "error", err)
-		return nil
+		return
 	}
 
 	if relreplident == "d" {
@@ -36,17 +36,15 @@ func checkReplicaIdentity(ctx context.Context, conn *pgx.Conn, schema, table str
 			"will only include primary key columns; set REPLICA IDENTITY FULL for complete before-images",
 			"schema", schema, "table", table)
 	}
-	return nil
 }
+
 
 // checkWALLag queries pg_stat_replication for the byte difference between
 // sent_lsn and write_lsn on the primary. If the lag exceeds thresholdBytes,
 // a slog.Warn is emitted. When m is non-nil, sets the SourceLagBytes gauge.
 //
-// Returns nil when:
-//   - No standbys are attached (empty pg_stat_replication — not an error).
-//   - Lag is within the threshold.
-func checkWALLag(ctx context.Context, conn *pgx.Conn, thresholdBytes int64, sourceID string, m *observability.KaptantoMetrics) error {
+// This function only logs; it never returns an error.
+func checkWALLag(ctx context.Context, conn *pgx.Conn, thresholdBytes int64, sourceID string, m *observability.KaptantoMetrics) {
 	var lagBytes int64
 	err := conn.QueryRow(ctx,
 		`SELECT COALESCE(sent_lsn - write_lsn, 0) AS lag_bytes
@@ -54,7 +52,7 @@ func checkWALLag(ctx context.Context, conn *pgx.Conn, thresholdBytes int64, sour
 	).Scan(&lagBytes)
 	if err != nil {
 		// No rows — no standbys attached. This is normal for a single-node setup.
-		return nil
+		return
 	}
 
 	if m != nil {
@@ -67,8 +65,8 @@ func checkWALLag(ctx context.Context, conn *pgx.Conn, thresholdBytes int64, sour
 			"threshold_bytes", thresholdBytes,
 		)
 	}
-	return nil
 }
+
 
 // splitSchemaTable splits a "schema.table" string into its two parts.
 // Quoted identifiers (e.g. public."CamelCaseTable") are parsed into raw

--- a/internal/source/postgres/validation.go
+++ b/internal/source/postgres/validation.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 
@@ -43,7 +44,9 @@ func checkReplicaIdentity(ctx context.Context, conn *pgx.Conn, schema, table str
 // sent_lsn and write_lsn on the primary. If the lag exceeds thresholdBytes,
 // a slog.Warn is emitted. When m is non-nil, sets the SourceLagBytes gauge.
 //
-// This function only logs; it never returns an error.
+// This function only logs; it never returns an error. Single-node setups have
+// no replication rows, so a zero lag is reported rather than leaving the gauge
+// stale.
 func checkWALLag(ctx context.Context, conn *pgx.Conn, thresholdBytes int64, sourceID string, m *observability.KaptantoMetrics) {
 	var lagBytes int64
 	err := conn.QueryRow(ctx,
@@ -51,7 +54,17 @@ func checkWALLag(ctx context.Context, conn *pgx.Conn, thresholdBytes int64, sour
 		 FROM pg_stat_replication LIMIT 1`,
 	).Scan(&lagBytes)
 	if err != nil {
-		// No rows — no standbys attached. This is normal for a single-node setup.
+		if m != nil {
+			m.SourceLagBytes.WithLabelValues(sourceID).Set(0)
+		}
+		if errors.Is(err, pgx.ErrNoRows) {
+			// No standbys attached — normal for a single-node setup.
+			return
+		}
+		slog.Warn("postgres: could not check WAL lag",
+			"source_id", sourceID,
+			"error", err,
+		)
 		return
 	}
 

--- a/landing/eslint.config.js
+++ b/landing/eslint.config.js
@@ -68,6 +68,8 @@ export default tseslint.config(
   {
     rules: {
       "@typescript-eslint/no-explicit-any": "off",
+      "@typescript-eslint/no-unnecessary-condition": "error",
+      "no-useless-catch": "error",
     },
   },
 );

--- a/landing/src/data/docs-content.ts
+++ b/landing/src/data/docs-content.ts
@@ -1,7 +1,7 @@
 export type DocItem = { title: string; sub: string; body: string };
 
 // docs content
-export const DOCS_CONTENT: Record<string, DocItem> = {
+export const DOCS_CONTENT: Record<string, DocItem | undefined> = {
   "docs-intro": {
     title: "What is Kaptanto?",
     sub: "The fastest way to stream changes from Postgres and MongoDB to your application. One binary, no infrastructure.",


### PR DESCRIPTION
## Problem

PR #65 cleaned up dead code, duplicate branches, and redundant defensive checks across the Go core. Without lint enforcement the same patterns can reappear.

## What this PR does

### Go

- Adds govet passes nilness/unreachable, wastedassign, unparam, gocritic, and usestdlibvars to .golangci.yml.
- Excludes _test.go files from unparam, gocritic, and usestdlibvars so test helpers don't generate noise.
- Fixes every genuine production finding the new rules surface (duplicate branch bodies, append-to-caller-slice, unused params, always-nil error returns, etc.).

### Landing

- Enables @typescript-eslint/no-unnecessary-condition and no-useless-catch in landing/eslint.config.js.
- Adjusts DOCS_CONTENT typing so existing defensive guards are recognized as necessary by the type-aware rule.

### Docs

- Updates AGENTS.md to reflect the new lint gates.

## Verification

- make lint: 0 issues.
- CGO_ENABLED=0 go test ./...: all green.
- cd landing && npm run lint: 0 errors (pre-existing warnings unchanged).
- cd landing && npm run build.types: passes.

Note: landing has untracked test files (test/github-stars.test.ts, test/ui-wave3.test.ts) and source files that are not part of this change; the tracked npm run test suite has unrelated failures in those untracked files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Review findings

### High — PostgreSQL replication setup now ignores validation failures

`internal/source/postgres/connector.go` and `internal/source/postgres/validation.go` stop returning errors from `checkReplicaIdentity` and `checkWALLag`. The connection setup can now continue when these queries fail.

This can start replication without confirming the required replica identity or acceptable WAL lag. The failure may also be caused by permission, connectivity, or transaction errors. That can produce incomplete `UPDATE`/`DELETE` events or unsafe replication behavior.

Keep validation errors in the connection result. If the checks are advisory, log them with an explicit severity and add a configuration-controlled policy. Add tests for query failures and invalid validation results.

### Medium — Backfill checkpoint advancement needs a durability regression test

`internal/backfill/backfill.go` now saves state after each processed page and advances the cursor to the last scanned primary key, including rows skipped by the watermark.

This may be correct for the watermark handoff, but the change affects the checkpoint boundary. A crash between cursor persistence and durable event-log append could skip rows unless the existing append-before-checkpoint contract still holds for every path.

Add a focused test that injects failures before and after event-log append, including watermark-skipped rows and single-event pages. Verify that restart does not skip or duplicate snapshot rows and that live WAL events are not lost during handoff.

### Low — Vector error truncation semantics should be verified

`internal/output/vector/pinecone.go` and `internal/output/vector/qdrant.go` centralize truncation at a fixed 512-byte limit. Confirm that the helper truncates by bytes rather than runes and preserves valid UTF-8. Add a table-driven test for multibyte error text and boundary lengths.

## Residual risk

The reported verification is positive: Go lint, Go tests, TypeScript checks, and ESLint complete without errors. The main residual risk is insufficient failure-injection coverage for checkpoint durability and PostgreSQL validation failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->