### PR TITLE
fix(postgres): reset completed backfill after replication slot loss

### DIFF
--- a/internal/backfill/backfill.go
+++ b/internal/backfill/backfill.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"sync"
 	"time"
 
 	"github.com/jackc/pglogrepl"
@@ -42,6 +43,11 @@ type BackfillEngine interface {
 	// HasPendingBackfills returns true if any configured table has a pending or
 	// running backfill that has not yet completed.
 	HasPendingBackfills() bool
+	// ResetForSlotLoss clears persisted snapshot progress so the next Run starts
+	// from page one with a new SnapshotID/SnapshotLSN. SRC-06: a recreated slot
+	// starts at current WAL, so rows changed only in the lost gap must be
+	// re-emitted as OpRead. stream_only tables are left untouched.
+	ResetForSlotLoss(ctx context.Context, snapshotLSN uint64) error
 }
 
 // ---------------------------------------------------------------------------
@@ -92,7 +98,13 @@ type BackfillEngineImpl struct {
 	openConnFn    OpenConnFn
 	// watermark is optional; nil disables watermark deduplication.
 	watermark *WatermarkChecker
+	// mu serializes Run and ResetForSlotLoss so a slot-loss reset cannot race
+	// an in-flight snapshot's LoadState/SaveState.
+	mu sync.Mutex
 }
+
+// Compile-time assertion: BackfillEngineImpl must satisfy BackfillEngine.
+var _ BackfillEngine = (*BackfillEngineImpl)(nil)
 
 // NewBackfillEngine creates a BackfillEngineImpl with the given dependencies.
 // appendFn must not be nil. appendBatchFn must not be nil. openConnFn must not be nil.
@@ -164,8 +176,55 @@ func (b *BackfillEngineImpl) HasPendingBackfills() bool {
 	return false
 }
 
+// ResetForSlotLoss clears persisted snapshot progress so the next Run starts
+// from page one. It waits for an in-flight Run (same mutex) so a still-running
+// snapshot cannot race store writes. Idempotency keys stay in the EVT-03
+// format; a new SnapshotID lets EventLog accept the re-snapshot, including
+// gap rows whose previous OpRead used a different snapshot_id.
+func (b *BackfillEngineImpl) ResetForSlotLoss(ctx context.Context, snapshotLSN uint64) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	now := time.Now()
+	for _, cfg := range b.configs {
+		if cfg.Strategy == "stream_only" {
+			continue
+		}
+		state, err := b.store.LoadState(ctx, cfg.SourceID, cfg.Table)
+		if err != nil {
+			return fmt.Errorf("reset slot-loss state %s/%s: %w", cfg.SourceID, cfg.Table, err)
+		}
+		if state == nil {
+			state = &BackfillState{
+				SourceID: cfg.SourceID,
+				Table:    cfg.Table,
+				Strategy: cfg.Strategy,
+			}
+		}
+		state.Status = "pending"
+		state.Strategy = cfg.Strategy
+		state.CursorKey = nil
+		state.TotalRows = 0
+		state.ProcessedRows = 0
+		state.SnapshotLSN = snapshotLSN
+		state.SnapshotID = newSnapshotID(cfg.SourceID, cfg.Table)
+		state.StartedAt = time.Time{}
+		state.UpdatedAt = now
+		if err := b.store.SaveState(ctx, state); err != nil {
+			return fmt.Errorf("save slot-loss reset %s/%s: %w", cfg.SourceID, cfg.Table, err)
+		}
+	}
+	return nil
+}
+
+func newSnapshotID(sourceID, table string) string {
+	return fmt.Sprintf("%s_%s_%d", sourceID, table, time.Now().UnixNano())
+}
+
 // Run executes all pending backfills in order.
 func (b *BackfillEngineImpl) Run(ctx context.Context) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
 	for _, cfg := range b.configs {
 		if err := b.runOne(ctx, cfg); err != nil {
 			return fmt.Errorf("backfill: run %s/%s: %w", cfg.SourceID, cfg.Table, err)
@@ -269,7 +328,7 @@ func (b *BackfillEngineImpl) snapshotTable(ctx context.Context, cfg BackfillConf
 	// Stable snapshotID for all rows in this run; persisted for crash-resume dedup.
 	snapshotID := state.SnapshotID
 	if snapshotID == "" {
-		snapshotID = fmt.Sprintf("%s_%s_%d", cfg.SourceID, cfg.Table, time.Now().UnixNano())
+		snapshotID = newSnapshotID(cfg.SourceID, cfg.Table)
 		state.SnapshotID = snapshotID
 	}
 

--- a/internal/backfill/snapshot_engine_test.go
+++ b/internal/backfill/snapshot_engine_test.go
@@ -13,6 +13,7 @@ import (
 	"encoding/json"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
@@ -73,18 +74,32 @@ func (r *fakeConnRows) Values() ([]any, error) {
 // pagination in the caller regardless of the LIMIT/OFFSET-free SQL text
 // snapshotTable actually generates (which this fake never parses).
 type fakeSnapshotConn struct {
-	cols       []string
-	pages      [][][]any
-	pageIdx    int
-	queryErr   error
-	closeCalls int
+	cols         []string
+	pages        [][][]any
+	pageIdx      int
+	queryErr     error
+	closeCalls   int
+	queries      []string
+	queryGate    chan struct{}
+	queryEntered chan struct{}
 }
 
 func (c *fakeSnapshotConn) QueryRow(_ context.Context, _ string, _ ...any) pgx.Row {
 	return fakeConnRow{}
 }
 
-func (c *fakeSnapshotConn) Query(_ context.Context, _ string, _ ...any) (pgx.Rows, error) {
+func (c *fakeSnapshotConn) Query(_ context.Context, sql string, _ ...any) (pgx.Rows, error) {
+	c.queries = append(c.queries, sql)
+	if c.queryEntered != nil {
+		select {
+		case <-c.queryEntered:
+		default:
+			close(c.queryEntered)
+		}
+	}
+	if c.queryGate != nil {
+		<-c.queryGate
+	}
 	if c.queryErr != nil {
 		return nil, c.queryErr
 	}
@@ -284,4 +299,186 @@ func TestSnapshotTable_FlushFailure_DoesNotAdvancePersistedCursor(t *testing.T) 
 		"persisted cursor must remain nil: the successful flush only updated an "+
 			"in-memory cursor/state that snapshotTable never got to persist before "+
 			"the second flush failed and aborted the page")
+}
+
+// TestResetForSlotLoss_CompletedStateRestartsFromPageOne is the SRC-06 gap
+// recovery case: a completed snapshot left CursorKey on the last PK, so a
+// naive Run no-ops and never re-emits rows changed only in the lost WAL gap.
+// After ResetForSlotLoss the snapshot starts from page one and emits the
+// gap row as OpRead.
+func TestResetForSlotLoss_CompletedStateRestartsFromPageOne(t *testing.T) {
+	store, err := backfill.OpenSQLiteBackfillStore(t.TempDir() + "/backfill.db")
+	require.NoError(t, err)
+	defer func() { _ = store.Close() }()
+
+	cfg := backfill.BackfillConfig{
+		SourceID:      "pg1",
+		Schema:        "public",
+		Table:         "orders",
+		Strategy:      "snapshot_and_stream",
+		PKCols:        []string{"id"},
+		NumPartitions: 64,
+	}
+
+	cursorKey, err := json.Marshal([]any{int64(2)})
+	require.NoError(t, err)
+	require.NoError(t, store.SaveState(context.Background(), &backfill.BackfillState{
+		SourceID:      "pg1",
+		Table:         "orders",
+		Status:        "completed",
+		Strategy:      "snapshot_and_stream",
+		CursorKey:     cursorKey,
+		ProcessedRows: 2,
+		SnapshotID:    "old_snap",
+		SnapshotLSN:   100,
+	}))
+
+	conn := &fakeSnapshotConn{
+		cols: []string{"id", "status"},
+		pages: [][][]any{
+			{
+				{int64(1), "pending"},
+				{int64(2), "shipped"}, // gap UPDATE lost with the dropped slot
+			},
+		},
+	}
+
+	idGen := event.NewIDGenerator()
+	bl := &countingBatchLog{}
+	eng := backfill.NewBackfillEngineWithBatch(
+		[]backfill.BackfillConfig{cfg}, store, idGen,
+		bl.appendSingle, bl.appendBatch,
+		func(_ context.Context) (backfill.SnapshotConn, error) { return conn, nil },
+	)
+
+	// Without reset, completed state makes Run a no-op.
+	require.NoError(t, eng.Run(context.Background()))
+	assert.Empty(t, readEvents(bl.received), "completed backfill must not re-scan before reset")
+	assert.Empty(t, conn.queries)
+
+	const newLSN = uint64(999)
+	require.NoError(t, eng.ResetForSlotLoss(context.Background(), newLSN))
+
+	state, err := store.LoadState(context.Background(), "pg1", "orders")
+	require.NoError(t, err)
+	require.NotNil(t, state)
+	assert.Equal(t, "pending", state.Status)
+	assert.Nil(t, state.CursorKey)
+	assert.Equal(t, newLSN, state.SnapshotLSN)
+	assert.NotEqual(t, "old_snap", state.SnapshotID)
+	assert.NotEmpty(t, state.SnapshotID)
+	assert.True(t, eng.HasPendingBackfills())
+
+	require.NoError(t, eng.Run(context.Background()))
+
+	require.NotEmpty(t, conn.queries, "re-snapshot must query from page one")
+	assert.NotContains(t, conn.queries[0], ">",
+		"first snapshot query after reset must be BuildFirstQuery, not keyset resume")
+
+	got := readEvents(bl.received)
+	require.Len(t, got, 2, "both rows including the gap UPDATE must be emitted as OpRead")
+	var foundGap bool
+	for _, ev := range got {
+		assert.Equal(t, event.OpRead, ev.Operation)
+		assert.Contains(t, ev.IdempotencyKey, ":read:")
+		assert.NotContains(t, ev.IdempotencyKey, "old_snap",
+			"new SnapshotID must be used so EventLog does not drop the gap row as a dup")
+		if string(ev.Key) == `{"id":"2"}` {
+			foundGap = true
+			assert.Contains(t, string(ev.After), "shipped")
+		}
+	}
+	assert.True(t, foundGap, "gap row id=2 must be re-emitted as OpRead")
+}
+
+func TestResetForSlotLoss_SkipsStreamOnly(t *testing.T) {
+	store, err := backfill.OpenSQLiteBackfillStore(t.TempDir() + "/backfill.db")
+	require.NoError(t, err)
+	defer func() { _ = store.Close() }()
+
+	require.NoError(t, store.SaveState(context.Background(), &backfill.BackfillState{
+		SourceID: "pg1",
+		Table:    "orders",
+		Status:   "completed",
+		Strategy: "stream_only",
+	}))
+
+	eng := backfill.NewBackfillEngine(
+		[]backfill.BackfillConfig{{
+			SourceID: "pg1",
+			Table:    "orders",
+			Strategy: "stream_only",
+			PKCols:   []string{"id"},
+		}},
+		store, event.NewIDGenerator(),
+		func(context.Context, *event.ChangeEvent) error { return nil },
+		func(context.Context) (backfill.SnapshotConn, error) {
+			return nil, errors.New("stream_only must not open a snapshot connection")
+		},
+	)
+
+	require.NoError(t, eng.ResetForSlotLoss(context.Background(), 42))
+	state, err := store.LoadState(context.Background(), "pg1", "orders")
+	require.NoError(t, err)
+	require.NotNil(t, state)
+	assert.Equal(t, "completed", state.Status, "stream_only must not be reset on slot loss")
+}
+
+func TestResetForSlotLoss_WaitsForInFlightRun(t *testing.T) {
+	store, err := backfill.OpenSQLiteBackfillStore(t.TempDir() + "/backfill.db")
+	require.NoError(t, err)
+	defer func() { _ = store.Close() }()
+
+	cfg := backfill.BackfillConfig{
+		SourceID:      "pg1",
+		Schema:        "public",
+		Table:         "orders",
+		Strategy:      "snapshot_and_stream",
+		PKCols:        []string{"id"},
+		NumPartitions: 64,
+	}
+
+	entered := make(chan struct{})
+	gate := make(chan struct{})
+	conn := &fakeSnapshotConn{
+		cols:         []string{"id"},
+		pages:        [][][]any{idRows(1, 3)},
+		queryGate:    gate,
+		queryEntered: entered,
+	}
+
+	eng := backfill.NewBackfillEngineWithBatch(
+		[]backfill.BackfillConfig{cfg}, store, event.NewIDGenerator(),
+		func(context.Context, *event.ChangeEvent) error { return nil },
+		func(context.Context, []*event.ChangeEvent) error { return nil },
+		func(context.Context) (backfill.SnapshotConn, error) { return conn, nil },
+	)
+
+	runDone := make(chan error, 1)
+	go func() { runDone <- eng.Run(context.Background()) }()
+
+	select {
+	case <-entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for in-flight snapshot query")
+	}
+
+	resetDone := make(chan error, 1)
+	go func() { resetDone <- eng.ResetForSlotLoss(context.Background(), 7) }()
+
+	select {
+	case err := <-resetDone:
+		t.Fatalf("ResetForSlotLoss returned before Run finished: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(gate)
+	require.NoError(t, <-runDone)
+	require.NoError(t, <-resetDone)
+
+	state, err := store.LoadState(context.Background(), "pg1", "orders")
+	require.NoError(t, err)
+	require.NotNil(t, state)
+	assert.Equal(t, "pending", state.Status, "reset must run after in-flight snapshot completes")
+	assert.Nil(t, state.CursorKey)
 }

--- a/internal/source/postgres/connector.go
+++ b/internal/source/postgres/connector.go
@@ -114,6 +114,22 @@ func EvalSlotCheck(slotPresent, wasEverConnected bool) (needsSnapshot bool) {
 	return wasEverConnected
 }
 
+// ReplicationStartLSN returns the StartReplication LSN and the CHK-01 ack
+// floor after ensureSlot.
+//
+// Slot-loss (needsSnapshot=true): start at the new slot consistent point
+// and keep lastSavedLSN at 0 so we never confirm a lost-gap checkpoint.
+// Ordinary reconnect: resume at checkpoint+1 to skip the last delivered event.
+func ReplicationStartLSN(needsSnapshot bool, consistentPoint, checkpointLSN pglogrepl.LSN, hasCheckpoint bool) (startLSN, lastSavedLSN pglogrepl.LSN) {
+	if needsSnapshot {
+		return consistentPoint, 0
+	}
+	if !hasCheckpoint {
+		return 0, 0
+	}
+	return checkpointLSN + 1, checkpointLSN
+}
+
 // PostgresConnector implements the Postgres CDC source. It maintains a
 // replication connection (for WAL streaming) and a separate query connection
 // (for schema queries, slot/publication management, and lag monitoring).
@@ -365,7 +381,7 @@ func (c *PostgresConnector) connectAndStream(ctx context.Context, wasEverConnect
 	}
 
 	// 6. Ensure slot exists; detect missing slot after failover (SRC-06).
-	needsSnapshot, _, err := ensureSlot(ctx, replConn, queryConn, c.cfg.SlotName, wasEverConnected)
+	needsSnapshot, consistentPoint, err := ensureSlot(ctx, replConn, queryConn, c.cfg.SlotName, wasEverConnected)
 	if err != nil {
 		return err
 	}
@@ -380,15 +396,23 @@ func (c *PostgresConnector) connectAndStream(ctx context.Context, wasEverConnect
 		return fmt.Errorf("postgres: load checkpoint: %w", err)
 	}
 
-	// 8. Parse stored LSN; start from 0 on first run.
-	var startLSN pglogrepl.LSN
-	if lastLSNStr != "" {
-		startLSN, err = pglogrepl.ParseLSN(lastLSNStr)
+	// 8. Parse stored LSN; start from 0 on first run. Slot-loss recovery
+	// ignores the stale checkpoint and starts at the new slot consistent point.
+	var checkpointLSN pglogrepl.LSN
+	hasCheckpoint := lastLSNStr != ""
+	if hasCheckpoint {
+		checkpointLSN, err = pglogrepl.ParseLSN(lastLSNStr)
 		if err != nil {
 			return fmt.Errorf("postgres: parse checkpoint LSN %q: %w", lastLSNStr, err)
 		}
-		// 9. Advance by 1 to avoid re-delivering the last event (off-by-one).
-		startLSN++
+	}
+	startLSN, lastSavedLSN := ReplicationStartLSN(needsSnapshot, consistentPoint, checkpointLSN, hasCheckpoint)
+
+	// SRC-06: reset completed snapshot cursors before StartReplication so
+	// Run cannot no-op. Reset waits for an in-flight snapshot (same mutex)
+	// and is skipped on ordinary reconnects (needsSnapshot=false).
+	if err := c.resetBackfillOnSlotLoss(ctx, needsSnapshot, uint64(consistentPoint)); err != nil {
+		return err
 	}
 
 	// 10. Clear relation cache — new session; Postgres will re-send RelationMessages.
@@ -408,26 +432,9 @@ func (c *PostgresConnector) connectAndStream(ctx context.Context, wasEverConnect
 		return fmt.Errorf("postgres: start replication: %w", err)
 	}
 
-	// 12. Launch backfill goroutine: pending work exists (12a), or slot loss
-	// requires re-snapshot (12b, SRC-06). Merged into a single launch to prevent
-	// two concurrent bkEng.Run goroutines when both conditions are simultaneously
-	// true (post-failover reconnect with existing pending backfills).
-	// BackfillEngineImpl has no Run-level mutex; concurrent runs would race on
-	// LoadState/SaveState and snapshotTable.
-	// TODO(SRC-06): on slot loss (needsSnapshot=true), consider resetting cursor
-	// state to force a full re-snapshot; currently resumes from the stored cursor
-	// position which may miss rows changed during the WAL gap.
-	if c.backfillEng != nil && (c.backfillEng.HasPendingBackfills() || needsSnapshot) {
-		go func() {
-			if err := c.backfillEng.Run(ctx); err != nil && ctx.Err() == nil {
-				slog.Error("backfill engine: run failed",
-					"needs_snapshot", needsSnapshot,
-					"error", err)
-			}
-		}()
-	}
+	c.launchBackfill(ctx, needsSnapshot)
 
-	// 13. WAL lag monitoring goroutine (SRC-07).
+	// 12. WAL lag monitoring goroutine (SRC-07).
 	lagCtx, cancelLag := context.WithCancel(ctx)
 	defer cancelLag()
 	go func() {
@@ -443,12 +450,38 @@ func (c *PostgresConnector) connectAndStream(ctx context.Context, wasEverConnect
 		}
 	}()
 
-	// 14. ReceiveMessage loop (SRC-03).
-	var lastSavedLSN pglogrepl.LSN
-	if startLSN > 0 {
-		lastSavedLSN = startLSN - 1
-	}
+	// 13. ReceiveMessage loop (SRC-03).
 	return c.receiveLoop(ctx, replConn, lastSavedLSN)
+}
+
+// resetBackfillOnSlotLoss clears completed snapshot cursors on SRC-06 slot
+// loss. Ordinary reconnects (needsSnapshot=false) are a no-op.
+func (c *PostgresConnector) resetBackfillOnSlotLoss(ctx context.Context, needsSnapshot bool, snapshotLSN uint64) error {
+	if c.backfillEng == nil || !needsSnapshot {
+		return nil
+	}
+	if err := c.backfillEng.ResetForSlotLoss(ctx, snapshotLSN); err != nil {
+		return fmt.Errorf("postgres: reset backfill after slot loss: %w", err)
+	}
+	return nil
+}
+
+// launchBackfill starts at most one Run goroutine when pending work exists
+// or slot-loss recovery requested a re-snapshot.
+func (c *PostgresConnector) launchBackfill(ctx context.Context, needsSnapshot bool) {
+	if c.backfillEng == nil {
+		return
+	}
+	if !c.backfillEng.HasPendingBackfills() && !needsSnapshot {
+		return
+	}
+	go func() {
+		if err := c.backfillEng.Run(ctx); err != nil && ctx.Err() == nil {
+			slog.Error("backfill engine: run failed",
+				"needs_snapshot", needsSnapshot,
+				"error", err)
+		}
+	}()
 }
 
 // receiveLoop runs the core WAL message receive loop using pgconn.ReceiveMessage

--- a/internal/source/postgres/connector_slot_loss_test.go
+++ b/internal/source/postgres/connector_slot_loss_test.go
@@ -1,0 +1,111 @@
+package postgres
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/olucasandrade/kaptanto/internal/checkpoint"
+	"github.com/olucasandrade/kaptanto/internal/event"
+)
+
+type stubCheckpointStore struct{}
+
+func (stubCheckpointStore) Save(context.Context, string, string) error   { return nil }
+func (stubCheckpointStore) Load(context.Context, string) (string, error) { return "", nil }
+func (stubCheckpointStore) Close() error                                 { return nil }
+
+var _ checkpoint.CheckpointStore = stubCheckpointStore{}
+
+type recordingBackfillEngine struct {
+	resetCalls int32
+	pending    bool
+	resetLSN   uint64
+	runStarted chan struct{}
+}
+
+func (r *recordingBackfillEngine) Run(_ context.Context) error {
+	if r.runStarted != nil {
+		select {
+		case <-r.runStarted:
+		default:
+			close(r.runStarted)
+		}
+	}
+	return nil
+}
+
+func (r *recordingBackfillEngine) HasPendingBackfills() bool { return r.pending }
+
+func (r *recordingBackfillEngine) ResetForSlotLoss(_ context.Context, lsn uint64) error {
+	atomic.AddInt32(&r.resetCalls, 1)
+	r.resetLSN = lsn
+	r.pending = true
+	return nil
+}
+
+func newTestConnector(t *testing.T, eng *recordingBackfillEngine) *PostgresConnector {
+	t.Helper()
+	cfg := Config{DSN: "postgres://localhost/testdb", SourceID: "pg1"}
+	c := New(cfg, stubCheckpointStore{}, event.NewIDGenerator())
+	if eng != nil {
+		c.SetBackfillEngine(eng)
+	}
+	return c
+}
+
+func TestResetBackfillOnSlotLoss_OnlyWhenNeedsSnapshot(t *testing.T) {
+	eng := &recordingBackfillEngine{}
+	c := newTestConnector(t, eng)
+
+	if err := c.resetBackfillOnSlotLoss(context.Background(), false, 99); err != nil {
+		t.Fatalf("ordinary reconnect reset: %v", err)
+	}
+	if atomic.LoadInt32(&eng.resetCalls) != 0 {
+		t.Fatal("ordinary reconnect must not reset backfill state")
+	}
+
+	if err := c.resetBackfillOnSlotLoss(context.Background(), true, 99); err != nil {
+		t.Fatalf("slot-loss reset: %v", err)
+	}
+	if atomic.LoadInt32(&eng.resetCalls) != 1 {
+		t.Fatalf("slot-loss reset calls = %d, want 1", eng.resetCalls)
+	}
+	if eng.resetLSN != 99 {
+		t.Fatalf("reset LSN = %d, want 99", eng.resetLSN)
+	}
+}
+
+func TestResetBackfillOnSlotLoss_NilEngine(t *testing.T) {
+	c := newTestConnector(t, nil)
+	if err := c.resetBackfillOnSlotLoss(context.Background(), true, 1); err != nil {
+		t.Fatalf("nil engine: %v", err)
+	}
+}
+
+func TestLaunchBackfill_SlotLossLaunchesWithoutPending(t *testing.T) {
+	eng := &recordingBackfillEngine{runStarted: make(chan struct{})}
+	c := newTestConnector(t, eng)
+
+	c.launchBackfill(context.Background(), true)
+
+	select {
+	case <-eng.runStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("slot-loss must launch Run even when HasPendingBackfills is false")
+	}
+}
+
+func TestLaunchBackfill_OrdinaryReconnectWithoutPendingDoesNotLaunch(t *testing.T) {
+	eng := &recordingBackfillEngine{runStarted: make(chan struct{})}
+	c := newTestConnector(t, eng)
+
+	c.launchBackfill(context.Background(), false)
+
+	select {
+	case <-eng.runStarted:
+		t.Fatal("ordinary reconnect with no pending backfills must not launch Run")
+	case <-time.After(50 * time.Millisecond):
+	}
+}

--- a/internal/source/postgres/connector_test.go
+++ b/internal/source/postgres/connector_test.go
@@ -315,7 +315,8 @@ type mockBackfillEngine struct {
 	runCalled  chan struct{}
 }
 
-func (m *mockBackfillEngine) HasPendingBackfills() bool { return m.hasPending }
+func (m *mockBackfillEngine) HasPendingBackfills() bool                          { return m.hasPending }
+func (m *mockBackfillEngine) ResetForSlotLoss(_ context.Context, _ uint64) error { return nil }
 func (m *mockBackfillEngine) Run(_ context.Context) error {
 	if m.runCalled != nil {
 		close(m.runCalled)
@@ -401,6 +402,9 @@ type mockBackfillEngineSimple struct{ pending bool }
 
 func (m *mockBackfillEngineSimple) Run(_ context.Context) error { return nil }
 func (m *mockBackfillEngineSimple) HasPendingBackfills() bool   { return m.pending }
+func (m *mockBackfillEngineSimple) ResetForSlotLoss(_ context.Context, _ uint64) error {
+	return nil
+}
 
 // TestSetBackfillEngine verifies that calling SetBackfillEngine on a connector
 // constructed with NewWithEventLog (nil engine) sets the engine; subsequent
@@ -778,5 +782,30 @@ func TestNewWithoutEventLog_NilGuard(t *testing.T) {
 		}
 	default:
 		t.Error("event not forwarded to channel when eventLog is nil")
+	}
+}
+
+func TestReplicationStartLSN(t *testing.T) {
+	const checkpoint = 50
+	const consistent = 200
+
+	start, saved := postgres.ReplicationStartLSN(true, consistent, checkpoint, true)
+	if start != consistent || saved != 0 {
+		t.Errorf("slot-loss: start=%d saved=%d, want start=%d saved=0", start, saved, consistent)
+	}
+
+	start, saved = postgres.ReplicationStartLSN(false, consistent, checkpoint, true)
+	if start != checkpoint+1 || saved != checkpoint {
+		t.Errorf("ordinary reconnect: start=%d saved=%d, want start=%d saved=%d", start, saved, checkpoint+1, checkpoint)
+	}
+
+	start, saved = postgres.ReplicationStartLSN(false, consistent, 0, false)
+	if start != 0 || saved != 0 {
+		t.Errorf("first run: start=%d saved=%d, want 0, 0", start, saved)
+	}
+
+	start, saved = postgres.ReplicationStartLSN(true, 0, checkpoint, true)
+	if start != 0 || saved != 0 {
+		t.Errorf("slot-loss with zero consistent point: start=%d saved=%d, want 0, 0", start, saved)
 	}
 }


### PR DESCRIPTION
## Summary

- **Source fix plan:** `.claude/fix-plans/slot-loss-backfill-reset-20260818-213000.md`
- After a replication slot is lost, reconnect already sets `needsSnapshot=true` and recreates the slot at current WAL, but `backfillEng.Run` no-ops when `BackfillState.Status` is `completed`. Rows changed only in the lost WAL gap are never re-emitted; watermark cannot help because those WAL events never reached EventLog.

**Introduced by:**
- https://github.com/olucasandrade/kaptanto/commit/f23bbd923a569a466aebce1902b6da82425cc34b
- completed skip: https://github.com/olucasandrade/kaptanto/commit/8e8075a0ee4de9f874861d5f02e6bb9f86c1febb

## Implementation

- On SRC-06 slot loss, `ResetForSlotLoss` sets snapshot tables to `Status=pending`, `CursorKey=nil`, and a new `SnapshotID`/`SnapshotLSN` before `Run`. `stream_only` tables are left untouched.
- `Run` and `ResetForSlotLoss` share a mutex so a still-running snapshot cannot race store writes; reset waits for that `Run` to finish.
- Replication after slot loss starts at the new slot consistent point (`ReplicationStartLSN`); ordinary reconnects still resume at checkpoint+1 and do not reset backfill.
- Idempotency keys keep the existing EVT-03 format (`…:read:<snapshotID>`). The new `SnapshotID` lets EventLog accept the re-snapshot, including gap rows whose previous `OpRead` used a different snapshot id. Crash-resume of the same snapshot run still dedups.

## Test plan

- [x] Persist completed state with a last PK; drive `ResetForSlotLoss`; assert snapshot restarts from page one and emits the gap row as `OpRead`
- [x] `stream_only` is not reset
- [x] Reset waits for an in-flight `Run`
- [x] Ordinary reconnect (`needsSnapshot=false`) does not reset and does not launch when nothing is pending
- [x] Slot-loss start LSN is the consistent point; ordinary reconnect is checkpoint+1

## Validation

```
CGO_ENABLED=0 go test ./internal/backfill ./internal/source/postgres ./internal/cmd -count=1
golangci-lint run ./internal/backfill/... ./internal/source/postgres/...
```

Results: all tests passed; golangci-lint reported 0 issues.

Live “drop the slot, reconnect, confirm the gap UPDATE appears” was not run (no `POSTGRES_TEST_DSN` in this worktree).

## Residual risk

- Slot-loss recovery re-snapshots the whole table (accepted in the plan). Unchanged rows are re-emitted as `OpRead` with a new `snapshot_id`; consumers must tolerate a second snapshot after slot drop, same as first boot.
- EventLog cannot content-dedup overlapping rows across snapshot runs because keys include `SnapshotID`. Reusing the old id would drop the gap row as a duplicate.
- Heartbeats after slot loss keep `lastSavedLSN=0` until the next durably checkpointed commit (CHK-01). The new slot holds WAL until then.
- `snapshot_deferred` is reset to pending, then `Run` immediately marks it deferred again without scanning. Those tables still do not fill a WAL gap.