### PR TITLE
fix(eventlog): reuse long-lived NATS pull consumers in ReadPartition

### DIFF
--- a/internal/eventlog/eventlog.go
+++ b/internal/eventlog/eventlog.go
@@ -36,6 +36,14 @@ type PartitionNotifier interface {
 	NotifyCh(partition uint32) <-chan struct{}
 }
 
+// PartitionReleaser is implemented by EventLog backends that keep per-partition
+// resources (for example NatsEventLog's long-lived JetStream pull consumers).
+// Callers must invoke ReleasePartition when they stop reading a partition so
+// those resources are not leaked across cluster ownership changes.
+type PartitionReleaser interface {
+	ReleasePartition(partition uint32)
+}
+
 // EventLog is the append-only durable event store interface.
 // Implementations must be safe for sequential calls from a single goroutine.
 // Callers must serialize concurrent Append calls externally if needed.

--- a/internal/eventlog/nats.go
+++ b/internal/eventlog/nats.go
@@ -19,13 +19,17 @@ package eventlog
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"strconv"
+	"sync"
 	"time"
 
+	natssrv "github.com/nats-io/nats-server/v2/server"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
-	natssrv "github.com/nats-io/nats-server/v2/server"
 
 	"github.com/olucasandrade/kaptanto/internal/event"
 )
@@ -36,6 +40,8 @@ var _ EventLog = (*NatsEventLog)(nil)
 // Compile-time assertion: NatsEventLog implements PartitionNotifier.
 var _ PartitionNotifier = (*NatsEventLog)(nil)
 
+var _ PartitionReleaser = (*NatsEventLog)(nil)
+
 const (
 	// natsStreamName is the single JetStream stream that holds all 64 partition subjects.
 	// One stream per kaptanto instance — one Raft group, one SyncAlways applies.
@@ -43,12 +49,23 @@ const (
 
 	// natsSubjectPattern matches all partition subjects for use in StreamConfig.Subjects.
 	natsSubjectPattern = "kaptanto.events.*"
+
+	natsPullInactiveThreshold = 30 * time.Second
+	natsConsumerDeleteTimeout = 2 * time.Second
 )
 
 // natsSubject returns the JetStream subject for the given partition number.
 // Subject format: "kaptanto.events.{partition:05d}" — zero-padded for lexicographic ordering.
 func natsSubject(partition uint32) string {
 	return fmt.Sprintf("kaptanto.events.%05d", partition)
+}
+
+func newNatsInstanceID() string {
+	var b [8]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return strconv.FormatInt(time.Now().UnixNano(), 36)
+	}
+	return hex.EncodeToString(b[:])
 }
 
 // NatsEventLogConfig holds configuration for opening a NatsEventLog.
@@ -66,6 +83,15 @@ type NatsEventLogConfig struct {
 	Retention time.Duration
 }
 
+// natsPartitionReader holds the long-lived JetStream pull consumer for one
+// partition. nextSeq is the fromSeq this consumer will next deliver; a
+// mismatch (router rewind, watermark scan) deletes and recreates it.
+type natsPartitionReader struct {
+	mu      sync.Mutex
+	cons    jetstream.Consumer
+	nextSeq uint64
+}
+
 // NatsEventLog is the NATS JetStream-backed implementation of EventLog.
 // It is safe for sequential calls from a single goroutine. Callers must
 // serialize concurrent Append calls externally.
@@ -78,6 +104,8 @@ type NatsEventLog struct {
 	stream        jetstream.Stream
 	numPartitions uint32
 	notifyChs     []chan struct{} // one depth-1 buffered channel per partition
+	instanceID    string
+	readers       []*natsPartitionReader
 }
 
 // OpenNats opens a NatsEventLog, starting an embedded NATS server and creating
@@ -146,8 +174,10 @@ func OpenNats(cfg NatsEventLogConfig) (*NatsEventLog, error) {
 	}
 
 	notifyChs := make([]chan struct{}, numPartitions)
+	readers := make([]*natsPartitionReader, numPartitions)
 	for i := uint32(0); i < numPartitions; i++ {
 		notifyChs[i] = make(chan struct{}, 1)
+		readers[i] = &natsPartitionReader{}
 	}
 
 	return &NatsEventLog{
@@ -157,6 +187,8 @@ func OpenNats(cfg NatsEventLogConfig) (*NatsEventLog, error) {
 		stream:        stream,
 		numPartitions: numPartitions,
 		notifyChs:     notifyChs,
+		instanceID:    newNatsInstanceID(),
+		readers:       readers,
 	}, nil
 }
 
@@ -282,64 +314,156 @@ func (n *NatsEventLog) AppendBatch(evs []*event.ChangeEvent) ([]uint64, error) {
 }
 
 // ReadPartition returns up to limit events from the given partition, starting at
-// fromSeq (inclusive), using a JetStream OrderedConsumer.
+// fromSeq (inclusive), using a long-lived JetStream pull consumer per partition.
 //
-// The OrderedConsumer is created per call (stateless, no persistent subscription).
-// It uses DeliverByStartSequencePolicy with OptStartSeq=fromSeq, which tells
-// JetStream to deliver only messages at or after that stream-global sequence that
-// also match the partition's subject filter.
+// The consumer is created once and reused while fromSeq matches the next
+// sequence the consumer will deliver. A rewind (failed delivery) or a jump
+// (watermark scan vs router) deletes and recreates it with OptStartSeq=fromSeq.
+// Empty probes use FetchNoWait so idle notify can wake the partition without a
+// 2s FetchMaxWait tail.
 //
 // Note on sequence semantics (Pitfall 4): JetStream sequences are stream-global,
 // not partition-local. LogEntry.Seq contains the stream-global sequence. Callers
 // must treat seq as an opaque cursor — the router and backfill engine do this already.
 func (n *NatsEventLog) ReadPartition(ctx context.Context, partition uint32, fromSeq uint64, limit int) ([]LogEntry, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if limit <= 0 {
+		return nil, nil
+	}
+
 	startSeq := fromSeq
 	if startSeq == 0 {
-		startSeq = 1 // JetStream sequences start at 1; fromSeq=0 is treated as "from start"
+		startSeq = 1
 	}
 
-	cons, err := n.js.OrderedConsumer(ctx, natsStreamName, jetstream.OrderedConsumerConfig{
-		FilterSubjects: []string{natsSubject(partition)},
-		DeliverPolicy:  jetstream.DeliverByStartSequencePolicy,
-		OptStartSeq:    startSeq,
-	})
+	r := n.readers[partition]
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	cons, err := n.ensurePullConsumer(ctx, partition, r, startSeq)
 	if err != nil {
-		return nil, fmt.Errorf("nats eventlog: ordered consumer for partition %d: %w", partition, err)
+		return nil, err
 	}
 
-	msgs, err := cons.Fetch(limit, jetstream.FetchMaxWait(2*time.Second))
+	msgs, err := cons.FetchNoWait(limit)
 	if err != nil {
+		n.deletePullConsumerLocked(r)
 		return nil, fmt.Errorf("nats eventlog: fetch partition %d: %w", partition, err)
 	}
 
+	entries, lastSeq, err := collectPullEntries(msgs, partition)
+	if err != nil {
+		n.deletePullConsumerLocked(r)
+		return nil, err
+	}
+	if lastSeq != 0 {
+		r.nextSeq = lastSeq + 1
+	}
+	return entries, nil
+}
+
+func collectPullEntries(msgs jetstream.MessageBatch, partition uint32) ([]LogEntry, uint64, error) {
 	var entries []LogEntry
+	var lastSeq uint64
 	for msg := range msgs.Messages() {
+		data := msg.Data()
+		raw := make([]byte, len(data))
+		copy(raw, data)
+
 		var ev event.ChangeEvent
-		if err := json.Unmarshal(msg.Data(), &ev); err != nil {
-			return nil, fmt.Errorf("nats eventlog: unmarshal event in partition %d: %w", partition, err)
+		if err := json.Unmarshal(raw, &ev); err != nil {
+			return nil, 0, fmt.Errorf("nats eventlog: unmarshal event in partition %d: %w", partition, err)
 		}
 		meta, err := msg.Metadata()
 		if err != nil {
-			return nil, fmt.Errorf("nats eventlog: message metadata in partition %d: %w", partition, err)
+			return nil, 0, fmt.Errorf("nats eventlog: message metadata in partition %d: %w", partition, err)
 		}
+		lastSeq = meta.Sequence.Stream
 		entries = append(entries, LogEntry{
-			Seq:         meta.Sequence.Stream,
+			Seq:         lastSeq,
 			PartitionID: partition,
 			Event:       &ev,
+			Raw:         raw,
 		})
 	}
+	if err := msgs.Error(); err != nil {
+		return nil, 0, err
+	}
+	return entries, lastSeq, nil
+}
 
-	return entries, msgs.Error()
+func (n *NatsEventLog) pullConsumerName(partition uint32) string {
+	return fmt.Sprintf("kaptanto-rp-%05d-%s", partition, n.instanceID)
+}
+
+func (n *NatsEventLog) ensurePullConsumer(ctx context.Context, partition uint32, r *natsPartitionReader, startSeq uint64) (jetstream.Consumer, error) {
+	if r.cons != nil && r.nextSeq == startSeq {
+		return r.cons, nil
+	}
+	n.deletePullConsumerLocked(r)
+
+	name := n.pullConsumerName(partition)
+	_ = n.stream.DeleteConsumer(ctx, name)
+
+	cons, err := n.stream.CreateConsumer(ctx, jetstream.ConsumerConfig{
+		Name:              name,
+		FilterSubject:     natsSubject(partition),
+		DeliverPolicy:     jetstream.DeliverByStartSequencePolicy,
+		OptStartSeq:       startSeq,
+		AckPolicy:         jetstream.AckNonePolicy,
+		ReplayPolicy:      jetstream.ReplayInstantPolicy,
+		MemoryStorage:     true,
+		InactiveThreshold: natsPullInactiveThreshold,
+		Replicas:          1,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("nats eventlog: pull consumer for partition %d: %w", partition, err)
+	}
+	r.cons = cons
+	r.nextSeq = startSeq
+	return cons, nil
+}
+
+func (n *NatsEventLog) deletePullConsumerLocked(r *natsPartitionReader) {
+	if r.cons == nil {
+		return
+	}
+	name := r.cons.CachedInfo().Name
+	r.cons = nil
+	r.nextSeq = 0
+	delCtx, cancel := context.WithTimeout(context.Background(), natsConsumerDeleteTimeout)
+	defer cancel()
+	_ = n.stream.DeleteConsumer(delCtx, name)
+}
+
+// ReleasePartition stops and deletes the long-lived pull consumer for partition.
+// Safe to call when no consumer exists. Cluster ownership changes and
+// runPartition shutdown must call this so consumers do not leak across a steal.
+func (n *NatsEventLog) ReleasePartition(partition uint32) {
+	if partition >= n.numPartitions {
+		return
+	}
+	r := n.readers[partition]
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	n.deletePullConsumerLocked(r)
 }
 
 // Close shuts down the NATS connection and the embedded server.
 // It is safe to call Close multiple times; subsequent calls are no-ops.
 func (n *NatsEventLog) Close() error {
+	for p := uint32(0); p < n.numPartitions; p++ {
+		n.ReleasePartition(p)
+	}
 	if n.nc != nil {
 		n.nc.Close()
+		n.nc = nil
 	}
 	if n.ns != nil {
 		n.ns.Shutdown()
+		n.ns = nil
 	}
 	return nil
 }

--- a/internal/eventlog/nats_test.go
+++ b/internal/eventlog/nats_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/nats-io/nats.go/jetstream"
 	"github.com/oklog/ulid/v2"
 	"github.com/stretchr/testify/require"
 
@@ -78,8 +79,7 @@ func TestNatsEventLogReadPartition(t *testing.T) {
 
 	// Write several events that should land on one partition (deterministic key).
 	// Key `{"id": 1}` hashes to a fixed partition via FNV-1a — use PartitionOf to
-	// identify the exact partition rather than scanning all 64 (which would take
-	// up to 64 × FetchMaxWait = ~128s and exceed the test timeout).
+	// identify the exact partition rather than scanning all 64.
 	key := `{"id": 1}`
 	partition := eventlog.PartitionOf(json.RawMessage(key), 64)
 
@@ -211,4 +211,108 @@ func TestNatsEventLogPartitionIsolation(t *testing.T) {
 		require.NotEqual(t, evB.IdempotencyKey, e.Event.IdempotencyKey,
 			"event from partition B must not appear in partition A reads")
 	}
+}
+
+func listStreamConsumers(t *testing.T, el *eventlog.NatsEventLog) []*jetstream.ConsumerInfo {
+	t.Helper()
+	jsctx, err := jetstream.New(el.Conn())
+	require.NoError(t, err)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	stream, err := jsctx.Stream(ctx, "kaptanto-events")
+	require.NoError(t, err)
+	lister := stream.ListConsumers(ctx)
+	var infos []*jetstream.ConsumerInfo
+	for info := range lister.Info() {
+		infos = append(infos, info)
+	}
+	require.NoError(t, lister.Err())
+	return infos
+}
+
+// TestNatsEventLogReadPartitionEmptyIsFast verifies empty ReadPartition returns
+// without waiting FetchMaxWait(2s). Scanning all 64 partitions must finish well
+// under the old 64x2s bound so idle notify can wake a partition.
+func TestNatsEventLogReadPartitionEmptyIsFast(t *testing.T) {
+	el := openTestNatsEventLog(t)
+	ctx := context.Background()
+	start := time.Now()
+	entries, err := el.ReadPartition(ctx, 0, 1, 10)
+	require.NoError(t, err)
+	require.Empty(t, entries)
+	elapsed := time.Since(start)
+	require.Less(t, elapsed, 500*time.Millisecond,
+		"empty ReadPartition took %s; must not wait FetchMaxWait(2s)", elapsed)
+}
+
+// TestNatsEventLogReadPartitionRawPopulated verifies msg.Data is copied into Raw.
+func TestNatsEventLogReadPartitionRawPopulated(t *testing.T) {
+	el := openTestNatsEventLog(t)
+	key := `{"id": 1}`
+	partition := eventlog.PartitionOf(json.RawMessage(key), 64)
+	ev := makeNatsEvent("nats:raw:1:insert:0/1", key)
+	_, err := el.Append(ev)
+	require.NoError(t, err)
+
+	entries, err := el.ReadPartition(context.Background(), partition, 1, 10)
+	require.NoError(t, err)
+	require.NotEmpty(t, entries)
+	found := entries[0]
+	require.NotEmpty(t, found.Raw, "LogEntry.Raw must be populated by ReadPartition")
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(found.Raw, &decoded))
+	require.Equal(t, ev.IdempotencyKey, found.Event.IdempotencyKey)
+	// Mutating Raw must not affect a subsequent read (copied, not aliased).
+	found.Raw[0] ^= 0xff
+	entries2, err := el.ReadPartition(context.Background(), partition, 1, 10)
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(entries2[0].Raw, &decoded))
+}
+
+// TestNatsEventLogReadPartitionReusesConsumer verifies repeated empty polls
+// do not create a new JetStream consumer each time.
+func TestNatsEventLogReadPartitionReusesConsumer(t *testing.T) {
+	el := openTestNatsEventLog(t)
+	ctx := context.Background()
+	for i := 0; i < 8; i++ {
+		entries, err := el.ReadPartition(ctx, 0, 1, 10)
+		require.NoError(t, err)
+		require.Empty(t, entries)
+	}
+	require.Len(t, listStreamConsumers(t, el), 1)
+}
+
+// TestNatsEventLogReleasePartitionDeletesConsumer verifies ownership release
+// removes the long-lived pull consumer.
+func TestNatsEventLogReleasePartitionDeletesConsumer(t *testing.T) {
+	el := openTestNatsEventLog(t)
+	_, err := el.ReadPartition(context.Background(), 0, 1, 10)
+	require.NoError(t, err)
+	require.Len(t, listStreamConsumers(t, el), 1)
+
+	el.ReleasePartition(0)
+	require.Empty(t, listStreamConsumers(t, el))
+}
+
+// TestNatsEventLogReadPartitionRewindReReads verifies a lower fromSeq recreates
+// the pull consumer so failed delivery can re-read the same window.
+func TestNatsEventLogReadPartitionRewindReReads(t *testing.T) {
+	el := openTestNatsEventLog(t)
+	key := `{"id": 1}`
+	partition := eventlog.PartitionOf(json.RawMessage(key), 64)
+	for i := 1; i <= 3; i++ {
+		ev := makeNatsEvent(fmt.Sprintf("nats:rewind:%d:insert:0/%d", i, i), key)
+		_, err := el.Append(ev)
+		require.NoError(t, err)
+	}
+	ctx := context.Background()
+	first, err := el.ReadPartition(ctx, partition, 1, 10)
+	require.NoError(t, err)
+	require.Len(t, first, 3)
+
+	again, err := el.ReadPartition(ctx, partition, 1, 10)
+	require.NoError(t, err)
+	require.Len(t, again, 3)
+	require.Equal(t, first[0].Seq, again[0].Seq)
+	require.Equal(t, first[2].Seq, again[2].Seq)
 }

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -437,6 +437,10 @@ type flusherBackoff struct {
 // grown as needed and reset ([:0]) per event. This eliminates the two
 // per-event heap allocations that the previous dispatch signature caused.
 func (r *Router) runPartition(ctx context.Context, partitionID uint32) {
+	if rel, ok := r.eventLog.(eventlog.PartitionReleaser); ok {
+		defer rel.ReleasePartition(partitionID)
+	}
+
 	// Capture the notify channel once; nil if EventLog doesn't implement
 	// PartitionNotifier (fakes/tests fall back to pure timer polling).
 	var notifyCh <-chan struct{}


### PR DESCRIPTION
## Summary

- **Source fix plan:** `.claude/fix-plans/nats-readpartition-ordered-consumer-20260818-213000.md`
- **Problem:** `NatsEventLog.ReadPartition` created a JetStream `OrderedConsumer` on every poll and blocked on `FetchMaxWait(2s)`. Discarding the Go consumer left ephemeral JetStream consumers alive for 5 minutes. Idle `NotifyCh` could not wake a partition stuck in Fetch, so cluster fan-out paid a consumer-create RPC per poll and up to 2s tail latency on empty reads.
- **Introduced by:** https://github.com/olucasandrade/kaptanto/commit/911ae3f053d3fa58e6c92ffda6ff467d4a636130
- **Implementation:** Keep one named ephemeral pull consumer per partition (instance-unique name so cluster nodes do not share cursors). Reuse it while `fromSeq` matches the next sequence; recreate on rewind. Empty probes use `FetchNoWait`. Copy `msg.Data()` into `LogEntry.Raw`. `ReleasePartition` / `Close` / `runPartition` shutdown delete the consumer. Cluster watermark `AppendObservable` is intentionally out of scope.

## Test plan

- [x] `CGO_ENABLED=0 go test ./internal/eventlog ./internal/router -count=1` — PASS (`eventlog` 2.1s, `router` 36.0s)
- [x] `CGO_ENABLED=0 go test ./internal/eventlog -count=1 -run 'TestNatsEventLogReadPartition|TestNatsEventLogReleasePartition|TestNatsEventLogClose' -v` — all PASS, including:
  - `TestNatsEventLogReadPartitionEmptyIsFast` (0.03s, well under 2s)
  - `TestNatsEventLogReadPartitionReusesConsumer` (consumer count stays 1 across 8 empty polls)
  - `TestNatsEventLogReleasePartitionDeletesConsumer`
  - `TestNatsEventLogReadPartitionRewindReReads`
  - `TestNatsEventLogReadPartitionRawPopulated`

## Residual risk

- Watermark scans and the router may interleave `ReadPartition` on the same partition with different `fromSeq`, causing extra delete/create RPCs until the separate cluster-watermark `AppendObservable` plan lands.
- `SetOwnedPartitions` still does not stop a live `runPartition` goroutine on steal; the losing node keeps polling until process shutdown. `InactiveThreshold` is 30s as a leak safety net; `ReleasePartition` runs when the goroutine exits.
- `FetchNoWait` returns only messages already in the stream. Append waits for PubAck before `NotifyCh`, so the notify path should still see the event; a missed notify falls back to the 500ms poll timer.