### PR TITLE
fix(postgres): checkpoint streamed WAL commits and discard aborts

### DIFF
--- a/internal/parser/pgoutput/parser.go
+++ b/internal/parser/pgoutput/parser.go
@@ -32,7 +32,7 @@ type Parser struct {
 	relations  *RelationCache
 	toast      *TOASTCache
 	currentLSN pglogrepl.LSN
-	changeSeq  uint64 // per-transaction monotonic counter, reset on BeginMessage
+	changeSeq  uint64 // per-transaction monotonic counter, reset on Begin and first StreamStart
 	inStream   bool   // true between StreamStartMessageV2 and StreamStopMessageV2
 }
 
@@ -87,6 +87,13 @@ func (p *Parser) Parse(walData []byte, _ bool) (*event.ChangeEvent, error) {
 
 	case *pglogrepl.StreamStartMessageV2:
 		p.inStream = true
+		// FirstSegment==1 is the streamed equivalent of Begin: reset the
+		// per-transaction counter so crash replay mints the same keys.
+		// Later segments of the same XID must not reset — that would collide
+		// changeSeq across segments of one transaction.
+		if m.FirstSegment == 1 {
+			p.changeSeq = 0
+		}
 		return nil, nil
 
 	case *pglogrepl.StreamStopMessageV2:
@@ -94,11 +101,16 @@ func (p *Parser) Parse(walData []byte, _ bool) (*event.ChangeEvent, error) {
 		return nil, nil
 
 	case *pglogrepl.StreamCommitMessageV2:
-		// Streamed transaction committed — no ChangeEvent.
+		// Analogous to Begin.FinalLSN: CommitLSN is the durable identity of
+		// this transaction. DML already parsed in this stream still carries
+		// the previous currentLSN; the connector rewrites those keys before
+		// AppendBatch (CHK-01: streamed rows stay in walBuf until now).
+		p.currentLSN = m.CommitLSN
+		p.inStream = false
 		return nil, nil
 
 	case *pglogrepl.StreamAbortMessageV2:
-		// Streamed transaction aborted — no ChangeEvent.
+		p.inStream = false
 		return nil, nil
 
 	default:
@@ -277,6 +289,13 @@ func (p *Parser) newEvent(
 	}
 }
 
+// CurrentLSN returns the commit LSN of the current (or just-completed)
+// transaction. For streamed transactions this is 0 until StreamCommit, then
+// StreamCommit.CommitLSN.
+func (p *Parser) CurrentLSN() pglogrepl.LSN {
+	return p.currentLSN
+}
+
 // ClearRelationCache resets the relation cache and streaming state. It must be
 // called at the start of every new replication session — Postgres re-sends
 // RelationMessages at the beginning of each session, so stale OID → schema
@@ -284,6 +303,8 @@ func (p *Parser) newEvent(
 func (p *Parser) ClearRelationCache() {
 	p.relations = NewRelationCache()
 	p.inStream = false
+	p.changeSeq = 0
+	p.currentLSN = 0
 }
 
 // RelationCache returns the live relation metadata cache. Callers must not

--- a/internal/parser/pgoutput/parser_stream_test.go
+++ b/internal/parser/pgoutput/parser_stream_test.go
@@ -1,0 +1,152 @@
+package pgoutput_test
+
+import (
+	"encoding/binary"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pglogrepl"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func encodeStreamStart(xid uint32, firstSegment uint8) []byte {
+	buf := []byte{'S'}
+	buf = appendUint32(buf, xid)
+	return append(buf, firstSegment)
+}
+
+func encodeStreamStop() []byte { return []byte{'E'} }
+
+func encodeStreamCommit(xid uint32, commitLSN pglogrepl.LSN) []byte {
+	buf := []byte{'c'}
+	buf = appendUint32(buf, xid)
+	buf = append(buf, 0) // flags
+	buf = appendUint64(buf, uint64(commitLSN))
+	buf = appendUint64(buf, uint64(commitLSN)) // TransactionEndLSN
+	buf = appendUint64(buf, 0)                 // CommitTime
+	return buf
+}
+
+func encodeStreamAbort(xid, subxid uint32) []byte {
+	buf := []byte{'A'}
+	buf = appendUint32(buf, xid)
+	return appendUint32(buf, subxid)
+}
+
+func encodeInStreamInsert(xid, relID uint32, cols []tupleCol) []byte {
+	inner := encodeInsert(relID, cols)
+	out := []byte{'I'}
+	out = appendUint32(out, xid)
+	return append(out, inner[1:]...)
+}
+
+func TestStreamStartResetsChangeSeqOnFirstSegment(t *testing.T) {
+	p := newParser()
+	sendRelation(t, p, testRelID, testNamespace, testRelName, testCols)
+	sendBegin(t, p, pglogrepl.LSN(0x100))
+	ev, err := p.Parse(encodeInsert(testRelID, []tupleCol{textCol("1"), textCol("a"), textCol("b")}), false)
+	require.NoError(t, err)
+	require.NotNil(t, ev)
+	assert.True(t, strings.HasSuffix(ev.IdempotencyKey, ":0"))
+
+	ev, err = p.Parse(encodeStreamStart(42, 1), false)
+	require.NoError(t, err)
+	assert.Nil(t, ev)
+
+	ev, err = p.Parse(encodeInStreamInsert(42, testRelID, []tupleCol{textCol("2"), textCol("c"), textCol("d")}), false)
+	require.NoError(t, err)
+	require.NotNil(t, ev)
+	assert.True(t, strings.HasSuffix(ev.IdempotencyKey, ":0"),
+		"first streamed change must reset changeSeq, got %q", ev.IdempotencyKey)
+}
+
+func TestStreamStartLaterSegmentKeepsChangeSeq(t *testing.T) {
+	p := newParser()
+	sendRelation(t, p, testRelID, testNamespace, testRelName, testCols)
+
+	ev, err := p.Parse(encodeStreamStart(7, 1), false)
+	require.NoError(t, err)
+	assert.Nil(t, ev)
+
+	ev, err = p.Parse(encodeInStreamInsert(7, testRelID, []tupleCol{textCol("1"), textCol("a"), textCol("b")}), false)
+	require.NoError(t, err)
+	require.NotNil(t, ev)
+	assert.True(t, strings.HasSuffix(ev.IdempotencyKey, ":0"))
+
+	ev, err = p.Parse(encodeStreamStop(), false)
+	require.NoError(t, err)
+	assert.Nil(t, ev)
+
+	ev, err = p.Parse(encodeStreamStart(7, 0), false)
+	require.NoError(t, err)
+	assert.Nil(t, ev)
+
+	ev, err = p.Parse(encodeInStreamInsert(7, testRelID, []tupleCol{textCol("2"), textCol("c"), textCol("d")}), false)
+	require.NoError(t, err)
+	require.NotNil(t, ev)
+	assert.True(t, strings.HasSuffix(ev.IdempotencyKey, ":1"),
+		"continuation segment must not reset changeSeq, got %q", ev.IdempotencyKey)
+}
+
+func TestStreamCommitSetsCurrentLSN(t *testing.T) {
+	p := newParser()
+	commitLSN := pglogrepl.LSN(0x1A2B3C4)
+	ev, err := p.Parse(encodeStreamCommit(9, commitLSN), false)
+	require.NoError(t, err)
+	assert.Nil(t, ev)
+	assert.Equal(t, commitLSN, p.CurrentLSN())
+}
+
+func TestStreamAbortClearsInStream(t *testing.T) {
+	p := newParser()
+	sendRelation(t, p, testRelID, testNamespace, testRelName, testCols)
+	_, err := p.Parse(encodeStreamStart(3, 1), false)
+	require.NoError(t, err)
+
+	ev, err := p.Parse(encodeStreamAbort(3, 3), false)
+	require.NoError(t, err)
+	assert.Nil(t, ev)
+
+	// After abort, inserts must decode without the in-stream XID prefix.
+	ev, err = p.Parse(encodeInsert(testRelID, []tupleCol{textCol("1"), textCol("a"), textCol("b")}), false)
+	require.NoError(t, err)
+	require.NotNil(t, ev)
+}
+
+func TestStreamReplayAfterClearRelationCacheReusesKeys(t *testing.T) {
+	p := newParser()
+	sendRelation(t, p, testRelID, testNamespace, testRelName, testCols)
+	xid := uint32(11)
+	commitLSN := pglogrepl.LSN(0xABC)
+
+	drive := func() []string {
+		_, err := p.Parse(encodeStreamStart(xid, 1), false)
+		require.NoError(t, err)
+		var keys []string
+		for i, pk := range []string{"1", "2", "3"} {
+			ev, err := p.Parse(encodeInStreamInsert(xid, testRelID, []tupleCol{textCol(pk), textCol("n"), textCol("b")}), false)
+			require.NoError(t, err)
+			require.NotNil(t, ev, "insert %d", i)
+			keys = append(keys, ev.IdempotencyKey)
+		}
+		_, err = p.Parse(encodeStreamStop(), false)
+		require.NoError(t, err)
+		_, err = p.Parse(encodeStreamCommit(xid, commitLSN), false)
+		require.NoError(t, err)
+		return keys
+	}
+
+	first := drive()
+	p.ClearRelationCache()
+	sendRelation(t, p, testRelID, testNamespace, testRelName, testCols)
+	second := drive()
+	assert.Equal(t, first, second, "replay after ClearRelationCache must reuse idempotency keys")
+}
+
+func TestEncodeStreamStartWireFormat(t *testing.T) {
+	raw := encodeStreamStart(0x01020304, 1)
+	require.Equal(t, byte('S'), raw[0])
+	require.Equal(t, uint32(0x01020304), binary.BigEndian.Uint32(raw[1:5]))
+	require.Equal(t, byte(1), raw[5])
+}

--- a/internal/source/postgres/connector.go
+++ b/internal/source/postgres/connector.go
@@ -26,6 +26,7 @@ const (
 	defaultStandbyTimeout  = 10 * time.Second
 	defaultWALLagThreshold = 100 * 1024 * 1024 // 100 MB
 	walLagCheckInterval    = 30 * time.Second
+	walBufFlushThreshold   = 1024
 )
 
 // Config holds all parameters for the PostgresConnector.
@@ -455,51 +456,19 @@ func (c *PostgresConnector) connectAndStream(ctx context.Context, wasEverConnect
 // and pglogrepl parsers. It sends standby status updates on heartbeat timeout
 // and when PrimaryKeepalive.ReplyRequested is set.
 //
-// Fix B: WAL events are buffered in walBuf and flushed via AppendBatch in a
-// single Badger transaction per commit (or per 256 events). This amortises the
-// virtiofs fsync overhead that was capping sustained throughput at ~2–3k eps.
-// CHK-01 is preserved: flushWALBuf is always called before sendStandbyStatus
-// on the commit path, ensuring events are durable before the LSN advances.
+// WAL events are buffered and flushed via AppendBatch per commit, or per
+// walBufFlushThreshold events for non-streamed transactions. Streamed
+// transactions flush only on StreamCommit; StreamAbort discards the buffer.
+// CHK-01: flush happens before sendStandbyStatus on the commit path.
 //
-//nolint:gocyclo // the WAL receive loop dispatches every message type inline; splitting it would scatter the CHK-01 ordering guarantee. Tracked for incremental refactor.
+//nolint:gocyclo // keepalive vs XLogData dispatch stays inline; commit/abort live in handleXLogData.
 func (c *PostgresConnector) receiveLoop(
 	ctx context.Context,
 	replConn *pgconn.PgConn,
 	lastSavedLSN pglogrepl.LSN,
 ) error {
-	var clientXLogPos pglogrepl.LSN
+	st := &walReceiveState{lastSavedLSN: lastSavedLSN}
 	nextHeartbeat := time.Now().Add(c.cfg.StandbyTimeout)
-
-	// walBuf accumulates events within a Postgres transaction for batch writes.
-	var walBuf []*event.ChangeEvent
-
-	// flushWALBuf writes all buffered events to the event log in a single
-	// Badger transaction (Fix B: batch writes). Must be called before
-	// advancing the LSN checkpoint to Postgres (CHK-01). After a successful
-	// flush, each event is forwarded to the events channel (best-effort; drop
-	// is safe because the router reads from eventlog.ReadPartition).
-	flushWALBuf := func() error {
-		if len(walBuf) == 0 {
-			return nil
-		}
-		if c.eventLog != nil {
-			c.appendMu.Lock()
-			_, err := c.eventLog.AppendBatch(walBuf)
-			c.appendMu.Unlock()
-			if err != nil {
-				return fmt.Errorf("eventlog: append batch: %w", err)
-			}
-		}
-		for _, ev := range walBuf {
-			select {
-			case c.events <- ev:
-			default:
-				// Router reads from eventLog.ReadPartition; drop is safe.
-			}
-		}
-		walBuf = walBuf[:0]
-		return nil
-	}
 
 	for {
 		// Set receive deadline to next heartbeat.
@@ -511,7 +480,7 @@ func (c *PostgresConnector) receiveLoop(
 			if pgconn.Timeout(err) {
 				// Heartbeat deadline exceeded — send standby status update (SRC-03).
 				// CHK-01: never ack past the last durably checkpointed LSN.
-				if sendErr := c.sendStandbyStatus(ctx, replConn, ackLSN(clientXLogPos, lastSavedLSN)); sendErr != nil {
+				if sendErr := c.sendStandbyStatus(ctx, replConn, ackLSN(st.clientXLogPos, st.lastSavedLSN)); sendErr != nil {
 					return fmt.Errorf("postgres: send standby heartbeat: %w", sendErr)
 				}
 				nextHeartbeat = time.Now().Add(c.cfg.StandbyTimeout)
@@ -541,12 +510,12 @@ func (c *PostgresConnector) receiveLoop(
 				slog.Warn("postgres: parse keepalive message", "error", err)
 				continue
 			}
-			if pkm.ServerWALEnd > clientXLogPos {
-				clientXLogPos = pkm.ServerWALEnd
+			if pkm.ServerWALEnd > st.clientXLogPos {
+				st.clientXLogPos = pkm.ServerWALEnd
 			}
 			// If server requests a reply, send status immediately (SRC-03).
 			if pkm.ReplyRequested {
-				if sendErr := c.sendStandbyStatus(ctx, replConn, ackLSN(clientXLogPos, lastSavedLSN)); sendErr != nil {
+				if sendErr := c.sendStandbyStatus(ctx, replConn, ackLSN(st.clientXLogPos, st.lastSavedLSN)); sendErr != nil {
 					return fmt.Errorf("postgres: send standby on request: %w", sendErr)
 				}
 				nextHeartbeat = time.Now().Add(c.cfg.StandbyTimeout)
@@ -559,49 +528,13 @@ func (c *PostgresConnector) receiveLoop(
 				continue
 			}
 
-			ev, parseErr := c.parser.Parse(xld.WALData, false)
-			if parseErr != nil {
-				slog.Warn("postgres: parse WAL data error", "error", parseErr)
-				// Non-fatal: log and continue (unknown RelationID can occur transiently).
-				break
+			ack, committed, herr := c.handleXLogData(ctx, st, xld)
+			if herr != nil {
+				return herr
 			}
-			if ev != nil {
-				// Buffer event; flush when batch is full (Fix B).
-				// Threshold 1024 > default loadgen batch-size 500, so each
-				// CopyFrom call produces exactly one Badger transaction.
-				walBuf = append(walBuf, ev)
-				if len(walBuf) >= 1024 {
-					// Mid-transaction flush: durably write the batch but do NOT
-					// advance clientXLogPos — CHK-01 requires all events for a
-					// transaction to be durable before acknowledging the Commit LSN.
-					if err := flushWALBuf(); err != nil {
-						return err
-					}
-				}
-			}
-
-			// Advance client position.
-			end := xld.WALStart + pglogrepl.LSN(len(xld.WALData))
-			if end > clientXLogPos {
-				clientXLogPos = end
-			}
-
-			// CHK-01: save checkpoint BEFORE advancing LSN to Postgres.
-			// When the parser emits nil (Commit message), we persist the LSN.
-			// We detect "commit" by checking if WALData[0] == 'C' (CommitMessage).
-			if len(xld.WALData) > 0 && xld.WALData[0] == 'C' {
-				// CHK-01: flush all buffered events before acknowledging commit LSN.
-				if err := flushWALBuf(); err != nil {
-					return err
-				}
-				lsnStr := clientXLogPos.String()
-				if saveErr := c.store.Save(ctx, c.cfg.SourceID, lsnStr); saveErr != nil {
-					return fmt.Errorf("postgres: save checkpoint: %w", saveErr)
-				}
-				lastSavedLSN = clientXLogPos
-				// CHK-01: checkpoint BEFORE advancing LSN to Postgres.
-				if sendErr := c.sendStandbyStatus(ctx, replConn, clientXLogPos); sendErr != nil {
-					return fmt.Errorf("postgres: send standby after commit: %w", sendErr)
+			if committed {
+				if sendErr := c.sendStandbyStatus(ctx, replConn, ack); sendErr != nil {
+					return fmt.Errorf("postgres: send standby after checkpoint: %w", sendErr)
 				}
 				nextHeartbeat = time.Now().Add(c.cfg.StandbyTimeout)
 			}
@@ -616,6 +549,136 @@ func ackLSN(clientPos, lastSaved pglogrepl.LSN) pglogrepl.LSN {
 		return lastSaved
 	}
 	return clientPos
+}
+
+// walReceiveState holds in-flight WAL decode state for receiveLoop.
+// Tests drive handleXLogData against this struct as a fake walsender.
+type walReceiveState struct {
+	walBuf        []*event.ChangeEvent
+	streamedOpen  bool
+	clientXLogPos pglogrepl.LSN
+	lastSavedLSN  pglogrepl.LSN
+}
+
+func (st *walReceiveState) flushWALBuf(c *PostgresConnector) error {
+	if len(st.walBuf) == 0 {
+		return nil
+	}
+	if c.eventLog != nil {
+		c.appendMu.Lock()
+		_, err := c.eventLog.AppendBatch(st.walBuf)
+		c.appendMu.Unlock()
+		if err != nil {
+			return fmt.Errorf("eventlog: append batch: %w", err)
+		}
+	}
+	for _, ev := range st.walBuf {
+		select {
+		case c.events <- ev:
+		default:
+		}
+	}
+	st.walBuf = st.walBuf[:0]
+	return nil
+}
+
+func (st *walReceiveState) bufferEvent(c *PostgresConnector, ev *event.ChangeEvent) error {
+	st.walBuf = append(st.walBuf, ev)
+	if len(st.walBuf) >= walBufFlushThreshold && !st.streamedOpen {
+		return st.flushWALBuf(c)
+	}
+	return nil
+}
+
+func (c *PostgresConnector) checkpointLSN(ctx context.Context, st *walReceiveState) error {
+	if saveErr := c.store.Save(ctx, c.cfg.SourceID, st.clientXLogPos.String()); saveErr != nil {
+		return fmt.Errorf("postgres: save checkpoint: %w", saveErr)
+	}
+	st.lastSavedLSN = st.clientXLogPos
+	return nil
+}
+
+// handleXLogData applies one logical decoding payload. Tests call this as a
+// fake walsender: StreamStart, N inserts, StreamStop, StreamCommit/Abort.
+func (c *PostgresConnector) handleXLogData(ctx context.Context, st *walReceiveState, xld pglogrepl.XLogData) (ack pglogrepl.LSN, committed bool, err error) {
+	ev, parseErr := c.parser.Parse(xld.WALData, false)
+	if parseErr != nil {
+		slog.Warn("postgres: parse WAL data error", "error", parseErr)
+		return 0, false, nil
+	}
+	if ev != nil {
+		if bufErr := st.bufferEvent(c, ev); bufErr != nil {
+			return 0, false, bufErr
+		}
+	}
+	end := xld.WALStart + pglogrepl.LSN(len(xld.WALData))
+	if end > st.clientXLogPos {
+		st.clientXLogPos = end
+	}
+	if len(xld.WALData) == 0 {
+		return 0, false, nil
+	}
+	return c.finishXLogData(ctx, st, pglogrepl.MessageType(xld.WALData[0]))
+}
+
+func (c *PostgresConnector) finishXLogData(ctx context.Context, st *walReceiveState, msgType pglogrepl.MessageType) (pglogrepl.LSN, bool, error) {
+	switch msgType {
+	case pglogrepl.MessageTypeStreamStart:
+		st.streamedOpen = true
+		return 0, false, nil
+	case pglogrepl.MessageTypeStreamAbort:
+		st.walBuf = st.walBuf[:0]
+		st.streamedOpen = false
+		if err := c.checkpointLSN(ctx, st); err != nil {
+			return 0, false, err
+		}
+		return st.clientXLogPos, true, nil
+	case pglogrepl.MessageTypeCommit, pglogrepl.MessageTypeStreamCommit:
+		if msgType == pglogrepl.MessageTypeStreamCommit {
+			stampCommitLSN(st.walBuf, c.parser.CurrentLSN())
+		}
+		if err := st.flushWALBuf(c); err != nil {
+			return 0, false, err
+		}
+		if err := c.checkpointLSN(ctx, st); err != nil {
+			return 0, false, err
+		}
+		st.streamedOpen = false
+		return st.clientXLogPos, true, nil
+	default:
+		return 0, false, nil
+	}
+}
+
+func stampCommitLSN(evs []*event.ChangeEvent, lsn pglogrepl.LSN) {
+	lsnStr := lsn.String()
+	for _, ev := range evs {
+		if ev == nil {
+			continue
+		}
+		rewriteIdempotencyLSN(ev, lsnStr)
+		if ev.Metadata == nil {
+			ev.Metadata = make(map[string]any, 2)
+		}
+		ev.Metadata["lsn"] = lsnStr
+	}
+}
+
+// rewriteIdempotencyLSN replaces the LSN segment of
+// sourceID:schema.table:pk:op:lsn:changeSeq. pk is JSON and may contain colons,
+// so only the second-to-last colon-separated field is rewritten.
+func rewriteIdempotencyLSN(ev *event.ChangeEvent, lsnStr string) {
+	key := ev.IdempotencyKey
+	last := strings.LastIndexByte(key, ':')
+	if last <= 0 {
+		return
+	}
+	rest := key[:last]
+	second := strings.LastIndexByte(rest, ':')
+	if second < 0 {
+		return
+	}
+	ev.IdempotencyKey = key[:second+1] + lsnStr + key[last:]
 }
 
 // sendStandbyStatus sends a StandbyStatusUpdate to the server.

--- a/internal/source/postgres/connector_stream_test.go
+++ b/internal/source/postgres/connector_stream_test.go
@@ -1,0 +1,379 @@
+package postgres
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pglogrepl"
+	"github.com/olucasandrade/kaptanto/internal/checkpoint"
+	"github.com/olucasandrade/kaptanto/internal/event"
+	"github.com/olucasandrade/kaptanto/internal/eventlog"
+)
+
+type streamEventLog struct {
+	events []*event.ChangeEvent
+}
+
+func (m *streamEventLog) Append(ev *event.ChangeEvent) (uint64, error) {
+	m.events = append(m.events, ev)
+	return uint64(len(m.events)), nil
+}
+
+func (m *streamEventLog) AppendBatch(evs []*event.ChangeEvent) ([]uint64, error) {
+	seqs := make([]uint64, len(evs))
+	for i, ev := range evs {
+		m.events = append(m.events, ev)
+		seqs[i] = uint64(len(m.events))
+	}
+	return seqs, nil
+}
+
+func (m *streamEventLog) ReadPartition(_ context.Context, _ uint32, _ uint64, _ int) ([]eventlog.LogEntry, error) {
+	return nil, nil
+}
+
+func (m *streamEventLog) Close() error { return nil }
+
+type streamCheckpointStore struct {
+	saves []string
+}
+
+func (m *streamCheckpointStore) Save(_ context.Context, _, lsn string) error {
+	m.saves = append(m.saves, lsn)
+	return nil
+}
+
+func (m *streamCheckpointStore) Load(_ context.Context, _ string) (string, error) { return "", nil }
+func (m *streamCheckpointStore) Close() error                                     { return nil }
+
+var (
+	_ eventlog.EventLog          = (*streamEventLog)(nil)
+	_ checkpoint.CheckpointStore = (*streamCheckpointStore)(nil)
+)
+
+const (
+	streamTestRelID = uint32(12345)
+	streamTestXID   = uint32(42)
+)
+
+func streamPutU32(buf []byte, v uint32) []byte {
+	b := make([]byte, 4)
+	binary.BigEndian.PutUint32(b, v)
+	return append(buf, b...)
+}
+
+func streamPutU64(buf []byte, v uint64) []byte {
+	b := make([]byte, 8)
+	binary.BigEndian.PutUint64(b, v)
+	return append(buf, b...)
+}
+
+func streamPutStr(buf []byte, s string) []byte {
+	return append(append(buf, s...), 0)
+}
+
+func binaryAppendU16(buf []byte, v uint16) []byte {
+	b := make([]byte, 2)
+	binary.BigEndian.PutUint16(b, v)
+	return append(buf, b...)
+}
+
+func encodeStreamRelation() []byte {
+	buf := []byte{'R'}
+	buf = streamPutU32(buf, streamTestRelID)
+	buf = streamPutStr(buf, "public")
+	buf = streamPutStr(buf, "orders")
+	buf = append(buf, 'd')
+	buf = binaryAppendU16(buf, 3)
+	cols := []struct {
+		flags byte
+		name  string
+		oid   uint32
+	}{
+		{1, "id", 23},
+		{0, "name", 25},
+		{0, "content", 25},
+	}
+	for _, col := range cols {
+		buf = append(buf, col.flags)
+		buf = streamPutStr(buf, col.name)
+		buf = streamPutU32(buf, col.oid)
+		buf = streamPutU32(buf, uint32(0xFFFFFFFF))
+	}
+	return buf
+}
+
+func encodeStreamTuple(buf []byte, cols []string) []byte {
+	buf = binaryAppendU16(buf, uint16(len(cols)))
+	for _, s := range cols {
+		buf = append(buf, 't')
+		buf = streamPutU32(buf, uint32(len(s)))
+		buf = append(buf, s...)
+	}
+	return buf
+}
+
+func encodeStreamInsert(pk string) []byte {
+	buf := []byte{'I'}
+	buf = streamPutU32(buf, streamTestRelID)
+	buf = append(buf, 'N')
+	return encodeStreamTuple(buf, []string{pk, "n", "b"})
+}
+
+func encodeInStreamInsert(pk string) []byte {
+	inner := encodeStreamInsert(pk)
+	out := []byte{'I'}
+	out = streamPutU32(out, streamTestXID)
+	return append(out, inner[1:]...)
+}
+
+func encodeTestStreamStart(first uint8) []byte {
+	buf := []byte{'S'}
+	buf = streamPutU32(buf, streamTestXID)
+	return append(buf, first)
+}
+
+func encodeTestStreamStop() []byte { return []byte{'E'} }
+
+func encodeTestStreamCommit(lsn pglogrepl.LSN) []byte {
+	buf := []byte{'c'}
+	buf = streamPutU32(buf, streamTestXID)
+	buf = append(buf, 0)
+	buf = streamPutU64(buf, uint64(lsn))
+	buf = streamPutU64(buf, uint64(lsn))
+	buf = streamPutU64(buf, 0)
+	return buf
+}
+
+func encodeTestStreamAbort() []byte {
+	buf := []byte{'A'}
+	buf = streamPutU32(buf, streamTestXID)
+	return streamPutU32(buf, streamTestXID)
+}
+
+func encodeTestBegin(lsn pglogrepl.LSN) []byte {
+	buf := []byte{'B'}
+	buf = streamPutU64(buf, uint64(lsn))
+	buf = streamPutU64(buf, 0)
+	return streamPutU32(buf, 1)
+}
+
+func encodeTestCommit(lsn pglogrepl.LSN) []byte {
+	buf := []byte{'C'}
+	buf = append(buf, 0)
+	buf = streamPutU64(buf, uint64(lsn))
+	buf = streamPutU64(buf, uint64(lsn))
+	return streamPutU64(buf, 0)
+}
+
+func newStreamConnector(t *testing.T) (*PostgresConnector, *streamEventLog, *streamCheckpointStore) {
+	t.Helper()
+	el := &streamEventLog{}
+	store := &streamCheckpointStore{}
+	c := NewWithEventLog(Config{DSN: "postgres://localhost/testdb", SourceID: "pg1"}, store, event.NewIDGenerator(), el)
+	return c, el, store
+}
+
+func applyWAL(t *testing.T, c *PostgresConnector, st *walReceiveState, walStart pglogrepl.LSN, payload []byte) (pglogrepl.LSN, bool) {
+	t.Helper()
+	ack, committed, err := c.handleXLogData(context.Background(), st, pglogrepl.XLogData{
+		WALStart: walStart,
+		WALData:  payload,
+	})
+	if err != nil {
+		t.Fatalf("handleXLogData: %v", err)
+	}
+	return ack, committed
+}
+
+func TestHandleXLogData_StreamCommitFlushesAndCheckpoints(t *testing.T) {
+	c, el, store := newStreamConnector(t)
+	st := &walReceiveState{}
+	commitLSN := pglogrepl.LSN(0x1A2B3C4)
+	pos := pglogrepl.LSN(0x100)
+
+	_, committed := applyWAL(t, c, st, pos, encodeStreamRelation())
+	if committed {
+		t.Fatal("relation must not commit")
+	}
+	pos += 16
+	_, committed = applyWAL(t, c, st, pos, encodeTestStreamStart(1))
+	if committed || !st.streamedOpen {
+		t.Fatalf("StreamStart: committed=%v streamedOpen=%v", committed, st.streamedOpen)
+	}
+	if len(el.events) != 0 {
+		t.Fatalf("no rows before StreamCommit, got %d", len(el.events))
+	}
+
+	n := 3
+	for i := 0; i < n; i++ {
+		pos += 16
+		applyWAL(t, c, st, pos, encodeInStreamInsert(fmt.Sprintf("%d", i+1)))
+		if len(el.events) != 0 {
+			t.Fatalf("insert %d flushed early", i)
+		}
+	}
+	pos += 16
+	applyWAL(t, c, st, pos, encodeTestStreamStop())
+	pos += 16
+	ack, committed := applyWAL(t, c, st, pos, encodeTestStreamCommit(commitLSN))
+	if !committed {
+		t.Fatal("StreamCommit must checkpoint")
+	}
+	if ack == 0 {
+		t.Fatal("StreamCommit ack LSN must be non-zero")
+	}
+	if len(el.events) != n {
+		t.Fatalf("got %d persisted rows, want %d", len(el.events), n)
+	}
+	if len(store.saves) != 1 {
+		t.Fatalf("got %d checkpoint saves, want 1", len(store.saves))
+	}
+	lsnStr := commitLSN.String()
+	for i, ev := range el.events {
+		if got, _ := ev.Metadata["lsn"].(string); got != lsnStr {
+			t.Errorf("event %d metadata lsn=%q want %q", i, got, lsnStr)
+		}
+		if !strings.Contains(ev.IdempotencyKey, ":"+lsnStr+":") {
+			t.Errorf("event %d key %q missing commit LSN", i, ev.IdempotencyKey)
+		}
+		if !strings.HasSuffix(ev.IdempotencyKey, fmt.Sprintf(":%d", i)) {
+			t.Errorf("event %d key %q want changeSeq %d", i, ev.IdempotencyKey, i)
+		}
+	}
+}
+
+func TestHandleXLogData_StreamAbortPersistsZeroRows(t *testing.T) {
+	c, el, store := newStreamConnector(t)
+	st := &walReceiveState{}
+	pos := pglogrepl.LSN(0x200)
+	applyWAL(t, c, st, pos, encodeStreamRelation())
+	pos += 16
+	applyWAL(t, c, st, pos, encodeTestStreamStart(1))
+	for i := 0; i < 5; i++ {
+		pos += 16
+		applyWAL(t, c, st, pos, encodeInStreamInsert(fmt.Sprintf("%d", i+1)))
+	}
+	pos += 16
+	applyWAL(t, c, st, pos, encodeTestStreamStop())
+	pos += 16
+	_, committed := applyWAL(t, c, st, pos, encodeTestStreamAbort())
+	if !committed {
+		t.Fatal("StreamAbort should still checkpoint so the slot can advance")
+	}
+	if len(el.events) != 0 {
+		t.Fatalf("StreamAbort must persist zero rows, got %d", len(el.events))
+	}
+	if len(store.saves) != 1 {
+		t.Fatalf("got %d saves, want 1", len(store.saves))
+	}
+	if st.streamedOpen {
+		t.Fatal("streamedOpen must be false after abort")
+	}
+}
+
+func TestHandleXLogData_NoMidFlushWhileStreamed(t *testing.T) {
+	c, el, _ := newStreamConnector(t)
+	st := &walReceiveState{}
+	pos := pglogrepl.LSN(0x300)
+	applyWAL(t, c, st, pos, encodeStreamRelation())
+	pos += 16
+	applyWAL(t, c, st, pos, encodeTestStreamStart(1))
+	n := walBufFlushThreshold + 1
+	for i := 0; i < n; i++ {
+		pos += 16
+		applyWAL(t, c, st, pos, encodeInStreamInsert(fmt.Sprintf("%d", i+1)))
+		if len(el.events) != 0 {
+			t.Fatalf("mid-flush at insert %d leaked %d rows", i, len(el.events))
+		}
+	}
+	pos += 16
+	applyWAL(t, c, st, pos, encodeTestStreamStop())
+	pos += 16
+	_, committed := applyWAL(t, c, st, pos, encodeTestStreamCommit(pglogrepl.LSN(0x999)))
+	if !committed {
+		t.Fatal("expected StreamCommit")
+	}
+	if len(el.events) != n {
+		t.Fatalf("got %d rows after StreamCommit, want %d", len(el.events), n)
+	}
+}
+
+func TestHandleXLogData_ReplayAfterClearRelationCacheReusesKeys(t *testing.T) {
+	c, el, _ := newStreamConnector(t)
+	drive := func(st *walReceiveState) {
+		pos := pglogrepl.LSN(0x400)
+		applyWAL(t, c, st, pos, encodeStreamRelation())
+		pos += 16
+		applyWAL(t, c, st, pos, encodeTestStreamStart(1))
+		for i := 0; i < 3; i++ {
+			pos += 16
+			applyWAL(t, c, st, pos, encodeInStreamInsert(fmt.Sprintf("%d", i+1)))
+		}
+		pos += 16
+		applyWAL(t, c, st, pos, encodeTestStreamStop())
+		pos += 16
+		_, committed := applyWAL(t, c, st, pos, encodeTestStreamCommit(pglogrepl.LSN(0xABC)))
+		if !committed {
+			t.Fatal("expected commit")
+		}
+	}
+
+	drive(&walReceiveState{})
+	first := make([]string, len(el.events))
+	for i, ev := range el.events {
+		first[i] = ev.IdempotencyKey
+	}
+
+	c.parser.ClearRelationCache()
+	drive(&walReceiveState{})
+	if len(el.events) != 6 {
+		t.Fatalf("got %d events after replay, want 6", len(el.events))
+	}
+	for i := 0; i < 3; i++ {
+		if el.events[i+3].IdempotencyKey != first[i] {
+			t.Errorf("replay key[%d]=%q want %q", i, el.events[i+3].IdempotencyKey, first[i])
+		}
+	}
+}
+
+func TestHandleXLogData_RegularCommitStillFlushes(t *testing.T) {
+	c, el, store := newStreamConnector(t)
+	st := &walReceiveState{}
+	lsn := pglogrepl.LSN(0x50)
+	pos := pglogrepl.LSN(0x10)
+	applyWAL(t, c, st, pos, encodeStreamRelation())
+	pos += 16
+	applyWAL(t, c, st, pos, encodeTestBegin(lsn))
+	pos += 16
+	applyWAL(t, c, st, pos, encodeStreamInsert("9"))
+	if len(el.events) != 0 {
+		t.Fatal("regular insert must wait for Commit")
+	}
+	pos += 16
+	_, committed := applyWAL(t, c, st, pos, encodeTestCommit(lsn))
+	if !committed {
+		t.Fatal("Commit C must checkpoint")
+	}
+	if len(el.events) != 1 {
+		t.Fatalf("got %d rows, want 1", len(el.events))
+	}
+	if len(store.saves) != 1 {
+		t.Fatalf("got %d saves, want 1", len(store.saves))
+	}
+	if !strings.Contains(el.events[0].IdempotencyKey, ":"+lsn.String()+":") {
+		t.Errorf("regular commit key %q should keep Begin LSN", el.events[0].IdempotencyKey)
+	}
+}
+
+func TestRewriteIdempotencyLSN(t *testing.T) {
+	ev := &event.ChangeEvent{IdempotencyKey: `pg1:public.orders:{"id":"1"}:insert:0/0:3`}
+	rewriteIdempotencyLSN(ev, "0/1A2B3C4")
+	want := `pg1:public.orders:{"id":"1"}:insert:0/1A2B3C4:3`
+	if ev.IdempotencyKey != want {
+		t.Fatalf("got %q want %q", ev.IdempotencyKey, want)
+	}
+}


### PR DESCRIPTION
## Summary

- **Source fix plan:** `.claude/fix-plans/streamed-wal-commit-20260818-213000.md`
- **Problem:** `StartReplication` always sets `streaming 'true'`. Large transactions emit pgoutput StreamCommit (`c`) instead of Commit (`C`). `receiveLoop` only flushed, checkpointed, and sent standby on `C`, so streamed commits never advanced the slot LSN. StreamAbort did not discard `walBuf`, and the 1024-event mid-flush could Append in-progress streamed rows — CHK-01 violation.
- **Introduced by:** https://github.com/olucasandrade/kaptanto/commit/95a5c0a6eaacd8d82b853db53b6c6ed78a37e3b5 (enabled `streaming 'true'` and `'C'`-only commit detect); parser stream handlers https://github.com/olucasandrade/kaptanto/commit/d10b00a54dbcb8cb90683e25d53ff1b825b17874 (handlers added without wiring the receive loop).

## Implementation

- Treat StreamCommit (`c`) like Commit: stamp buffered events with `StreamCommit.CommitLSN`, `AppendBatch`, checkpoint, then standby.
- Treat StreamAbort (`A`) as rollback: discard `walBuf` (zero persisted rows) and checkpoint so the slot can advance.
- Do not mid-flush while a streamed transaction is open (`streamedOpen` from StreamStart until commit/abort).
- Reset `changeSeq` on first StreamStart segment; `ClearRelationCache` also resets stream counters so replay mints the same idempotency keys.

## Validation

```
CGO_ENABLED=0 go test ./internal/parser/pgoutput ./internal/source/postgres -count=1
# ok  github.com/olucasandrade/kaptanto/internal/parser/pgoutput
# ok  github.com/olucasandrade/kaptanto/internal/source/postgres

CGO_ENABLED=0 go test ./internal/parser/pgoutput ./internal/source/postgres -count=1 -run 'Stream|RewriteIdempotency|HandleXLogData' -v
# all new StreamStart/StreamCommit/StreamAbort/replay/mid-flush tests PASS
```

## Residual risk

- Checkpoint LSN on StreamCommit is `WALStart + len(WALData)` (same as `'C'`), while idempotency keys use `StreamCommit.CommitLSN`. A mismatch vs Postgres `confirmed_flush_lsn` on reconnect is possible if those two LSNs diverge; not observed in the fake-walsender tests.
- Any StreamAbort discards the whole in-flight buffer, including a subtransaction abort (`xid != subxid`) where Postgres may still StreamCommit the parent. Aborted-subxact rows are not tracked separately.
- Live Postgres with `logical_decoding_work_mem` small enough to force streaming was not run (`POSTGRES_TEST_DSN` unset).
- Huge streamed transactions now sit in `walBuf` until StreamCommit (no 1024 mid-flush), so peak memory follows the streamed txn size.