### PR TITLE
fix(landing): render full docs HTML on crawlable /docs/[slug] routes

### DIFF
--- a/landing/src/components/docs/DocsViewer.tsx
+++ b/landing/src/components/docs/DocsViewer.tsx
@@ -1,36 +1,27 @@
 import { component$, useVisibleTask$ } from "@builder.io/qwik";
 import type { Signal } from "@builder.io/qwik";
-import { DOCS_CONTENT, SIDEBAR, DOC_FLOW } from "../../data/docs-content";
+import { useLocation } from "@builder.io/qwik-city";
+import { SIDEBAR } from "../../data/docs-content";
+import { isDocsPath, renderDocPageHtml } from "../../data/docs-html";
 
 interface DocsViewerProps {
   currentDoc: Signal<string | null>;
 }
 
-function docLabel(id: string): string {
-  for (const section of SIDEBAR) {
-    for (const [slug, label] of section.items) {
-      if (slug === id) return label;
-    }
-  }
-  return DOCS_CONTENT[id]?.title ?? id;
-}
-
-function buildNextSteps(id: string): string {
-  const i = DOC_FLOW.indexOf(id);
-  if (i === -1) return "";
-  const next1 = DOC_FLOW[(i + 1) % DOC_FLOW.length];
-  const next2 = DOC_FLOW[(i + 2) % DOC_FLOW.length];
-  return `<h2 class="dh2">Next steps</h2><div class="dcards">
-<a class="dcard" href="/docs/${next1}" onclick="return window.__go('${next1}')"><h4>${docLabel(next1)}</h4><p>Next page.</p></a>
-<a class="dcard" href="/docs/${next2}" onclick="return window.__go('${next2}')"><h4>${docLabel(next2)}</h4><p>Then read this.</p></a>
-</div>`;
-}
-
 export const DocsViewer = component$<DocsViewerProps>(({ currentDoc }) => {
-  // Register window.__go so onclick="go(...)" handlers in the docs HTML work.
+  const loc = useLocation();
+  const docsRoute = isDocsPath(loc.url.pathname);
+
+  // Register window.__go / go() so in-doc handlers work.
+  // On /docs/[slug], navigate to the crawlable URL; on /?doc=, keep the SPA.
   // Content is static, trusted HTML from src/data/docs-content.ts — not user input.
+  // eslint-disable-next-line qwik/no-use-visible-task
   useVisibleTask$(() => {
     const go = (id: string) => {
+      if (isDocsPath(window.location.pathname)) {
+        window.location.assign(`/docs/${id}`);
+        return false;
+      }
       currentDoc.value = id;
       window.history.pushState({}, "", `/?doc=${id}`);
       window.scrollTo(0, 0);
@@ -40,6 +31,7 @@ export const DocsViewer = component$<DocsViewerProps>(({ currentDoc }) => {
     (window as any).go = go;
   });
 
+  // eslint-disable-next-line qwik/no-use-visible-task
   useVisibleTask$(({ track }) => {
     track(() => currentDoc.value);
     requestAnimationFrame(() => {
@@ -54,9 +46,9 @@ export const DocsViewer = component$<DocsViewerProps>(({ currentDoc }) => {
   });
 
   const id = currentDoc.value ?? "docs-intro";
-  const doc = DOCS_CONTENT[id];
+  const content = renderDocPageHtml(id);
 
-  if (!doc) {
+  if (!content) {
     return (
       <div class="dl">
         <main class="dc">
@@ -65,9 +57,6 @@ export const DocsViewer = component$<DocsViewerProps>(({ currentDoc }) => {
       </div>
     );
   }
-
-  // Trusted static content from docs-content.ts — safe to use dangerouslySetInnerHTML.
-  const content = `<div class="dhead"><img src="/logo.png" alt="Kaptanto logo" class="dlg"><h1>${doc.title}</h1></div><p class="dsub">${doc.sub}</p>${doc.body}${buildNextSteps(id)}`;
 
   return (
     <div class="dl">
@@ -90,6 +79,7 @@ export const DocsViewer = component$<DocsViewerProps>(({ currentDoc }) => {
                   class={`dsa${slug === id ? " act" : ""}`}
                   href={`/docs/${slug}`}
                   onClick$={(e) => {
+                    if (docsRoute) return;
                     e.preventDefault();
                     currentDoc.value = slug;
                     window.history.pushState({}, "", `/?doc=${slug}`);

--- a/landing/src/components/nav/Nav.tsx
+++ b/landing/src/components/nav/Nav.tsx
@@ -1,11 +1,15 @@
 import { component$, useSignal, useVisibleTask$ } from "@builder.io/qwik";
 import type { Signal } from "@builder.io/qwik";
+import { useLocation } from "@builder.io/qwik-city";
+import { isDocsPath } from "../../data/docs-html";
 
 interface NavProps {
   currentDoc: Signal<string | null>;
 }
 
 export const Nav = component$<NavProps>(({ currentDoc }) => {
+  const loc = useLocation();
+  const docsRoute = isDocsPath(loc.url.pathname);
   const isMenuOpen = useSignal(false);
   const isLanding = !currentDoc.value;
   const stars = useSignal<string | null>(null);
@@ -35,19 +39,23 @@ export const Nav = component$<NavProps>(({ currentDoc }) => {
   return (
     <nav class="nav">
       <div class="ni">
-        <div
+        <a
+          href="/"
           class="nb"
-          onClick$={() => {
+          onClick$={(e) => {
+            if (docsRoute) return;
+            e.preventDefault();
             currentDoc.value = null;
           }}
         >
           <img src="/logo.png" alt="Kaptanto logo" class="nlg" />
           kaptanto
-        </div>
+        </a>
         <div class={`nl${isMenuOpen.value ? " open" : ""}`} id="navL">
           <a
             href="/"
             onClick$={(e) => {
+              if (docsRoute) return;
               e.preventDefault();
               currentDoc.value = null;
               window.scrollTo(0, 0);
@@ -58,8 +66,9 @@ export const Nav = component$<NavProps>(({ currentDoc }) => {
             Home
           </a>
           <a
-            href="/?doc=docs-intro"
+            href={docsRoute ? "/docs/docs-intro" : "/?doc=docs-intro"}
             onClick$={(e) => {
+              if (docsRoute) return;
               e.preventDefault();
               currentDoc.value = "docs-intro";
               window.scrollTo(0, 0);
@@ -70,32 +79,36 @@ export const Nav = component$<NavProps>(({ currentDoc }) => {
             Docs
           </a>
           <a
-            href="#features"
+            href={docsRoute ? "/#features" : "#features"}
             onClick$={() => {
+              if (docsRoute) return;
               currentDoc.value = null;
             }}
           >
             Features
           </a>
           <a
-            href="#compare"
+            href={docsRoute ? "/#compare" : "#compare"}
             onClick$={() => {
+              if (docsRoute) return;
               currentDoc.value = null;
             }}
           >
             Compare
           </a>
           <a
-            href="#changelog"
+            href={docsRoute ? "/#changelog" : "#changelog"}
             onClick$={() => {
+              if (docsRoute) return;
               currentDoc.value = null;
             }}
           >
             Changelog
           </a>
           <a
-            href="/?doc=docs-benchmarks"
+            href={docsRoute ? "/docs/docs-benchmarks" : "/?doc=docs-benchmarks"}
             onClick$={(e) => {
+              if (docsRoute) return;
               e.preventDefault();
               currentDoc.value = "docs-benchmarks";
               window.scrollTo(0, 0);

--- a/landing/src/data/docs-html.ts
+++ b/landing/src/data/docs-html.ts
@@ -1,0 +1,56 @@
+import { DOCS_CONTENT, SIDEBAR, DOC_FLOW } from "./docs-content";
+
+/** True for the crawlable docs index and /docs/[slug] routes. */
+export function isDocsPath(pathname: string): boolean {
+  return pathname === "/docs" || pathname.startsWith("/docs/");
+}
+
+export function docHref(id: string): string {
+  return `/docs/${id}`;
+}
+
+export function docLabel(id: string): string {
+  for (const section of SIDEBAR) {
+    for (const [slug, label] of section.items) {
+      if (slug === id) return label;
+    }
+  }
+  return DOCS_CONTENT[id]?.title ?? id;
+}
+
+/**
+ * Rewrite SPA-only go() handlers in trusted DOCS_CONTENT HTML into crawlable
+ * /docs/[slug] links. window.__go still intercepts clicks on the interactive
+ * /?doc= view; without JS the hrefs work on the slug routes.
+ */
+export function rewriteDocLinks(html: string): string {
+  return html
+    .replace(
+      /<div class="dcard" onclick="go\('([^']+)'\)">([\s\S]*?)<\/div>/g,
+      (_match, slug: string, inner: string) =>
+        `<a class="dcard" href="${docHref(slug)}" onclick="return window.__go && window.__go('${slug}')">${inner}</a>`,
+    )
+    .replace(
+      /<a onclick="go\('([^']+)'\)">/g,
+      (_match, slug: string) =>
+        `<a href="${docHref(slug)}" onclick="return window.__go && window.__go('${slug}')">`,
+    );
+}
+
+export function buildNextSteps(id: string): string {
+  const i = DOC_FLOW.indexOf(id);
+  if (i === -1) return "";
+  const next1 = DOC_FLOW[(i + 1) % DOC_FLOW.length];
+  const next2 = DOC_FLOW[(i + 2) % DOC_FLOW.length];
+  return `<h2 class="dh2">Next steps</h2><div class="dcards">
+<a class="dcard" href="${docHref(next1)}" onclick="return window.__go && window.__go('${next1}')"><h4>${docLabel(next1)}</h4><p>Next page.</p></a>
+<a class="dcard" href="${docHref(next2)}" onclick="return window.__go && window.__go('${next2}')"><h4>${docLabel(next2)}</h4><p>Then read this.</p></a>
+</div>`;
+}
+
+/** Same HTML DocsViewer SSR/SSG-emits so /docs/[slug] cannot drift from /?doc=. */
+export function renderDocPageHtml(id: string): string | null {
+  const doc = DOCS_CONTENT[id];
+  if (!doc) return null;
+  return `<div class="dhead"><img src="/logo.png" alt="Kaptanto logo" class="dlg"><h1>${doc.title}</h1></div><p class="dsub">${doc.sub}</p>${rewriteDocLinks(doc.body)}${buildNextSteps(id)}`;
+}

--- a/landing/src/routes/docs/[slug]/index.tsx
+++ b/landing/src/routes/docs/[slug]/index.tsx
@@ -1,14 +1,38 @@
-import { component$ } from "@builder.io/qwik";
-import type { DocumentHead } from "@builder.io/qwik-city";
+import { component$, useSignal, useTask$ } from "@builder.io/qwik";
+import type {
+  DocumentHead,
+  StaticGenerateHandler,
+} from "@builder.io/qwik-city";
 import { useLocation } from "@builder.io/qwik-city";
+import { DocsViewer } from "../../../components/docs/DocsViewer";
+import { Nav } from "../../../components/nav/Nav";
 import { SEO_DOCS, SEO_DOCS_MAP } from "../../../data/docs";
+import { DOCS_CONTENT } from "../../../data/docs-content";
+
+const siteStyleLinks = [
+  { rel: "preconnect", href: "https://fonts.googleapis.com" },
+  {
+    rel: "preconnect",
+    href: "https://fonts.gstatic.com",
+    crossorigin: "anonymous" as const,
+  },
+  {
+    rel: "stylesheet",
+    href: "https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=IBM+Plex+Sans:wght@300;400;500;600;700&display=swap",
+  },
+  { rel: "stylesheet", href: "/legacy.css" },
+];
 
 export default component$(() => {
   const loc = useLocation();
-  const slug = loc.params.slug;
-  const doc = SEO_DOCS_MAP.get(slug);
+  const currentDoc = useSignal<string | null>(loc.params.slug);
 
-  if (!doc) {
+  useTask$(({ track }) => {
+    currentDoc.value = track(() => loc.params.slug);
+  });
+
+  const slug = loc.params.slug;
+  if (!SEO_DOCS_MAP.has(slug) || !DOCS_CONTENT[slug]) {
     return (
       <main class="seo-docs">
         <div class="seo-wrap">
@@ -21,25 +45,19 @@ export default component$(() => {
     );
   }
 
-  const idx = SEO_DOCS.findIndex((d) => d.slug === slug);
-  const next = SEO_DOCS[(idx + 1) % SEO_DOCS.length];
-  const next2 = SEO_DOCS[(idx + 2) % SEO_DOCS.length];
-
   return (
-    <main class="seo-docs">
-      <div class="seo-wrap">
-        <p class="seo-kicker">Kaptanto Docs</p>
-        <h1>{doc.title}</h1>
-        <p>{doc.description}</p>
-        <nav class="seo-nav" aria-label="Next documentation pages">
-          <a href={`/docs/${next.slug}`}>Next: {next.title}</a>
-          <a href={`/docs/${next2.slug}`}>Then: {next2.title}</a>
-          <a href="/?doc=docs-intro">Open interactive docs view</a>
-        </nav>
-      </div>
-    </main>
+    <>
+      <Nav currentDoc={currentDoc} />
+      <DocsViewer currentDoc={currentDoc} />
+    </>
   );
 });
+
+export const onStaticGenerate: StaticGenerateHandler = async () => {
+  return {
+    params: SEO_DOCS.map((d) => ({ slug: d.slug })),
+  };
+};
 
 export const head: DocumentHead = ({ params }) => {
   const doc = SEO_DOCS_MAP.get(params.slug);
@@ -62,5 +80,6 @@ export const head: DocumentHead = ({ params }) => {
       { property: "og:image", content: "https://kaptan.to/logo.png" },
       { name: "twitter:card", content: "summary" },
     ],
+    links: siteStyleLinks,
   };
 };

--- a/landing/test/docs-slug-route.test.ts
+++ b/landing/test/docs-slug-route.test.ts
@@ -1,0 +1,71 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { DOCS_CONTENT } from "../src/data/docs-content";
+import { SEO_DOCS } from "../src/data/docs";
+import { renderDocPageHtml, rewriteDocLinks } from "../src/data/docs-html";
+
+const landingRoot = path.dirname(fileURLToPath(import.meta.url));
+
+describe("crawlable /docs/[slug] routes render real docs HTML", () => {
+  const slugRoute = readFileSync(
+    path.join(
+      landingRoot,
+      "..",
+      "src",
+      "routes",
+      "docs",
+      "[slug]",
+      "index.tsx",
+    ),
+    "utf8",
+  );
+
+  it("mounts Nav and DocsViewer on the slug route", () => {
+    expect(slugRoute).toContain("DocsViewer");
+    expect(slugRoute).toMatch(/<Nav /);
+    expect(slugRoute).toContain("/legacy.css");
+  });
+
+  it("docs-consistency HTML includes Event Log / Badger", () => {
+    const html = renderDocPageHtml("docs-consistency");
+    expect(html).toBeTruthy();
+    expect(html).toContain("Event Log");
+    expect(html).toContain("Badger");
+  });
+
+  it("rewrites in-doc go() links to crawlable /docs/ hrefs", () => {
+    const html = renderDocPageHtml("docs-intro");
+    expect(html).toBeTruthy();
+    expect(html).toContain('href="/docs/docs-quickstart"');
+    expect(html).toContain('href="/docs/docs-schema"');
+    expect(html).not.toContain('onclick="go(');
+  });
+
+  it("rewrites every go() target in DOCS_CONTENT to a /docs/ href", () => {
+    for (const [slug, doc] of Object.entries(DOCS_CONTENT)) {
+      if (!doc) continue;
+      const html = rewriteDocLinks(doc.body);
+      const targets = [...doc.body.matchAll(/go\('([^']+)'\)/g)].map(
+        (m) => m[1],
+      );
+      for (const target of targets) {
+        expect(html, `${slug} missing href for ${target}`).toContain(
+          `href="/docs/${target}"`,
+        );
+      }
+      expect(html, `${slug} still has SPA-only go()`).not.toContain(
+        'onclick="go(',
+      );
+    }
+  });
+
+  it("renderDocPageHtml covers every SEO slug", () => {
+    for (const { slug } of SEO_DOCS) {
+      const html = renderDocPageHtml(slug);
+      expect(html, slug).toBeTruthy();
+      expect(html).toContain(DOCS_CONTENT[slug]!.title);
+    }
+  });
+});


### PR DESCRIPTION
## Source plan

`.claude/fix-plans/landing-crawlable-docs-slug-20260818-213000.md`

## Problem

`landing/src/routes/docs/[slug]/index.tsx` rendered only the SEO title, description, and next-page links. `DOCS_CONTENT` HTML, Nav, and DocsViewer lived on the client `/?doc=` view, so crawlers and open-in-new-tab missed CHK-01, outputs, and config.

## Introduced by

https://github.com/olucasandrade/kaptanto/commit/d10b00a54dbcb8cb90683e25d53ff1b825b17874

## Implementation

- Mount Nav + DocsViewer on `/docs/[slug]` so SSR emits the same `DOCS_CONTENT` HTML as the interactive viewer.
- Keep `/?doc=` as the SPA: sidebar and in-doc clicks still `pushState` there.
- Rewrite `onclick="go('…')"` handlers to crawlable `/docs/[slug]` hrefs (shared `renderDocPageHtml` / `rewriteDocLinks`) so links work without JS; `window.go` / `__go` on slug routes `assign` to `/docs/[id]`.
- Load `/legacy.css` and fonts on the slug routes; prerender every SEO slug via `onStaticGenerate`.

## Validation

- `npx prettier --write` on touched landing files
- `npm test` (vitest) — 4 files, 134 passed, including new `landing/test/docs-slug-route.test.ts`
- `npm run build.types` — pass
- `npm run lint` — 0 errors (pre-existing warnings only)
- `npm run build` — pass
- `npx wrangler pages dev ./dist` + `curl -L http://127.0.0.1:8788/docs/docs-consistency/` — HTML contains Event Log / Badger, `docSidebar`, `class="nav"`, rewritten `/docs/` hrefs, no leftover `onclick="go("`

## Residual risk

- Cloudflare Pages still SSRs these routes rather than emitting static `index.html` files; crawlers that do not execute JS still receive the full HTML (verified via curl). Qwik redirects `/docs/slug` → `/docs/slug/` (301).
- In-doc `go()` on slug routes does a full `location.assign` rather than Qwik client navigation.
- `/docs` index remains a listing page, not the interactive viewer.