### PR TITLE
fix(eventlog): index cluster backfill watermarks via NATS observers

### DIFF
--- a/internal/backfill/watermark.go
+++ b/internal/backfill/watermark.go
@@ -61,7 +61,7 @@ type tableIndex struct {
 //   - Scan (fallback): the original implementation, used automatically when
 //     StartTable was never called for a table, when the table's index
 //     exceeded the memory cap, or when the underlying EventLog does not
-//     support AppendObservable (e.g. the NATS cluster-mode EventLog). Pages
+//     support AppendObservable (test fakes that omit the interface). Pages
 //     through the entire partition for the row's key on every call —
 //     correct but O(partition size) per row.
 type WatermarkChecker struct {
@@ -78,8 +78,8 @@ type WatermarkChecker struct {
 // NewWatermarkChecker creates a WatermarkChecker backed by the given EventLog.
 // numPartitions must match the EventLog's partition count.
 //
-// If el implements eventlog.AppendObservable (BadgerEventLog does; the NATS
-// cluster EventLog currently does not), the checker registers itself as an
+// If el implements eventlog.AppendObservable (BadgerEventLog and NatsEventLog
+// both do), the checker registers itself as an
 // AppendObserver immediately — before any table's index is ever built — so
 // the "observer attached before initial scan" ordering required for
 // correctness (see StartTable) holds for every table, from the very first

--- a/internal/backfill/watermark_test.go
+++ b/internal/backfill/watermark_test.go
@@ -495,13 +495,16 @@ func TestWatermarkChecker_StartTableError_DoesNotLeaveTrustedPartialIndex(t *tes
 // NewWatermarkChecker registers the observer, and a post-StartTable Append
 // (after PubAck) is indexed so ShouldEmit suppresses without paging ReadPartition.
 func TestWatermarkChecker_NatsEventLog_IndexedPathSuppressesStaleRead(t *testing.T) {
+	// One partition: NATS ReadPartition still uses FetchMaxWait(2s) on empty
+	// pages, so a 64-partition StartTable (~128s) exceeds CI's 120s timeout.
+	const numPartitions = uint32(1)
 	el, err := eventlog.OpenNats(eventlog.NatsEventLogConfig{
 		Server: eventlog.NatsServerConfig{
 			ClientPort: -1,
 			StoreDir:   t.TempDir(),
 			SyncAlways: false,
 		},
-		NumPartitions: 64,
+		NumPartitions: numPartitions,
 		Retention:     time.Hour,
 	})
 	require.NoError(t, err)
@@ -510,10 +513,11 @@ func TestWatermarkChecker_NatsEventLog_IndexedPathSuppressesStaleRead(t *testing
 	_, ok := any(el).(eventlog.AppendObservable)
 	require.True(t, ok, "NatsEventLog must implement AppendObservable")
 
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
 	const table = "orders"
 	const snapshotLSN = uint64(100)
-	checker := backfill.NewWatermarkChecker(el, 64)
+	checker := backfill.NewWatermarkChecker(el, numPartitions)
 	defer checker.Close()
 	require.NoError(t, checker.StartTable(ctx, table, snapshotLSN))
 	defer checker.FinishTable(table)

--- a/internal/backfill/watermark_test.go
+++ b/internal/backfill/watermark_test.go
@@ -489,3 +489,51 @@ func TestWatermarkChecker_StartTableError_DoesNotLeaveTrustedPartialIndex(t *tes
 			"before failing must still be suppressed via the scan fallback — the "+
 			"failed StartTable must not leave a partial index for ShouldEmit to trust")
 }
+
+// TestWatermarkChecker_NatsEventLog_IndexedPathSuppressesStaleRead proves the
+// cluster-mode wiring this fix adds: NatsEventLog implements AppendObservable,
+// NewWatermarkChecker registers the observer, and a post-StartTable Append
+// (after PubAck) is indexed so ShouldEmit suppresses without paging ReadPartition.
+func TestWatermarkChecker_NatsEventLog_IndexedPathSuppressesStaleRead(t *testing.T) {
+	el, err := eventlog.OpenNats(eventlog.NatsEventLogConfig{
+		Server: eventlog.NatsServerConfig{
+			ClientPort: -1,
+			StoreDir:   t.TempDir(),
+			SyncAlways: false,
+		},
+		NumPartitions: 64,
+		Retention:     time.Hour,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = el.Close() })
+
+	_, ok := any(el).(eventlog.AppendObservable)
+	require.True(t, ok, "NatsEventLog must implement AppendObservable")
+
+	ctx := context.Background()
+	const table = "orders"
+	const snapshotLSN = uint64(100)
+	checker := backfill.NewWatermarkChecker(el, 64)
+	defer checker.Close()
+	require.NoError(t, checker.StartTable(ctx, table, snapshotLSN))
+	defer checker.FinishTable(table)
+
+	targetKey := json.RawMessage(`{"id":42}`)
+	emit, err := checker.ShouldEmit(ctx, table, targetKey, snapshotLSN)
+	require.NoError(t, err)
+	assert.True(t, emit, "no WAL event yet — snapshot row should be emitted")
+
+	ev := &event.ChangeEvent{
+		Table:          table,
+		Key:            targetKey,
+		IdempotencyKey: "nats:wm:42:insert:0/C8",
+		Metadata:       map[string]any{"lsn": fmt.Sprintf("0/%X", snapshotLSN+100)},
+	}
+	seq, err := el.Append(ev)
+	require.NoError(t, err)
+	require.Greater(t, seq, uint64(0))
+
+	emit, err = checker.ShouldEmit(ctx, table, targetKey, snapshotLSN)
+	require.NoError(t, err)
+	assert.False(t, emit, "post-PubAck observer must index the WAL event so ShouldEmit suppresses without scanning")
+}

--- a/internal/eventlog/eventlog.go
+++ b/internal/eventlog/eventlog.go
@@ -98,8 +98,8 @@ type AppendObserver interface {
 }
 
 // AppendObservable is implemented by EventLog backends that support
-// synchronous append observers (currently BadgerEventLog). Callers must type-
-// assert an EventLog to this interface — it is optional so fakes used in
+// synchronous append observers (BadgerEventLog and NatsEventLog). Callers must
+// type-assert an EventLog to this interface — it is optional so fakes used in
 // tests need not implement it.
 type AppendObservable interface {
 	// RegisterObserver registers obs to be called synchronously on every

--- a/internal/eventlog/nats.go
+++ b/internal/eventlog/nats.go
@@ -21,11 +21,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sync"
 	"time"
 
+	natssrv "github.com/nats-io/nats-server/v2/server"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
-	natssrv "github.com/nats-io/nats-server/v2/server"
 
 	"github.com/olucasandrade/kaptanto/internal/event"
 )
@@ -35,6 +36,10 @@ var _ EventLog = (*NatsEventLog)(nil)
 
 // Compile-time assertion: NatsEventLog implements PartitionNotifier.
 var _ PartitionNotifier = (*NatsEventLog)(nil)
+
+// Compile-time assertion: NatsEventLog implements AppendObservable so
+// WatermarkChecker can build the O(1) index in cluster mode (BKF-02).
+var _ AppendObservable = (*NatsEventLog)(nil)
 
 const (
 	// natsStreamName is the single JetStream stream that holds all 64 partition subjects.
@@ -78,6 +83,10 @@ type NatsEventLog struct {
 	stream        jetstream.Stream
 	numPartitions uint32
 	notifyChs     []chan struct{} // one depth-1 buffered channel per partition
+
+	obsMu     sync.RWMutex
+	observers map[int]AppendObserver // keyed by monotonically increasing id for stable unregister
+	nextObsID int
 }
 
 // OpenNats opens a NatsEventLog, starting an embedded NATS server and creating
@@ -157,7 +166,46 @@ func OpenNats(cfg NatsEventLogConfig) (*NatsEventLog, error) {
 		stream:        stream,
 		numPartitions: numPartitions,
 		notifyChs:     notifyChs,
+		observers:     make(map[int]AppendObserver),
 	}, nil
+}
+
+// RegisterObserver implements AppendObservable. obs is called synchronously,
+// after a successful (non-duplicate) PubAck, on every future Append/AppendBatch
+// that writes at least one non-duplicate event — including calls already in
+// flight when RegisterObserver is invoked, since registration and the
+// observer dispatch loop both hold obsMu (see notifyObservers).
+func (n *NatsEventLog) RegisterObserver(obs AppendObserver) (unregister func()) {
+	n.obsMu.Lock()
+	id := n.nextObsID
+	n.nextObsID++
+	n.observers[id] = obs
+	n.obsMu.Unlock()
+
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			n.obsMu.Lock()
+			delete(n.observers, id)
+			n.obsMu.Unlock()
+		})
+	}
+}
+
+// notifyObservers dispatches evs/seqs (already filtered to non-duplicates by
+// the caller) to every registered observer, synchronously and in the calling
+// goroutine — this is what makes RegisterObserver's "sees every future
+// commit" guarantee hold: PubAck has already confirmed the JetStream write
+// before this runs, and this runs before Append/AppendBatch returns.
+func (n *NatsEventLog) notifyObservers(evs []*event.ChangeEvent, seqs []uint64) {
+	if len(evs) == 0 {
+		return
+	}
+	n.obsMu.RLock()
+	defer n.obsMu.RUnlock()
+	for _, obs := range n.observers {
+		obs.ObserveAppend(evs, seqs)
+	}
 }
 
 // NotifyCh returns the read-only notify channel for the given partition.
@@ -208,11 +256,13 @@ func (n *NatsEventLog) Append(ev *event.ChangeEvent) (uint64, error) {
 
 	// Duplicate detection: PubAck.Duplicate=true means the Nats-Msg-Id was seen before.
 	// Return seq=0 as the "duplicate detected" sentinel (LOG-03), matching BadgerEventLog.
+	// Observers must not fire for duplicates, and must not fire before PubAck.
 	if ack.Duplicate {
 		return 0, nil
 	}
 
 	n.notify(partition)
+	n.notifyObservers([]*event.ChangeEvent{ev}, []uint64{ack.Sequence})
 	return ack.Sequence, nil
 }
 
@@ -258,6 +308,8 @@ func (n *NatsEventLog) AppendBatch(evs []*event.ChangeEvent) ([]uint64, error) {
 	}
 
 	notifyPartitions := make(map[uint32]struct{})
+	writtenEvs := make([]*event.ChangeEvent, 0, len(evs))
+	writtenSeqs := make([]uint64, 0, len(evs))
 	for j, fut := range futures {
 		pm := preparedMsgs[j]
 		select {
@@ -269,6 +321,8 @@ func (n *NatsEventLog) AppendBatch(evs []*event.ChangeEvent) ([]uint64, error) {
 			} else {
 				seqs[pm.idx] = ack.Sequence
 				notifyPartitions[pm.partition] = struct{}{}
+				writtenEvs = append(writtenEvs, evs[pm.idx])
+				writtenSeqs = append(writtenSeqs, ack.Sequence)
 			}
 		case err := <-fut.Err():
 			return nil, fmt.Errorf("nats eventlog: AppendBatch pubAck[%d]: %w", pm.idx, err)
@@ -278,6 +332,10 @@ func (n *NatsEventLog) AppendBatch(evs []*event.ChangeEvent) ([]uint64, error) {
 	for partition := range notifyPartitions {
 		n.notify(partition)
 	}
+	// Notify observers only after every PubAck has been collected, and never
+	// for duplicates (seq==0). This matches BadgerEventLog's contract so
+	// WatermarkChecker can index cluster-mode appends without a scan fallback.
+	n.notifyObservers(writtenEvs, writtenSeqs)
 	return seqs, nil
 }
 

--- a/internal/eventlog/nats.go
+++ b/internal/eventlog/nats.go
@@ -172,9 +172,9 @@ func OpenNats(cfg NatsEventLogConfig) (*NatsEventLog, error) {
 
 // RegisterObserver implements AppendObservable. obs is called synchronously,
 // after a successful (non-duplicate) PubAck, on every future Append/AppendBatch
-// that writes at least one non-duplicate event — including calls already in
-// flight when RegisterObserver is invoked, since registration and the
-// observer dispatch loop both hold obsMu (see notifyObservers).
+// that writes at least one non-duplicate event. An in-flight Append that has
+// not yet copied the observer snapshot will still notify obs; a registration
+// that races the snapshot may miss that one append (the next one is seen).
 func (n *NatsEventLog) RegisterObserver(obs AppendObserver) (unregister func()) {
 	n.obsMu.Lock()
 	id := n.nextObsID
@@ -197,13 +197,23 @@ func (n *NatsEventLog) RegisterObserver(obs AppendObserver) (unregister func()) 
 // goroutine — this is what makes RegisterObserver's "sees every future
 // commit" guarantee hold: PubAck has already confirmed the JetStream write
 // before this runs, and this runs before Append/AppendBatch returns.
+//
+// Observers are copied under obsMu and callbacks run after the lock is
+// released. ObserveAppend may call the observer's unregister func (which
+// takes obsMu.Lock) without deadlocking. A snapshot observer still receives
+// this dispatch even if it unregisters during the callback; later appends
+// will not see it.
 func (n *NatsEventLog) notifyObservers(evs []*event.ChangeEvent, seqs []uint64) {
 	if len(evs) == 0 {
 		return
 	}
 	n.obsMu.RLock()
-	defer n.obsMu.RUnlock()
+	observers := make([]AppendObserver, 0, len(n.observers))
 	for _, obs := range n.observers {
+		observers = append(observers, obs)
+	}
+	n.obsMu.RUnlock()
+	for _, obs := range observers {
 		obs.ObserveAppend(evs, seqs)
 	}
 }
@@ -274,12 +284,7 @@ func (n *NatsEventLog) AppendBatch(evs []*event.ChangeEvent) ([]uint64, error) {
 		return nil, nil
 	}
 
-	type prepared struct {
-		msg       *nats.Msg
-		partition uint32
-		idx       int
-	}
-	preparedMsgs := make([]prepared, 0, len(evs))
+	preparedMsgs := make([]natsPreparedMsg, 0, len(evs))
 	for i, ev := range evs {
 		partition := PartitionOf(ev.Key, n.numPartitions)
 		data, err := json.Marshal(ev)
@@ -291,10 +296,9 @@ func (n *NatsEventLog) AppendBatch(evs []*event.ChangeEvent) ([]uint64, error) {
 			Data:    data,
 			Header:  nats.Header{nats.MsgIdHdr: []string{ev.IdempotencyKey}},
 		}
-		preparedMsgs = append(preparedMsgs, prepared{msg: msg, partition: partition, idx: i})
+		preparedMsgs = append(preparedMsgs, natsPreparedMsg{msg: msg, partition: partition, idx: i})
 	}
 
-	seqs := make([]uint64, len(evs))
 	futures := make([]jetstream.PubAckFuture, 0, len(preparedMsgs))
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -307,36 +311,66 @@ func (n *NatsEventLog) AppendBatch(evs []*event.ChangeEvent) ([]uint64, error) {
 		futures = append(futures, fut)
 	}
 
-	notifyPartitions := make(map[uint32]struct{})
-	writtenEvs := make([]*event.ChangeEvent, 0, len(evs))
-	writtenSeqs := make([]uint64, 0, len(evs))
-	for j, fut := range futures {
-		pm := preparedMsgs[j]
-		select {
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		case ack := <-fut.Ok():
-			if ack.Duplicate {
-				seqs[pm.idx] = 0
-			} else {
-				seqs[pm.idx] = ack.Sequence
-				notifyPartitions[pm.partition] = struct{}{}
-				writtenEvs = append(writtenEvs, evs[pm.idx])
-				writtenSeqs = append(writtenSeqs, ack.Sequence)
-			}
-		case err := <-fut.Err():
-			return nil, fmt.Errorf("nats eventlog: AppendBatch pubAck[%d]: %w", pm.idx, err)
-		}
-	}
+	seqs, writtenEvs, writtenSeqs, notifyPartitions, firstErr := collectBatchPubAcks(ctx, evs, preparedMsgs, futures)
 
 	for partition := range notifyPartitions {
 		n.notify(partition)
 	}
-	// Notify observers only after every PubAck has been collected, and never
-	// for duplicates (seq==0). This matches BadgerEventLog's contract so
-	// WatermarkChecker can index cluster-mode appends without a scan fallback.
+	// Notify observers for every acknowledged non-duplicate event even when a
+	// later PubAck fails. Those writes are durable; a retry will hit JetStream
+	// dedup (seq==0) and would otherwise leave WatermarkChecker with a stale index.
 	n.notifyObservers(writtenEvs, writtenSeqs)
+	if firstErr != nil {
+		return seqs, firstErr
+	}
 	return seqs, nil
+}
+
+// natsPreparedMsg is one AppendBatch publish waiting on its PubAck future.
+type natsPreparedMsg struct {
+	msg       *nats.Msg
+	partition uint32
+	idx       int
+}
+
+// collectBatchPubAcks drains every PubAck future. The first error is preserved
+// but the rest of the batch is still collected so already-acked events can be
+// observed before the error is returned.
+func collectBatchPubAcks(ctx context.Context, evs []*event.ChangeEvent, preparedMsgs []natsPreparedMsg, futures []jetstream.PubAckFuture) (
+	seqs []uint64,
+	writtenEvs []*event.ChangeEvent,
+	writtenSeqs []uint64,
+	notifyPartitions map[uint32]struct{},
+	err error,
+) {
+	seqs = make([]uint64, len(evs))
+	writtenEvs = make([]*event.ChangeEvent, 0, len(evs))
+	writtenSeqs = make([]uint64, 0, len(evs))
+	notifyPartitions = make(map[uint32]struct{})
+	var firstErr error
+	for j, fut := range futures {
+		pm := preparedMsgs[j]
+		select {
+		case <-ctx.Done():
+			if firstErr == nil {
+				firstErr = fmt.Errorf("nats eventlog: AppendBatch pubAck[%d]: %w", pm.idx, ctx.Err())
+			}
+		case ack := <-fut.Ok():
+			if ack.Duplicate {
+				seqs[pm.idx] = 0
+				continue
+			}
+			seqs[pm.idx] = ack.Sequence
+			notifyPartitions[pm.partition] = struct{}{}
+			writtenEvs = append(writtenEvs, evs[pm.idx])
+			writtenSeqs = append(writtenSeqs, ack.Sequence)
+		case ackErr := <-fut.Err():
+			if firstErr == nil {
+				firstErr = fmt.Errorf("nats eventlog: AppendBatch pubAck[%d]: %w", pm.idx, ackErr)
+			}
+		}
+	}
+	return seqs, writtenEvs, writtenSeqs, notifyPartitions, firstErr
 }
 
 // ReadPartition returns up to limit events from the given partition, starting at

--- a/internal/eventlog/nats_collect_test.go
+++ b/internal/eventlog/nats_collect_test.go
@@ -1,0 +1,76 @@
+package eventlog
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/olucasandrade/kaptanto/internal/event"
+)
+
+type stubPubAckFuture struct {
+	ok  chan *jetstream.PubAck
+	err chan error
+}
+
+func (s stubPubAckFuture) Ok() <-chan *jetstream.PubAck { return s.ok }
+func (s stubPubAckFuture) Err() <-chan error            { return s.err }
+func (s stubPubAckFuture) Msg() *nats.Msg               { return nil }
+
+func TestCollectBatchPubAcks_NotifiesAckedEventsBeforeFirstError(t *testing.T) {
+	evs := []*event.ChangeEvent{
+		{IdempotencyKey: "a"},
+		{IdempotencyKey: "b"},
+		{IdempotencyKey: "c"},
+	}
+	prepared := []natsPreparedMsg{
+		{idx: 0, partition: 1},
+		{idx: 1, partition: 1},
+		{idx: 2, partition: 2},
+	}
+
+	ok0 := make(chan *jetstream.PubAck, 1)
+	ok0 <- &jetstream.PubAck{Sequence: 10}
+	err1 := make(chan error, 1)
+	err1 <- errors.New("puback failed")
+	ok2 := make(chan *jetstream.PubAck, 1)
+	ok2 <- &jetstream.PubAck{Sequence: 12}
+
+	futures := []jetstream.PubAckFuture{
+		stubPubAckFuture{ok: ok0},
+		stubPubAckFuture{err: err1},
+		stubPubAckFuture{ok: ok2},
+	}
+
+	seqs, writtenEvs, writtenSeqs, notifyPartitions, err := collectBatchPubAcks(
+		context.Background(), evs, prepared, futures,
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "pubAck[1]")
+	assert.Equal(t, []uint64{10, 0, 12}, seqs)
+	require.Len(t, writtenEvs, 2)
+	assert.Equal(t, "a", writtenEvs[0].IdempotencyKey)
+	assert.Equal(t, "c", writtenEvs[1].IdempotencyKey)
+	assert.Equal(t, []uint64{10, 12}, writtenSeqs)
+	assert.Equal(t, map[uint32]struct{}{1: {}, 2: {}}, notifyPartitions)
+}
+
+func TestCollectBatchPubAcks_SkipsDuplicates(t *testing.T) {
+	evs := []*event.ChangeEvent{{IdempotencyKey: "dup"}}
+	prepared := []natsPreparedMsg{{idx: 0, partition: 0}}
+	ok := make(chan *jetstream.PubAck, 1)
+	ok <- &jetstream.PubAck{Sequence: 99, Duplicate: true}
+	seqs, writtenEvs, writtenSeqs, notifyPartitions, err := collectBatchPubAcks(
+		context.Background(), evs, prepared, []jetstream.PubAckFuture{stubPubAckFuture{ok: ok}},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, []uint64{0}, seqs)
+	assert.Empty(t, writtenEvs)
+	assert.Empty(t, writtenSeqs)
+	assert.Empty(t, notifyPartitions)
+}

--- a/internal/eventlog/nats_test.go
+++ b/internal/eventlog/nats_test.go
@@ -308,3 +308,67 @@ func TestNatsEventLog_RegisterObserver_ConcurrentAppendAndUnregister(t *testing.
 	close(stop)
 	wg.Wait()
 }
+
+// selfUnregisterObserver calls its unregister func from ObserveAppend. Used to
+// prove notifyObservers does not hold obsMu across callbacks.
+type selfUnregisterObserver struct {
+	unregister func()
+	mu         sync.Mutex
+	keys       []string
+}
+
+func (s *selfUnregisterObserver) ObserveAppend(evs []*event.ChangeEvent, _ []uint64) {
+	s.mu.Lock()
+	for _, ev := range evs {
+		s.keys = append(s.keys, ev.IdempotencyKey)
+	}
+	s.mu.Unlock()
+	if s.unregister != nil {
+		s.unregister()
+	}
+}
+
+func (s *selfUnregisterObserver) allKeys() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]string, len(s.keys))
+	copy(out, s.keys)
+	return out
+}
+
+// TestNatsEventLog_RegisterObserver_SelfUnregisterDuringCallback is the
+// deadlock regression: unregister takes obsMu.Lock, so ObserveAppend must not
+// run while notifyObservers still holds obsMu.RLock.
+func TestNatsEventLog_RegisterObserver_SelfUnregisterDuringCallback(t *testing.T) {
+	el := openTestNatsEventLog(t)
+
+	self := &selfUnregisterObserver{}
+	self.unregister = el.RegisterObserver(self)
+	kept := &recordingObserver{}
+	unregisterKept := el.RegisterObserver(kept)
+
+	ev1 := makeNatsEvent("nats:self-unreg:1:insert:0/1", `{"id": 1}`)
+	done := make(chan error, 1)
+	go func() {
+		_, err := el.Append(ev1)
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		require.NoError(t, err, "Append must complete when an observer unregisters itself")
+	case <-time.After(5 * time.Second):
+		t.Fatal("Append deadlocked: observer unregistered while obsMu was held")
+	}
+
+	assert.Equal(t, []string{ev1.IdempotencyKey}, self.allKeys())
+	assert.Equal(t, []string{ev1.IdempotencyKey}, kept.allKeys(),
+		"snapshot observers captured before unregister still receive this append")
+
+	ev2 := makeNatsEvent("nats:self-unreg:2:insert:0/2", `{"id": 2}`)
+	_, err := el.Append(ev2)
+	require.NoError(t, err)
+	assert.Equal(t, []string{ev1.IdempotencyKey}, self.allKeys(),
+		"self-unregistered observer must not see later appends")
+	assert.ElementsMatch(t, []string{ev1.IdempotencyKey, ev2.IdempotencyKey}, kept.allKeys())
+	unregisterKept()
+}

--- a/internal/eventlog/nats_test.go
+++ b/internal/eventlog/nats_test.go
@@ -6,10 +6,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/olucasandrade/kaptanto/internal/event"
@@ -211,4 +213,98 @@ func TestNatsEventLogPartitionIsolation(t *testing.T) {
 		require.NotEqual(t, evB.IdempotencyKey, e.Event.IdempotencyKey,
 			"event from partition B must not appear in partition A reads")
 	}
+}
+
+// TestNatsEventLog_ImplementsAppendObservable is the compile/runtime gate
+// that cluster backfill depends on: without this interface, WatermarkChecker
+// falls back to paging ReadPartition on every ShouldEmit.
+func TestNatsEventLog_ImplementsAppendObservable(t *testing.T) {
+	el := openTestNatsEventLog(t)
+	_, ok := any(el).(eventlog.AppendObservable)
+	require.True(t, ok, "NatsEventLog must implement AppendObservable")
+}
+
+// TestNatsEventLog_RegisterObserver_SyncAfterPubAck verifies the
+// AppendObserver contract for the NATS EventLog: observers fire
+// synchronously after a successful (non-duplicate) PubAck and before
+// Append/AppendBatch returns. Duplicates (seq==0) are never observed.
+func TestNatsEventLog_RegisterObserver_SyncAfterPubAck(t *testing.T) {
+	el := openTestNatsEventLog(t)
+
+	obs := &recordingObserver{}
+	unregister := el.RegisterObserver(obs)
+
+	ev1 := makeNatsEvent("nats:obs:1:insert:0/1", `{"id": 1}`)
+	seq1, err := el.Append(ev1)
+	require.NoError(t, err)
+	require.Greater(t, seq1, uint64(0))
+	require.Equal(t, []string{ev1.IdempotencyKey}, obs.allKeys(),
+		"observer must see the event before Append returns (synchronous after PubAck)")
+
+	evs := []*event.ChangeEvent{
+		makeNatsEvent("nats:obs:2:insert:0/2", `{"id": 2}`),
+		makeNatsEvent("nats:obs:3:insert:0/3", `{"id": 3}`),
+	}
+	seqs, err := el.AppendBatch(evs)
+	require.NoError(t, err)
+	require.Greater(t, seqs[0], uint64(0))
+	require.Greater(t, seqs[1], uint64(0))
+
+	assert.ElementsMatch(t, []string{ev1.IdempotencyKey, evs[0].IdempotencyKey, evs[1].IdempotencyKey}, obs.allKeys(),
+		"observer must see every non-duplicate event from Append and AppendBatch")
+
+	_, err = el.Append(ev1)
+	require.NoError(t, err)
+	_, err = el.AppendBatch(evs)
+	require.NoError(t, err)
+	assert.Len(t, obs.allKeys(), 3, "duplicate appends must not generate additional observer calls")
+
+	unregister()
+	ev4 := makeNatsEvent("nats:obs:4:insert:0/4", `{"id": 4}`)
+	_, err = el.Append(ev4)
+	require.NoError(t, err)
+	assert.Len(t, obs.allKeys(), 3, "unregistered observer must not receive further calls")
+
+	unregister()
+}
+
+// TestNatsEventLog_RegisterObserver_ConcurrentAppendAndUnregister exercises
+// RegisterObserver's synchronization under concurrent Append while another
+// goroutine registers/unregisters.
+func TestNatsEventLog_RegisterObserver_ConcurrentAppendAndUnregister(t *testing.T) {
+	el := openTestNatsEventLog(t)
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		i := 0
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			ev := makeNatsEvent(fmt.Sprintf("nats:obs-race:%d:insert:0/%d", i, i), fmt.Sprintf(`{"id": %d}`, i))
+			_, err := el.Append(ev)
+			assert.NoError(t, err)
+			i++
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 50; i++ {
+			obs := &recordingObserver{}
+			unregister := el.RegisterObserver(obs)
+			unregister()
+		}
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	close(stop)
+	wg.Wait()
 }


### PR DESCRIPTION
## Summary

- **Source fix plan:** `.claude/fix-plans/cluster-watermark-nats-index-20260818-213000.md`
- **Problem:** `WatermarkChecker` uses the O(1) in-memory index only when `EventLog` implements `AppendObservable`. Badger does; NATS did not. Cluster backfill therefore took the `shouldEmitScan` path (~33.7 ms/op vs ~574 ns indexed on 100k entries), paging `ReadPartition` for every snapshot row.
- **Introduced by:** index path https://github.com/olucasandrade/kaptanto/pull/33 ; NATS gap https://github.com/olucasandrade/kaptanto/commit/911ae3f053d3fa58e6c92ffda6ff467d4a636130
- **Implementation:** `NatsEventLog` now implements `AppendObservable`. `RegisterObserver` dispatches synchronously **after** a successful non-duplicate PubAck (and never before PubAck, never for `seq==0` duplicates), matching Badger so `StartTable` can build the indexed map in cluster mode. `ReadPartition` / OrderedConsumer is unchanged.

## Test plan

- [x] `CGO_ENABLED=0 go test ./internal/eventlog -count=1` — pass (7.3s)
- [x] `CGO_ENABLED=0 go test ./internal/backfill -count=1` — pass (129s)
- [x] `CGO_ENABLED=0 go test ./internal/enrich -count=1` — pass (enrich wrap still forwards `AppendObservable`)
- [x] `CGO_ENABLED=0 go test ./internal/backfill -bench BenchmarkShouldEmit_ -benchtime=3x -count=1`
  - ScanPath_100kPartition: 6.54 ms/op
  - IndexedPath_100kPartition: 264 ns/op

## Residual risk

- Observer still fires only on the appending node. Multi-node cluster relies on `StartTable`'s stream scan for a consistent historical view; live index updates are local to the writer (typically the HA leader).
- Index memory on large tables is still bounded by `defaultMaxIndexKeys` (over-cap falls back to scan).
- A 1M-row live cluster wall-clock bench (indexed vs scan, Docker) was not run and should be done before treating this as a production throughput proof.
- `ReadPartition` OrderedConsumer paging remains a separate plan/PR; this change only adds the observer so cluster mode can avoid that path for `ShouldEmit`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Review findings

No blocking correctness, security, or data-loss issues found in the provided changes.

`NatsEventLog` now supports `AppendObservable`. Observers receive synchronous notifications for acknowledged, non-duplicate events. Batch notifications include acknowledged events even when another PubAck fails. Observer snapshots prevent callback-driven unregistration deadlocks. The tests cover duplicate suppression, unregistration, concurrent appends, batch partial failure, and NATS-backed indexed watermarking.

Residual risks remain:

- Live observer updates are local to each `NatsEventLog` instance.
- The `defaultMaxIndexKeys` limit can affect indexed backfill behavior for large partitions.
- The 1M-row live cluster benchmark is not covered.

Document and monitor these risks before relying on indexed backfill at larger production scales.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->